### PR TITLE
GH119 Add PlayCanvas publication API

### DIFF
--- a/apps/publish-frt/base/src/api/publication/PlayCanvasPublicationApi.ts
+++ b/apps/publish-frt/base/src/api/publication/PlayCanvasPublicationApi.ts
@@ -1,0 +1,44 @@
+// Universo Platformo | PlayCanvas Publication API - extends base Publication API
+// PlayCanvas-specific publication functionality
+
+import { PublicationApi } from './PublicationApi'
+
+// Local interface to avoid server dependencies
+interface ILibraryConfig {
+    playcanvas?: { version: string; source: string }
+}
+
+// Universo Platformo | PlayCanvas specific publication settings interface
+export interface PlayCanvasPublicationSettings {
+    isPublic: boolean
+    projectTitle: string
+    generationMode: string
+    templateId?: string
+    libraryConfig?: ILibraryConfig
+}
+
+/**
+ * PlayCanvas Publication API client - extends base Publication API
+ */
+export class PlayCanvasPublicationApi extends PublicationApi {
+    /**
+     * Save PlayCanvas publication settings to Supabase
+     * @param spaceId Space ID (formerly chatflowId)
+     * @param settings PlayCanvas publication settings to save
+     */
+    static async savePlayCanvasSettings(
+        spaceId: string,
+        settings: PlayCanvasPublicationSettings
+    ): Promise<void> {
+        return this.savePublicationSettings(spaceId, 'playcanvas', settings)
+    }
+
+    /**
+     * Load PlayCanvas publication settings from Supabase
+     * @param spaceId Space ID (formerly chatflowId)
+     * @returns PlayCanvas publication settings or null if not found
+     */
+    static async loadPlayCanvasSettings(spaceId: string): Promise<PlayCanvasPublicationSettings | null> {
+        return this.loadPublicationSettings(spaceId, 'playcanvas')
+    }
+}

--- a/apps/publish-frt/base/src/api/publication/index.ts
+++ b/apps/publish-frt/base/src/api/publication/index.ts
@@ -4,6 +4,7 @@
 export { PublicationApi } from './PublicationApi'
 export { ARJSPublicationApi, type ARJSPublicationSettings } from './ARJSPublicationApi'
 export { StreamingPublicationApi } from './StreamingPublicationApi'
+export { PlayCanvasPublicationApi, type PlayCanvasPublicationSettings } from './PlayCanvasPublicationApi'
 
 // Export centralized types
 export type { IARJSPublishRequest, IARJSPublishResponse, IUPDLFlowResult, IPublicationDataResult } from '@universo/publish-srv'


### PR DESCRIPTION
Fix #119 Add PlayCanvas publication API

## Summary
- add `PlayCanvasPublicationApi` with save/load helpers
- export new API from publication index

## Testing
- `pnpm build`
- `pnpm lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686873a0b400832384105c550d1cb276