### PR TITLE
Fix API key check when secret not found

### DIFF
--- a/packages/server/src/utils/validateKey.ts
+++ b/packages/server/src/utils/validateKey.ts
@@ -22,6 +22,7 @@ export const validateChatflowAPIKey = async (req: Request, chatflow: ChatFlow): 
     if (suppliedKey) {
         const keys = await apikeyService.getAllApiKeys()
         const apiSecret = keys.find((key: any) => key.id === chatFlowApiKeyId)?.apiSecret
+        if (!apiSecret) return false
         if (!compareKeys(apiSecret, suppliedKey)) return false
         return true
     }


### PR DESCRIPTION
## Summary
- handle missing `apiSecret` when verifying API keys

## Testing
- `pnpm --filter ./packages/server test` *(fails: Cannot find module '../../babel.config.js')*

------
https://chatgpt.com/codex/tasks/task_e_683f3a047b148323a69efd942be2e9ea