### PR TITLE
GH124 Add PlayCanvas template translations and docs

### DIFF
--- a/apps/publish-frt/base/README.md
+++ b/apps/publish-frt/base/README.md
@@ -166,6 +166,26 @@ console.log(result.html) // Generated AR.js HTML
 console.log(result.metadata) // Build metadata
 ```
 
+### PlayCanvas Builder Usage
+
+```typescript
+import { PlayCanvasBuilder } from './builders'
+
+const builder = new PlayCanvasBuilder()
+const result = await builder.buildFromFlowData(flowDataString, {
+    projectName: 'MMOOMM Demo',
+    templateId: 'mmoomm'
+})
+
+console.log(result.html) // PlayCanvas HTML
+```
+
+### Universo MMOOMM Example
+
+The `mmoomm` template produces a small demo scene with a ship, asteroids and a gate.
+Select **PlayCanvas MMOOMM Template** in the configuration or pass `templateId: 'mmoomm'` when using the builder.
+Publish the project and open the public link to explore the prototype MMO environment.
+
 ## UPDL Processing Architecture
 
 The frontend now includes independent UPDL processing capabilities through the `UPDLProcessor` class, eliminating dependencies on backend utilities.
@@ -305,6 +325,8 @@ Publication state persistence is handled through Supabase integration:
 -   `ARViewPage` - Page component for AR space viewing using iframe approach
 -   `ARJSBuilder` - **The high-level controller that delegates to the template system.**
 -   `ARJSQuizBuilder` - **A concrete template implementation for AR.js quizzes.**
+-   `PlayCanvasPublisher` - Component for PlayCanvas publication settings
+-   `PlayCanvasBuilder` - Builder for PlayCanvas HTML output with template support
 
 ## API Architecture
 

--- a/apps/publish-frt/base/src/i18n/locales/en/main.json
+++ b/apps/publish-frt/base/src/i18n/locales/en/main.json
@@ -208,5 +208,11 @@
         "configSaved": "PlayCanvas publication settings saved",
         "saveError": "Error saving PlayCanvas settings",
         "libraryHint": "Choose PlayCanvas engine version"
+    },
+    "playcanvasTemplates": {
+        "mmoomm": {
+            "name": "PlayCanvas MMOOMM Template",
+            "description": "Prototype MMO scene using PlayCanvas primitives"
+        }
     }
 }

--- a/apps/publish-frt/base/src/i18n/locales/ru/main.json
+++ b/apps/publish-frt/base/src/i18n/locales/ru/main.json
@@ -209,5 +209,11 @@
         "configSaved": "Настройки публикации PlayCanvas сохранены",
         "saveError": "Ошибка при сохранении настроек PlayCanvas",
         "libraryHint": "Выберите версию движка PlayCanvas"
+    },
+    "playcanvasTemplates": {
+        "mmoomm": {
+            "name": "Шаблон PlayCanvas MMOOMM",
+            "description": "Прототип MMO сцены на основе примитивов PlayCanvas"
+        }
     }
 }

--- a/apps/publish-srv/base/README.md
+++ b/apps/publish-srv/base/README.md
@@ -37,6 +37,7 @@ This service is implemented as a **pnpm workspace package** that:
 -   **Flow Data Provider**: Serves raw `flowData` from the database, delegating all UPDL processing to the frontend.
 -   **Centralized Types**: Exports shared UPDL and publication-related TypeScript types for use across the platform.
 -   **Modular and Decoupled**: Fully independent from `packages/server` business logic. It no longer contains UPDL generation code.
+-   **PlayCanvas Ready**: The same raw data endpoints are used by the PlayCanvas builder and templates.
 
 ## Integration with Main Flowise Server
 
@@ -71,6 +72,8 @@ The API is now streamlined to handle publication records and serve raw flow data
 
 -   `POST /api/v1/publish/arjs` - Creates or updates a publication record.
 -   `GET /api/v1/publish/arjs/public/:publicationId` - Gets the raw `flowData` for a given publication.
+-   `POST /api/v1/publish/playcanvas` - (planned) create a PlayCanvas publication.
+-   `GET /api/v1/publish/playcanvas/public/:publicationId` - (planned) return raw flow data for PlayCanvas builder.
 
 ### `POST /api/v1/publish/arjs`
 
@@ -106,6 +109,8 @@ Retrieves the raw `flowData` (as a JSON string) and `libraryConfig` for a given 
     }
 }
 ```
+
+PlayCanvas publications will follow the same pattern once the endpoints are implemented.
 
 ## Architectural Changes Summary
 

--- a/apps/updl/base/README.md
+++ b/apps/updl/base/README.md
@@ -110,8 +110,15 @@ The UPDL module provides node definitions that integrate with Flowise:
 -   **Data Node**: Question and answer content for quiz scenes
 -   **Camera Node**: Space viewpoint configuration
 -   **Light Node**: Lighting setup (point, directional, ambient)
+-   **Entity Node**: Runtime entity instance with transform data
+-   **Component Node**: Behaviour component attached to an entity
+-   **Event Node**: Trigger for actions within the scene
+-   **Action Node**: Response logic for events
+-   **Universo Node**: MMOOMM-specific functionality placeholder
 
 Data nodes are used for creating quizzes. A question node can have multiple answer nodes connected to it. Answers may be marked with `isCorrect` and can optionally define `pointsValue`. These answers can also link to Object nodes that appear when chosen.
+
+These additional nodes lay the groundwork for the **PlayCanvas MMOOMM template**, enabling future game-style exports with entities, components and event-driven logic.
 
 Each node includes:
 


### PR DESCRIPTION
Fix #124 Document PlayCanvas template usage and translations

## Summary
- document new entity/component/event/action/universo nodes
- add PlayCanvas builder usage and MMOOMM example
- note PlayCanvas endpoints in publish service
- add PlayCanvas template translations

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686883b6bb5c832387d25a7394794bc0