### PR TITLE
GH122 Register MMOOMM template and update PlayCanvas support

### DIFF
--- a/apps/publish-frt/base/src/builders/common/AbstractTemplateBuilder.ts
+++ b/apps/publish-frt/base/src/builders/common/AbstractTemplateBuilder.ts
@@ -122,7 +122,8 @@ ${libraryScripts}
         const defaultVersions: Record<string, string> = {
             aframe: '1.7.1',
             arjs: '3.4.7',
-            playcanvas: '1.65.0'
+            // Universo Platformo | Updated PlayCanvas default version
+            playcanvas: '2.9.0'
         }
 
         const baseUrls = {

--- a/apps/publish-frt/base/src/builders/common/TemplateRegistry.ts
+++ b/apps/publish-frt/base/src/builders/common/TemplateRegistry.ts
@@ -3,6 +3,7 @@
 
 import { ITemplateBuilder, TemplateInfo } from './types'
 import { ARJSQuizBuilder, QuizTemplateConfig } from '../arjs/templates/quiz'
+import { PlayCanvasMMOOMMBuilder } from '../playcanvas/templates/mmoomm/PlayCanvasMMOOMMBuilder'
 
 /**
  * Central registry for all export templates
@@ -26,6 +27,19 @@ export class TemplateRegistry {
             features: QuizTemplateConfig.features,
             defaults: QuizTemplateConfig.defaults,
             builder: ARJSQuizBuilder
+        })
+
+        // Universo Platformo | Register PlayCanvas MMOOMM template
+        const mmoommInfo = new PlayCanvasMMOOMMBuilder().getTemplateInfo()
+        this.registerTemplate({
+            id: mmoommInfo.id,
+            name: mmoommInfo.name,
+            description: mmoommInfo.description,
+            version: mmoommInfo.version,
+            supportedNodes: mmoommInfo.supportedNodes,
+            features: mmoommInfo.features,
+            defaults: mmoommInfo.defaults,
+            builder: PlayCanvasMMOOMMBuilder
         })
 
         console.log(`[TemplateRegistry] Registered ${this.templates.size} templates`)

--- a/apps/publish-frt/base/src/builders/playcanvas/templates/mmoomm/PlayCanvasMMOOMMBuilder.ts
+++ b/apps/publish-frt/base/src/builders/playcanvas/templates/mmoomm/PlayCanvasMMOOMMBuilder.ts
@@ -48,13 +48,13 @@ export class PlayCanvasMMOOMMBuilder extends AbstractTemplateBuilder {
 
     async build(_flowData: IFlowData, options: BuildOptions = {}): Promise<string> {
         const sceneScript = this.generateSceneScript()
-        const sceneContent = `<canvas id='application-canvas'></canvas>\n<script src='https://code.playcanvas.com/playcanvas-2.9.0.js'></script>\n<script>${sceneScript}</script>`
+        const sceneContent = `<canvas id='application-canvas'></canvas>\n<script>${sceneScript}</script>`
         return this.wrapWithDocumentStructure(sceneContent, options)
     }
 
     protected generateHTML(_content: { spaceContent: string; objectContent: string; cameraContent: string; lightContent: string; dataContent: string; template: string; error?: boolean }, options: BuildOptions = {}): string {
         const sceneScript = this.generateSceneScript()
-        const sceneContent = `<canvas id='application-canvas'></canvas>\n<script src='https://code.playcanvas.com/playcanvas-2.9.0.js'></script>\n<script>${sceneScript}</script>`
+        const sceneContent = `<canvas id='application-canvas'></canvas>\n<script>${sceneScript}</script>`
         return this.wrapWithDocumentStructure(sceneContent, options)
     }
 
@@ -71,7 +71,7 @@ export class PlayCanvasMMOOMMBuilder extends AbstractTemplateBuilder {
     }
 
     getRequiredLibraries(): string[] {
-        return []
+        return ['playcanvas']
     }
 
     private generateSceneScript(): string {


### PR DESCRIPTION
Fix #122 Register MMOOMM template and update PlayCanvas defaults

## Summary
- register the `mmoomm` template inside `TemplateRegistry`
- add PlayCanvas default version to `AbstractTemplateBuilder`
- inject PlayCanvas script via `AbstractTemplateBuilder` utilities

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68687d12d6a483238e45ed536523d6f1