### PR TITLE
GH110 Add new UPDL node classes

### DIFF
--- a/apps/updl/base/src/index.ts
+++ b/apps/updl/base/src/index.ts
@@ -7,6 +7,11 @@ import { DataNode } from './nodes/data/DataNode'
 import { LightNode } from './nodes/light/LightNode'
 import { ObjectNode } from './nodes/object/ObjectNode'
 import { SpaceNode } from './nodes/space/SpaceNode'
+import { EntityNode } from './nodes/entity/EntityNode'
+import { ComponentNode } from './nodes/component/ComponentNode'
+import { EventNode } from './nodes/event/EventNode'
+import { ActionNode } from './nodes/action/ActionNode'
+import { UniversoNode } from './nodes/universo/UniversoNode'
 import { BaseUPDLNode } from './nodes/base/BaseUPDLNode'
 
 // Export node classes directly
@@ -15,6 +20,11 @@ export { DataNode } from './nodes/data/DataNode'
 export { LightNode } from './nodes/light/LightNode'
 export { ObjectNode } from './nodes/object/ObjectNode'
 export { SpaceNode } from './nodes/space/SpaceNode'
+export { EntityNode } from './nodes/entity/EntityNode'
+export { ComponentNode } from './nodes/component/ComponentNode'
+export { EventNode } from './nodes/event/EventNode'
+export { ActionNode } from './nodes/action/ActionNode'
+export { UniversoNode } from './nodes/universo/UniversoNode'
 export { BaseUPDLNode } from './nodes/base/BaseUPDLNode'
 
 // Re-export interfaces
@@ -28,5 +38,10 @@ export default {
     LightNode,
     ObjectNode,
     SpaceNode,
+    EntityNode,
+    ComponentNode,
+    EventNode,
+    ActionNode,
+    UniversoNode,
     BaseUPDLNode
 }

--- a/apps/updl/base/src/nodes/action/ActionNode.ts
+++ b/apps/updl/base/src/nodes/action/ActionNode.ts
@@ -1,0 +1,67 @@
+// Universo Platformo | UPDL Action Node
+import { INodeData, ICommonObject } from '../interfaces'
+import { BaseUPDLNode } from '../base/BaseUPDLNode'
+
+/**
+ * ActionNode performs an action on a target entity
+ */
+export class ActionNode extends BaseUPDLNode {
+    constructor() {
+        super({
+            name: 'Action',
+            type: 'UPDLAction',
+            icon: 'action.svg',
+            description: 'Action performed on a target',
+            inputs: [
+                {
+                    name: 'actionType',
+                    type: 'options',
+                    label: 'Action Type',
+                    description: 'Type of action',
+                    options: [
+                        { label: 'Animate', name: 'animate' },
+                        { label: 'Sound', name: 'sound' },
+                        { label: 'Custom', name: 'custom' }
+                    ],
+                    default: 'animate'
+                },
+                {
+                    label: 'Target',
+                    name: 'target',
+                    type: 'UPDLEntity',
+                    description: 'Target entity for the action',
+                    optional: true
+                },
+                {
+                    name: 'params',
+                    type: 'object',
+                    label: 'Params',
+                    description: 'Additional parameters',
+                    optional: true,
+                    additionalParams: true
+                }
+            ]
+        })
+    }
+
+    async init(nodeData: INodeData, input: string = ''): Promise<any> {
+        return this
+    }
+
+    async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
+        const actionType = (nodeData.inputs?.actionType as string) || 'animate'
+        const target = nodeData.inputs?.target || null
+        const params = (nodeData.inputs?.params as any) || {}
+        const id = `action-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+        return {
+            id,
+            type: 'UPDLAction',
+            actionType,
+            target,
+            params
+        }
+    }
+}
+
+// Universo Platformo | Export class as nodeClass for Flowise compatibility
+module.exports = { nodeClass: ActionNode }

--- a/apps/updl/base/src/nodes/action/action.svg
+++ b/apps/updl/base/src/nodes/action/action.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"></rect>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg> 

--- a/apps/updl/base/src/nodes/component/ComponentNode.ts
+++ b/apps/updl/base/src/nodes/component/ComponentNode.ts
@@ -1,0 +1,61 @@
+// Universo Platformo | UPDL Component Node
+import { INodeData, ICommonObject } from '../interfaces'
+import { BaseUPDLNode } from '../base/BaseUPDLNode'
+
+/**
+ * ComponentNode attaches behaviour to an entity
+ */
+export class ComponentNode extends BaseUPDLNode {
+    constructor() {
+        super({
+            name: 'Component',
+            type: 'UPDLComponent',
+            icon: 'component.svg',
+            description: 'Component attached to an entity',
+            inputs: [
+                {
+                    name: 'type',
+                    type: 'string',
+                    label: 'Component Type',
+                    description: 'Type identifier of the component'
+                },
+                {
+                    name: 'props',
+                    type: 'object',
+                    label: 'Props',
+                    description: 'Component properties',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
+                    label: 'Target',
+                    name: 'target',
+                    type: 'UPDLEntity',
+                    description: 'Entity to attach this component to',
+                    optional: true
+                }
+            ]
+        })
+    }
+
+    async init(nodeData: INodeData, input: string = ''): Promise<any> {
+        return this
+    }
+
+    async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
+        const type = (nodeData.inputs?.type as string) || ''
+        const props = (nodeData.inputs?.props as any) || {}
+        const target = nodeData.inputs?.target || null
+        const id = `component-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+        return {
+            id,
+            type: 'UPDLComponent',
+            componentType: type,
+            props,
+            target
+        }
+    }
+}
+
+// Universo Platformo | Export class as nodeClass for Flowise compatibility
+module.exports = { nodeClass: ComponentNode }

--- a/apps/updl/base/src/nodes/component/component.svg
+++ b/apps/updl/base/src/nodes/component/component.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"></rect>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg> 

--- a/apps/updl/base/src/nodes/entity/EntityNode.ts
+++ b/apps/updl/base/src/nodes/entity/EntityNode.ts
@@ -1,0 +1,55 @@
+// Universo Platformo | UPDL Entity Node
+import { INodeData, ICommonObject } from '../interfaces'
+import { BaseUPDLNode } from '../base/BaseUPDLNode'
+
+/**
+ * EntityNode represents a runtime entity instance with transform data
+ */
+export class EntityNode extends BaseUPDLNode {
+    constructor() {
+        super({
+            name: 'Entity',
+            type: 'UPDLEntity',
+            icon: 'entity.svg',
+            description: 'Entity instance with transform and tags',
+            inputs: [
+                {
+                    name: 'transform',
+                    type: 'object',
+                    label: 'Transform',
+                    description: 'Position, rotation and scale',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
+                    name: 'tags',
+                    type: 'string',
+                    label: 'Tags',
+                    description: 'Tags for this entity',
+                    list: true,
+                    optional: true,
+                    additionalParams: true
+                }
+            ]
+        })
+    }
+
+    async init(nodeData: INodeData, input: string = ''): Promise<any> {
+        return this
+    }
+
+    async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
+        const transform = (nodeData.inputs?.transform as any) || {}
+        const tags = (nodeData.inputs?.tags as string[]) || []
+        const id = `entity-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+        return {
+            id,
+            type: 'UPDLEntity',
+            transform,
+            tags
+        }
+    }
+}
+
+// Universo Platformo | Export class as nodeClass for Flowise compatibility
+module.exports = { nodeClass: EntityNode }

--- a/apps/updl/base/src/nodes/entity/entity.svg
+++ b/apps/updl/base/src/nodes/entity/entity.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"></rect>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg> 

--- a/apps/updl/base/src/nodes/event/EventNode.ts
+++ b/apps/updl/base/src/nodes/event/EventNode.ts
@@ -1,0 +1,57 @@
+// Universo Platformo | UPDL Event Node
+import { INodeData, ICommonObject } from '../interfaces'
+import { BaseUPDLNode } from '../base/BaseUPDLNode'
+
+/**
+ * EventNode describes an event emitted by an entity or component
+ */
+export class EventNode extends BaseUPDLNode {
+    constructor() {
+        super({
+            name: 'Event',
+            type: 'UPDLEvent',
+            icon: 'event.svg',
+            description: 'Event definition for UPDL flows',
+            inputs: [
+                {
+                    name: 'eventType',
+                    type: 'options',
+                    label: 'Event Type',
+                    description: 'Type of event',
+                    options: [
+                        { label: 'Click', name: 'click' },
+                        { label: 'Hover', name: 'hover' },
+                        { label: 'Custom', name: 'custom' }
+                    ],
+                    default: 'click'
+                },
+                {
+                    label: 'Source',
+                    name: 'source',
+                    type: 'UPDLEntity',
+                    description: 'Entity emitting the event',
+                    optional: true
+                }
+            ]
+        })
+    }
+
+    async init(nodeData: INodeData, input: string = ''): Promise<any> {
+        return this
+    }
+
+    async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
+        const eventType = (nodeData.inputs?.eventType as string) || 'click'
+        const source = nodeData.inputs?.source || null
+        const id = `event-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+        return {
+            id,
+            type: 'UPDLEvent',
+            eventType,
+            source
+        }
+    }
+}
+
+// Universo Platformo | Export class as nodeClass for Flowise compatibility
+module.exports = { nodeClass: EventNode }

--- a/apps/updl/base/src/nodes/event/event.svg
+++ b/apps/updl/base/src/nodes/event/event.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"></rect>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg> 

--- a/apps/updl/base/src/nodes/universo/UniversoNode.ts
+++ b/apps/updl/base/src/nodes/universo/UniversoNode.ts
@@ -1,0 +1,64 @@
+// Universo Platformo | UPDL Universo Node
+import { INodeData, ICommonObject } from '../interfaces'
+import { BaseUPDLNode } from '../base/BaseUPDLNode'
+
+/**
+ * UniversoNode defines cross-system settings
+ */
+export class UniversoNode extends BaseUPDLNode {
+    constructor() {
+        super({
+            name: 'Universo',
+            type: 'UPDLUniverso',
+            icon: 'universo.svg',
+            description: 'Universo platform configuration',
+            inputs: [
+                {
+                    name: 'transports',
+                    type: 'object',
+                    label: 'Transports',
+                    description: 'Transport layer settings',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
+                    name: 'discovery',
+                    type: 'object',
+                    label: 'Discovery',
+                    description: 'Discovery settings',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
+                    name: 'security',
+                    type: 'object',
+                    label: 'Security',
+                    description: 'Security configuration',
+                    optional: true,
+                    additionalParams: true
+                }
+            ]
+        })
+    }
+
+    async init(nodeData: INodeData, input: string = ''): Promise<any> {
+        return this
+    }
+
+    async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
+        const transports = (nodeData.inputs?.transports as any) || {}
+        const discovery = (nodeData.inputs?.discovery as any) || {}
+        const security = (nodeData.inputs?.security as any) || {}
+        const id = `universo-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+        return {
+            id,
+            type: 'UPDLUniverso',
+            transports,
+            discovery,
+            security
+        }
+    }
+}
+
+// Universo Platformo | Export class as nodeClass for Flowise compatibility
+module.exports = { nodeClass: UniversoNode }

--- a/apps/updl/base/src/nodes/universo/universo.svg
+++ b/apps/updl/base/src/nodes/universo/universo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"></rect>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg> 


### PR DESCRIPTION
Fix #110 Expand UPDL Node Library with Action, Component, Entity, Event, and Universo classes

## Summary
- implement EntityNode, ComponentNode, EventNode, ActionNode and UniversoNode
- export new classes from UPDL module

## Testing
- `pnpm lint` *(fails: couldn't find ESLint config)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685bfe88bc83238849c9227cb254c7