### PR TITLE
Verify server utils against Flowise 3.0.1

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -288,3 +288,7 @@ This refactoring achieves the optimal architecture for our MVP:
 
 -   `apps/publish-frt/base/src/api/ARJSPublishApi.ts` - cleaner API client with proper error handling
 -   `apps/publish-frt/base/src/features/arjs/ARJSPublisher.jsx` - removed redundant code while preserving demo functionality
+
+### 2025-06-04: Server utils verified
+
+- Verified all utils match Flowise 3.0.1 baseline. No changes required.


### PR DESCRIPTION
## Summary
- document verification that server utils match Flowise 3.0.1 baseline

## Testing
- `pnpm lint` *(fails: ESLint config missing)*
- `pnpm build` *(fails: flowise-components build errors)*
- `pnpm --filter ./packages/server build` *(fails: tsc type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840d6b723d4832392e46ff123bbce89