### PR TITLE
GH112 Update UPDL Space and Data nodes

### DIFF
--- a/apps/updl/base/src/nodes/data/DataNode.ts
+++ b/apps/updl/base/src/nodes/data/DataNode.ts
@@ -35,6 +35,35 @@ export class DataNode extends BaseUPDLNode {
                     default: 'My Data'
                 },
                 {
+                    name: 'key',
+                    type: 'string',
+                    label: 'Key',
+                    description: 'Data key identifier',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
+                    name: 'scope',
+                    type: 'options',
+                    label: 'Scope',
+                    description: 'Variable scope',
+                    options: [
+                        { label: 'Local', name: 'Local' },
+                        { label: 'Space', name: 'Space' },
+                        { label: 'Global', name: 'Global' }
+                    ],
+                    default: 'Local',
+                    additionalParams: true
+                },
+                {
+                    name: 'value',
+                    type: 'string',
+                    label: 'Value',
+                    description: 'Stored value',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
                     name: 'dataType',
                     type: 'options',
                     label: 'Data Type',
@@ -146,6 +175,9 @@ export class DataNode extends BaseUPDLNode {
     async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
         // Extract properties via nodeData.inputs
         const dataName = (nodeData.inputs?.dataName as string) || 'My Data'
+        const key = (nodeData.inputs?.key as string) || ''
+        const scope = (nodeData.inputs?.scope as string) || 'Local'
+        const value = (nodeData.inputs?.value as string) || ''
         const dataType = (nodeData.inputs?.dataType as string) || 'question'
         const content = (nodeData.inputs?.content as string) || ''
         const isCorrect = nodeData.inputs?.isCorrect ? true : false
@@ -168,6 +200,9 @@ export class DataNode extends BaseUPDLNode {
             id,
             type: 'UPDLDataNode',
             name: dataName,
+            key,
+            scope,
+            value,
             dataType,
             content,
             isCorrect,

--- a/apps/updl/base/src/nodes/space/SpaceNode.ts
+++ b/apps/updl/base/src/nodes/space/SpaceNode.ts
@@ -36,6 +36,27 @@ export class SpaceNode extends BaseUPDLNode {
                     default: 'My Space'
                 },
                 {
+                    name: 'spaceType',
+                    type: 'options',
+                    label: 'Space Type',
+                    description: 'Classification of the space',
+                    options: [
+                        { label: 'Root', name: 'root' },
+                        { label: 'Module', name: 'module' },
+                        { label: 'Block', name: 'block' }
+                    ],
+                    default: 'root',
+                    additionalParams: true
+                },
+                {
+                    name: 'settings',
+                    type: 'json',
+                    label: 'Settings',
+                    description: 'Generic configuration object',
+                    optional: true,
+                    additionalParams: true
+                },
+                {
                     name: 'backgroundColor',
                     type: 'string',
                     label: 'Background Color',
@@ -197,6 +218,8 @@ export class SpaceNode extends BaseUPDLNode {
     async run(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any> {
         // Extract properties via nodeData.inputs
         const spaceName = (nodeData.inputs?.spaceName as string) || 'My Space'
+        const spaceType = (nodeData.inputs?.spaceType as string) || 'root'
+        const settings = (nodeData.inputs?.settings as any) || {}
         const backgroundColor = (nodeData.inputs?.backgroundColor as string) || '' // Use default from input definition
         const enableSkybox = nodeData.inputs?.skybox ? true : false
         const skyboxTexture = nodeData.inputs?.skyboxTexture as string
@@ -227,6 +250,8 @@ export class SpaceNode extends BaseUPDLNode {
             id,
             type: 'UPDLSpaceNode',
             name: spaceName,
+            spaceType,
+            settings,
             isRootNode: true,
             backgroundColor,
             skybox: {


### PR DESCRIPTION
Fix #112 Extend UPDL Space and Data nodes with generic settings

## Summary
- extend `SpaceNode` with `spaceType` option and `settings` JSON input
- extend `DataNode` with `key`, `scope` and `value` inputs

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686864e49d3c8323a9332a22fbdc9d02