### PR TITLE
Sync missing migrations from Flowise

### DIFF
--- a/packages/server/src/database/migrations/postgres/1714548873039-AddEvaluation.ts
+++ b/packages/server/src/database/migrations/postgres/1714548873039-AddEvaluation.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddEvaluation1714548873039 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS evaluation (
+                id uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "name" varchar NOT NULL,
+                "chatflowId" text NOT NULL,
+                "chatflowName" text NOT NULL,
+                "datasetId" varchar NOT NULL,
+                "datasetName" varchar NOT NULL,
+                "additionalConfig" text NULL,
+                "evaluationType" varchar NOT NULL,
+                "status" varchar NOT NULL,
+                "average_metrics" text NULL,
+                "runDate" timestamp NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_98989043dd804f54-9830ab99f8" PRIMARY KEY (id)
+            );`
+        )
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS evaluation_run (
+                id uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "evaluationId" varchar NOT NULL,
+                "input" text NOT NULL,
+                "expectedOutput" text NULL,
+                "actualOutput" text NULL,
+                "evaluators" text NULL,
+                "llmEvaluators" text DEFAULT NULL,
+                "metrics" text NULL,
+                "runDate" timestamp NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_98989927dd804f54-9840ab23f8" PRIMARY KEY (id)
+            );`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE evaluation`)
+        await queryRunner.query(`DROP TABLE evaluation_run`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1714548903384-AddDataset.ts
+++ b/packages/server/src/database/migrations/postgres/1714548903384-AddDataset.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddDatasets1714548903384 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS dataset (
+                id uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "name" varchar NOT NULL,
+                "description" varchar NULL,
+                "createdDate" timestamp NOT NULL DEFAULT now(),
+                "updatedDate" timestamp NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_98419043dd804f54-9830ab99f8" PRIMARY KEY (id)
+            );`
+        )
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS dataset_row (
+                id uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "datasetId" varchar NOT NULL,
+                "input" text NOT NULL,
+                "output" text NULL,
+                "updatedDate" timestamp NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_98909027dd804f54-9840ab99f8" PRIMARY KEY (id)
+            );`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE dataset`)
+        await queryRunner.query(`DROP TABLE dataset_row`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1714808591644-AddEvaluator.ts
+++ b/packages/server/src/database/migrations/postgres/1714808591644-AddEvaluator.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddEvaluator1714808591644 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS evaluator (
+                id uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "name" varchar NOT NULL,
+                "type" text NULL,
+                "config" text NULL,
+                "createdDate" timestamp NOT NULL DEFAULT now(),
+                "updatedDate" timestamp NOT NULL DEFAULT now(),
+                CONSTRAINT "PK_90019043dd804f54-9830ab11f8" PRIMARY KEY (id)
+            );`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE evaluator`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1733752119696-AddSeqNoToDatasetRow.ts
+++ b/packages/server/src/database/migrations/postgres/1733752119696-AddSeqNoToDatasetRow.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddSeqNoToDatasetRow1733752119696 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dataset_row" ADD COLUMN IF NOT EXISTS "sequence_no" integer  DEFAULT -1;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dataset_row" DROP COLUMN "sequence_no";`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1738090872625-AddExecutionEntity.ts
+++ b/packages/server/src/database/migrations/postgres/1738090872625-AddExecutionEntity.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddExecutionEntity1738090872625 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS execution (
+                id uuid NOT NULL DEFAULT uuid_generate_v4(),
+                "executionData" text NOT NULL,
+                "action" text,
+                "state" varchar NOT NULL,
+                "agentflowId" uuid NOT NULL,
+                "sessionId" uuid NOT NULL,
+                "isPublic" boolean,
+                "createdDate" timestamp NOT NULL DEFAULT now(),
+                "updatedDate" timestamp NOT NULL DEFAULT now(),
+                "stoppedDate" timestamp,
+                CONSTRAINT "PK_936a419c3b8044598d72d95da61" PRIMARY KEY (id)
+            );`
+        )
+
+        const columnExists = await queryRunner.hasColumn('chat_message', 'executionId')
+        if (!columnExists) {
+            await queryRunner.query(`ALTER TABLE "chat_message" ADD COLUMN "executionId" uuid;`)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE execution`)
+        await queryRunner.query(`ALTER TABLE "chat_message" DROP COLUMN "executionId";`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1743758056188-FixOpenSourceAssistantTable.ts
+++ b/packages/server/src/database/migrations/postgres/1743758056188-FixOpenSourceAssistantTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { Assistant } from '../../entities/Assistant'
+
+export class FixOpenSourceAssistantTable1743758056188 implements MigrationInterface {
+    name = 'FixOpenSourceAssistantTable1743758056188'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('assistant', 'type')
+        if (!columnExists) {
+            await queryRunner.query(`ALTER TABLE "assistant" ADD COLUMN "type" TEXT;`)
+            await queryRunner.query(`UPDATE "assistant" SET "type" = 'OPENAI';`)
+
+            const assistants: Assistant[] = await queryRunner.query(`SELECT * FROM "assistant";`)
+            for (let assistant of assistants) {
+                const details = JSON.parse(assistant.details)
+                if (!details?.id) await queryRunner.query(`UPDATE "assistant" SET "type" = 'CUSTOM' WHERE id = '${assistant.id}';`)
+            }
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "assistant" DROP COLUMN "type";`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1744964560174-AddErrorToEvaluationRun.ts
+++ b/packages/server/src/database/migrations/postgres/1744964560174-AddErrorToEvaluationRun.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddErrorToEvaluationRun1744964560174 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "evaluation_run" ADD COLUMN IF NOT EXISTS "errors" TEXT NULL DEFAULT '[]';`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "evaluation_run" DROP COLUMN "errors";`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/1748450230238-ModifyExecutionSessionIdFieldType.ts
+++ b/packages/server/src/database/migrations/postgres/1748450230238-ModifyExecutionSessionIdFieldType.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ModifyExecutionSessionIdFieldType1748450230238 implements MigrationInterface {
+    name = 'ModifyExecutionSessionIdFieldType1748450230238'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "execution" ALTER COLUMN "sessionId" type varchar USING "sessionId"::varchar`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "execution" ALTER COLUMN "sessionId" type uuid USING "sessionId"::uuid`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -29,6 +29,14 @@ import { AddArtifactsToChatMessage1726156258465 } from './1726156258465-AddArtif
 import { AddFollowUpPrompts1726666309552 } from './1726666309552-AddFollowUpPrompts'
 import { AddTypeToAssistant1733011290987 } from './1733011290987-AddTypeToAssistant'
 import { AddUniks1741277504476 } from './1741277504476-AddUniks'
+import { AddEvaluation1714548873039 } from './1714548873039-AddEvaluation'
+import { AddDatasets1714548903384 } from './1714548903384-AddDataset'
+import { AddEvaluator1714808591644 } from './1714808591644-AddEvaluator'
+import { AddSeqNoToDatasetRow1733752119696 } from './1733752119696-AddSeqNoToDatasetRow'
+import { AddExecutionEntity1738090872625 } from './1738090872625-AddExecutionEntity'
+import { FixOpenSourceAssistantTable1743758056188 } from './1743758056188-FixOpenSourceAssistantTable'
+import { AddErrorToEvaluationRun1744964560174 } from './1744964560174-AddErrorToEvaluationRun'
+import { ModifyExecutionSessionIdFieldType1748450230238 } from './1748450230238-ModifyExecutionSessionIdFieldType'
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -61,5 +69,13 @@ export const postgresMigrations = [
     AddArtifactsToChatMessage1726156258465,
     AddFollowUpPrompts1726666309552,
     AddTypeToAssistant1733011290987,
-    AddUniks1741277504476
+    AddUniks1741277504476,
+    AddEvaluation1714548873039,
+    AddDatasets1714548903384,
+    AddEvaluator1714808591644,
+    AddSeqNoToDatasetRow1733752119696,
+    AddExecutionEntity1738090872625,
+    FixOpenSourceAssistantTable1743758056188,
+    AddErrorToEvaluationRun1744964560174,
+    ModifyExecutionSessionIdFieldType1748450230238
 ]


### PR DESCRIPTION
## Summary
- copy missing Flowise 3.0.1 migrations into server package
- append new migrations to the postgres migration index after `AddUniks`

## Testing
- `pnpm --filter ./packages/server build` *(fails: Cannot find module 'flowise-components' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840bff3f3608323b54e2330994fad81