### PR TITLE
Sync Flowise entities

### DIFF
--- a/packages/server/src/Interface.Evaluation.ts
+++ b/packages/server/src/Interface.Evaluation.ts
@@ -1,0 +1,139 @@
+// Evaluation Related Interfaces
+import { Evaluator } from './database/entities/Evaluator'
+
+export interface IDataset {
+    id: string
+    name: string
+    description: string
+    createdDate: Date
+    updatedDate: Date
+    workspaceId?: string
+}
+export interface IDatasetRow {
+    id: string
+    datasetId: string
+    input: string
+    output: string
+    updatedDate: Date
+    sequenceNo: number
+}
+
+export enum EvaluationStatus {
+    PENDING = 'pending',
+    COMPLETED = 'completed',
+    ERROR = 'error'
+}
+
+export interface IEvaluation {
+    id: string
+    name: string
+    chatflowId: string
+    chatflowName: string
+    datasetId: string
+    datasetName: string
+    evaluationType: string
+    additionalConfig: string //json
+    average_metrics: string //json
+    status: string
+    runDate: Date
+    workspaceId?: string
+}
+
+export interface IEvaluationResult extends IEvaluation {
+    latestEval: boolean
+    version: number
+}
+
+export interface IEvaluationRun {
+    id: string
+    evaluationId: string
+    input: string
+    expectedOutput: string
+    actualOutput: string // JSON
+    metrics: string // JSON
+    runDate: Date
+    llmEvaluators?: string // JSON
+    evaluators?: string // JSON
+    errors?: string // JSON
+}
+
+export interface IEvaluator {
+    id: string
+    name: string
+    type: string
+    config: string // JSON
+    updatedDate: Date
+    createdDate: Date
+    workspaceId?: string
+}
+
+export class EvaluatorDTO {
+    id: string
+    name: string
+    type: string
+    measure?: string
+    operator?: string
+    value?: string
+    prompt?: string
+    evaluatorType?: string
+    outputSchema?: []
+    updatedDate: Date
+    createdDate: Date
+
+    static toEntity(body: any): Evaluator {
+        const newDs = new Evaluator()
+        Object.assign(newDs, body)
+        let config: any = {}
+        if (body.type === 'llm') {
+            config = {
+                prompt: body.prompt,
+                outputSchema: body.outputSchema
+            }
+        } else if (body.type === 'text') {
+            config = {
+                operator: body.operator,
+                value: body.value
+            }
+        } else if (body.type === 'json') {
+            config = {
+                operator: body.operator
+            }
+        } else if (body.type === 'numeric') {
+            config = {
+                operator: body.operator,
+                value: body.value,
+                measure: body.measure
+            }
+        } else {
+            throw new Error('Invalid evaluator type')
+        }
+        newDs.config = JSON.stringify(config)
+        return newDs
+    }
+
+    static fromEntity(entity: Evaluator): EvaluatorDTO {
+        const newDs = new EvaluatorDTO()
+        Object.assign(newDs, entity)
+        const config = JSON.parse(entity.config)
+        if (entity.type === 'llm') {
+            newDs.prompt = config.prompt
+            newDs.outputSchema = config.outputSchema
+        } else if (entity.type === 'text') {
+            newDs.operator = config.operator
+            newDs.value = config.value
+        } else if (entity.type === 'json') {
+            newDs.operator = config.operator
+            newDs.value = config.value
+        } else if (entity.type === 'numeric') {
+            newDs.operator = config.operator
+            newDs.value = config.value
+            newDs.measure = config.measure
+        }
+        delete (newDs as any).config
+        return newDs
+    }
+
+    static fromEntities(entities: Evaluator[]): EvaluatorDTO[] {
+        return entities.map((entity) => this.fromEntity(entity))
+    }
+}

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -356,5 +356,8 @@ export interface IVariableOverride {
 // DocumentStore related
 export * from './Interface.DocumentStore'
 
+// Evaluation related
+export * from './Interface.Evaluation'
+
 // UPDL related
 export * from './Interface.UPDL'

--- a/packages/server/src/database/entities/Dataset.ts
+++ b/packages/server/src/database/entities/Dataset.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+import { Entity, Column, CreateDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from 'typeorm'
+import { IAssistant, IDataset } from '../../Interface'
+
+@Entity()
+export class Dataset implements IDataset {
+    @PrimaryGeneratedColumn('uuid')
+    id: string
+
+    @Column({ type: 'text' })
+    name: string
+
+    @Column({ type: 'text' })
+    description: string
+
+    @CreateDateColumn()
+    createdDate: Date
+
+    @UpdateDateColumn()
+    updatedDate: Date
+
+    @Column({ nullable: true, type: 'text' })
+    workspaceId?: string
+}

--- a/packages/server/src/database/entities/DatasetRow.ts
+++ b/packages/server/src/database/entities/DatasetRow.ts
@@ -1,0 +1,25 @@
+/* eslint-disable */
+import { Entity, Column, CreateDateColumn, UpdateDateColumn, PrimaryGeneratedColumn, Index } from 'typeorm'
+import { IAssistant, IDataset, IDatasetRow } from '../../Interface'
+
+@Entity()
+export class DatasetRow implements IDatasetRow {
+    @PrimaryGeneratedColumn('uuid')
+    id: string
+
+    @Column({ type: 'text' })
+    @Index()
+    datasetId: string
+
+    @Column({ type: 'text' })
+    input: string
+
+    @Column({ type: 'text' })
+    output: string
+
+    @UpdateDateColumn()
+    updatedDate: Date
+
+    @Column({ name: 'sequence_no' })
+    sequenceNo: number
+}

--- a/packages/server/src/database/entities/Evaluation.ts
+++ b/packages/server/src/database/entities/Evaluation.ts
@@ -1,0 +1,41 @@
+import { Column, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { IEvaluation } from '../../Interface'
+
+@Entity()
+export class Evaluation implements IEvaluation {
+    @PrimaryGeneratedColumn('uuid')
+    id: string
+
+    @Column({ type: 'text' })
+    average_metrics: string
+
+    @Column({ type: 'text' })
+    additionalConfig: string
+
+    @Column()
+    name: string
+
+    @Column()
+    evaluationType: string
+
+    @Column()
+    chatflowId: string
+
+    @Column()
+    chatflowName: string
+
+    @Column()
+    datasetId: string
+
+    @Column()
+    datasetName: string
+
+    @Column()
+    status: string
+
+    @UpdateDateColumn()
+    runDate: Date
+
+    @Column({ nullable: true, type: 'text' })
+    workspaceId?: string
+}

--- a/packages/server/src/database/entities/EvaluationRun.ts
+++ b/packages/server/src/database/entities/EvaluationRun.ts
@@ -1,0 +1,35 @@
+import { Column, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { IEvaluationRun } from '../../Interface'
+
+@Entity()
+export class EvaluationRun implements IEvaluationRun {
+    @PrimaryGeneratedColumn('uuid')
+    id: string
+
+    @Column()
+    evaluationId: string
+
+    @Column({ type: 'text' })
+    input: string
+
+    @Column({ type: 'text' })
+    expectedOutput: string
+
+    @UpdateDateColumn()
+    runDate: Date
+
+    @Column({ type: 'text' })
+    actualOutput: string
+
+    @Column({ type: 'text' })
+    metrics: string
+
+    @Column({ type: 'text' })
+    llmEvaluators: string
+
+    @Column({ type: 'text' })
+    evaluators: string
+
+    @Column({ type: 'text' })
+    errors: string
+}

--- a/packages/server/src/database/entities/Evaluator.ts
+++ b/packages/server/src/database/entities/Evaluator.ts
@@ -1,0 +1,28 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { IEvaluator } from '../../Interface'
+
+//1714808591644
+
+@Entity()
+export class Evaluator implements IEvaluator {
+    @PrimaryGeneratedColumn('uuid')
+    id: string
+
+    @Column()
+    name: string
+
+    @Column()
+    type: string
+
+    @Column()
+    config: string
+
+    @CreateDateColumn()
+    createdDate: Date
+
+    @UpdateDateColumn()
+    updatedDate: Date
+
+    @Column({ nullable: true, type: 'text' })
+    workspaceId?: string
+}

--- a/packages/server/src/database/entities/Execution.ts
+++ b/packages/server/src/database/entities/Execution.ts
@@ -1,0 +1,47 @@
+import { Entity, Column, Index, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm'
+import { IExecution, ExecutionState } from '../../Interface'
+import { ChatFlow } from './ChatFlow'
+
+@Entity()
+export class Execution implements IExecution {
+    @PrimaryGeneratedColumn('uuid')
+    id: string
+
+    @Column({ type: 'text' })
+    executionData: string
+
+    @Column()
+    state: ExecutionState
+
+    @Index()
+    @Column({ type: 'uuid' })
+    agentflowId: string
+
+    @Index()
+    @Column({ type: 'varchar' })
+    sessionId: string
+
+    @Column({ nullable: true, type: 'text' })
+    action?: string
+
+    @Column({ nullable: true })
+    isPublic?: boolean
+
+    @Column({ type: 'timestamp' })
+    @CreateDateColumn()
+    createdDate: Date
+
+    @Column({ type: 'timestamp' })
+    @UpdateDateColumn()
+    updatedDate: Date
+
+    @Column()
+    stoppedDate: Date
+
+    @ManyToOne(() => ChatFlow)
+    @JoinColumn({ name: 'agentflowId' })
+    agentflow: ChatFlow
+
+    @Column({ nullable: true, type: 'text' })
+    workspaceId?: string
+}

--- a/packages/server/src/database/entities/index.ts
+++ b/packages/server/src/database/entities/index.ts
@@ -9,12 +9,26 @@ import { DocumentStore } from './DocumentStore'
 import { DocumentStoreFileChunk } from './DocumentStoreFileChunk'
 import { Lead } from './Lead'
 import { UpsertHistory } from './UpsertHistory'
+import { Dataset } from './Dataset'
+import { DatasetRow } from './DatasetRow'
+import { EvaluationRun } from './EvaluationRun'
+import { Evaluation } from './Evaluation'
+import { Evaluator } from './Evaluator'
 import { ApiKey } from './ApiKey'
 import { CustomTemplate } from './CustomTemplate'
+import { Execution } from './Execution'
+import { LoginActivity, WorkspaceShared, WorkspaceUsers } from '../../enterprise/database/entities/EnterpriseEntities'
+import { User as EnterpriseUser } from '../../enterprise/database/entities/user.entity'
+import { Organization } from '../../enterprise/database/entities/organization.entity'
+import { Role } from '../../enterprise/database/entities/role.entity'
+import { OrganizationUser } from '../../enterprise/database/entities/organization-user.entity'
+import { Workspace } from '../../enterprise/database/entities/workspace.entity'
+import { WorkspaceUser } from '../../enterprise/database/entities/workspace-user.entity'
+import { LoginMethod } from '../../enterprise/database/entities/login-method.entity'
 
-// New entities
+// Universo Platformo | Custom entities
 import { Unik } from './Unik'
-import { User } from './User'
+import { User as LocalUser } from './User'
 import { UserUnik } from './UserUnik'
 
 export const entities = {
@@ -25,14 +39,30 @@ export const entities = {
     Tool,
     Assistant,
     Variable,
+    UpsertHistory,
     DocumentStore,
     DocumentStoreFileChunk,
     Lead,
-    UpsertHistory,
+    Dataset,
+    DatasetRow,
+    Evaluation,
+    EvaluationRun,
+    Evaluator,
     ApiKey,
+    EnterpriseUser,
+    WorkspaceUsers,
+    LoginActivity,
+    WorkspaceShared,
     CustomTemplate,
-    // New entities
+    Execution,
+    Organization,
+    Role,
+    OrganizationUser,
+    Workspace,
+    WorkspaceUser,
+    LoginMethod,
+    // Universo Platformo | custom
     Unik,
-    User,
+    LocalUser,
     UserUnik
 }


### PR DESCRIPTION
## Summary
- add evaluation interfaces and dataset entities from Flowise 3.0.1
- export new interfaces
- include new entities alongside Universo Platformo custom ones

## Testing
- `pnpm lint`
- `pnpm build` *(fails: AutoGPT build)*
- `pnpm --filter flowise typeorm:migration-run` *(fails: type compilation errors)*


------
https://chatgpt.com/codex/tasks/task_e_6840d218da2083239fa9020aa7f0b73a