### PR TITLE
GH120 Add PlayCanvas publication tab

### DIFF
--- a/apps/publish-frt/base/src/features/playcanvas/PlayCanvasPublisher.jsx
+++ b/apps/publish-frt/base/src/features/playcanvas/PlayCanvasPublisher.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    Box,
+    Typography,
+    TextField,
+    Switch,
+    FormControlLabel,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    CircularProgress
+} from '@mui/material'
+
+import TemplateSelect from '../../components/TemplateSelect'
+import { PlayCanvasPublicationApi } from '../../api'
+
+const DEFAULT_VERSION = '2.9.0'
+const DEFAULT_TEMPLATE = 'mmoomm'
+
+const PlayCanvasPublisher = ({ flow }) => {
+    const { t } = useTranslation('publish')
+    const [projectTitle, setProjectTitle] = useState(flow?.name || '')
+    const [isPublic, setIsPublic] = useState(false)
+    const [templateId, setTemplateId] = useState(DEFAULT_TEMPLATE)
+    const [libraryVersion, setLibraryVersion] = useState(DEFAULT_VERSION)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState('')
+
+    useEffect(() => {
+        const load = async () => {
+            if (!flow?.id) {
+                setLoading(false)
+                return
+            }
+            try {
+                const settings = await PlayCanvasPublicationApi.loadPlayCanvasSettings(flow.id)
+                if (settings) {
+                    setProjectTitle(settings.projectTitle || flow?.name || '')
+                    setIsPublic(!!settings.isPublic)
+                    setTemplateId(settings.templateId || DEFAULT_TEMPLATE)
+                    const libVer = settings.libraryConfig?.playcanvas?.version
+                    setLibraryVersion(libVer || DEFAULT_VERSION)
+                }
+            } catch (e) {
+                console.error('PlayCanvasPublisher: load error', e)
+                setError(e.message)
+            } finally {
+                setLoading(false)
+            }
+        }
+        load()
+    }, [flow?.id])
+
+    const saveSettings = async () => {
+        if (!flow?.id) return
+        try {
+            await PlayCanvasPublicationApi.savePlayCanvasSettings(flow.id, {
+                isPublic,
+                projectTitle,
+                generationMode: 'streaming',
+                templateId,
+                libraryConfig: { playcanvas: { version: libraryVersion, source: 'official' } }
+            })
+        } catch (e) {
+            console.error('PlayCanvasPublisher: save error', e)
+        }
+    }
+
+    useEffect(() => {
+        if (!loading) {
+            const tId = setTimeout(saveSettings, 500)
+            return () => clearTimeout(tId)
+        }
+    }, [projectTitle, isPublic, templateId, libraryVersion, loading])
+
+    if (loading) return (
+        <Box sx={{ p: 2 }}><CircularProgress /></Box>
+    )
+    if (error) return (
+        <Box sx={{ p: 2 }}><Typography color='error'>{error}</Typography></Box>
+    )
+
+    return (
+        <Box sx={{ p: 2 }}>
+            <TextField
+                fullWidth
+                label={t('playcanvas.projectTitle')}
+                margin='normal'
+                value={projectTitle}
+                onChange={(e) => setProjectTitle(e.target.value)}
+            />
+            <FormControlLabel
+                control={<Switch checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />}
+                label={t('configuration.makePublic')}
+                sx={{ my: 1 }}
+            />
+            <TemplateSelect selectedTemplate={templateId} onTemplateChange={setTemplateId} />
+            <FormControl fullWidth margin='normal'>
+                <InputLabel>{t('playcanvas.libraryVersion.label')}</InputLabel>
+                <Select
+                    value={libraryVersion}
+                    label={t('playcanvas.libraryVersion.label')}
+                    onChange={(e) => setLibraryVersion(e.target.value)}
+                >
+                    <MenuItem value='2.9.0'>2.9.0</MenuItem>
+                </Select>
+            </FormControl>
+            <Typography variant='caption'>{t('playcanvas.libraryVersion.hint')}</Typography>
+        </Box>
+    )
+}
+
+export default PlayCanvasPublisher

--- a/apps/publish-frt/base/src/i18n/locales/en/main.json
+++ b/apps/publish-frt/base/src/i18n/locales/en/main.json
@@ -183,6 +183,13 @@
             "generatingScene": "Generating AR scene...",
             "showMarker": "Show this marker to the camera to activate AR"
         },
+        "playcanvas": {
+            "projectTitle": "Project Title",
+            "libraryVersion": {
+                "label": "PlayCanvas Version",
+                "hint": "Select library version"
+            }
+        },
         "templates": {
             "label": "Export Template",
             "selectTemplate": "Select template",
@@ -196,5 +203,10 @@
         "saveError": "Error saving publication settings",
         "streamingModeEnabled": "Streaming generation mode enabled",
         "publicLinkAvailable": "Public link is available"
+    },
+    "playcanvasPublication": {
+        "configSaved": "PlayCanvas publication settings saved",
+        "saveError": "Error saving PlayCanvas settings",
+        "libraryHint": "Choose PlayCanvas engine version"
     }
 }

--- a/apps/publish-frt/base/src/i18n/locales/ru/main.json
+++ b/apps/publish-frt/base/src/i18n/locales/ru/main.json
@@ -184,6 +184,13 @@
             "generatingScene": "Генерация AR сцены...",
             "showMarker": "Покажите этот маркер камере для активации AR"
         },
+        "playcanvas": {
+            "projectTitle": "Название проекта",
+            "libraryVersion": {
+                "label": "Версия PlayCanvas",
+                "hint": "Выберите версию библиотеки"
+            }
+        },
         "templates": {
             "label": "Шаблон экспорта",
             "selectTemplate": "Выберите шаблон",
@@ -197,5 +204,10 @@
         "saveError": "Ошибка при сохранении настроек",
         "streamingModeEnabled": "Режим потоковой генерации включен",
         "publicLinkAvailable": "Публичная ссылка доступна"
+    },
+    "playcanvasPublication": {
+        "configSaved": "Настройки публикации PlayCanvas сохранены",
+        "saveError": "Ошибка при сохранении настроек PlayCanvas",
+        "libraryHint": "Выберите версию движка PlayCanvas"
     }
 }

--- a/packages/ui/src/views/chatflows/APICodeDialog.jsx
+++ b/packages/ui/src/views/chatflows/APICodeDialog.jsx
@@ -31,6 +31,7 @@ import Configuration from './Configuration'
 import ChatBotSettings from '@/views/publish/bots/ChatBotSettings'
 import ARJSPublisher from '@apps/publish-frt/base/src/features/arjs/ARJSPublisher.jsx'
 import ARJSExporter from '@apps/publish-frt/base/src/features/arjs/ARJSExporter.jsx'
+import PlayCanvasPublisher from '@apps/publish-frt/base/src/features/playcanvas/PlayCanvasPublisher.jsx'
 import EmbedChat from './EmbedChat'
 
 // Const
@@ -800,6 +801,9 @@ formData.append("openAIApiKey[openAIEmbeddings_0]", "sk-my-openai-2nd-key")`
                         )}
                         {codeLang === tPub('tabs.publish') && !chatflowApiKeyId && displayMode === 'arjs' && (
                             <ARJSPublisher flow={chatflow} unikId={unikId} />
+                        )}
+                        {codeLang === tPub('tabs.publish') && !chatflowApiKeyId && displayMode === 'playcanvas' && (
+                            <PlayCanvasPublisher flow={chatflow} />
                         )}
                         {codeLang === tPub('tabs.publish') && !chatflowApiKeyId && displayMode === 'chat' && (
                             <ChatBotSettings

--- a/packages/ui/src/views/chatflows/Configuration.jsx
+++ b/packages/ui/src/views/chatflows/Configuration.jsx
@@ -19,6 +19,7 @@ import useNotifier from '@/utils/useNotifier'
 
 // Components
 import { TooltipWithParser } from '@/ui-component/tooltip/TooltipWithParser'
+import PlayCanvasPublisher from '@apps/publish-frt/base/src/features/playcanvas/PlayCanvasPublisher.jsx'
 
 const Configuration = ({ chatflowid, unikId: propUnikId, displayMode: propDisplayMode, setDisplayMode: propSetDisplayMode }) => {
     const dispatch = useDispatch()
@@ -290,6 +291,11 @@ const Configuration = ({ chatflowid, unikId: propUnikId, displayMode: propDispla
                         />
                     </RadioGroup>
                 </FormControl>
+                {displayMode === 'playcanvas' && (
+                    <Box sx={{ mt: 2 }}>
+                        <PlayCanvasPublisher flow={chatflow} />
+                    </Box>
+                )}
             </Paper>
         </Box>
     )


### PR DESCRIPTION
Fix #120 Add PlayCanvas publication tab

## Summary
- create `PlayCanvasPublisher` component connected to `PlayCanvasPublicationApi`
- display PlayCanvas publisher in Publish dialog and Configuration tab
- add playcanvas i18n keys and hints

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6868781b15d483238052280e9b530eae