### PR TITLE
Update AGENTS with English app guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,10 @@ Coding style:
 - Write comments in English and prefix them with `Universo Platformo |`.
 
 Refer to [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before contributing.
+
+## Guidelines for New Functionality
+
+- By default place new features under the `apps/` folder. If none of the existing apps fit, create a new one and wire it into the project. For instance, `apps/publish-frt` implements the React front end and `apps/publish-srv` implements the Node.js/Express back end for the publishing/export feature.
+- Each app must contain a root `base` directory. The project's architecture allows for alternative implementations in the future, so the default code lives under `base`.
+- Front-end apps include internationalization. Create an `i18n` folder with default localization files for English and Russian.
+- If a feature is not split into front end and back end, name the app without the `-frt` or `-srv` suffix. Example: `apps/updl`.


### PR DESCRIPTION
## Summary
- update guidelines in `AGENTS.md` for creating apps in `apps/`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb642c3f48323b06ec8b3e52ff5fa