### PR TITLE
Fix root node flag in SpaceNode

### DIFF
--- a/apps/publish-srv/base/src/types/publication.types.ts
+++ b/apps/publish-srv/base/src/types/publication.types.ts
@@ -115,6 +115,10 @@ export interface IUPDLData {
 export interface IUPDLSpace {
     id: string
     name: string
+    // Universo Platformo | Classification of space
+    spaceType?: string
+    // Universo Platformo | Root node indicator
+    isRootNode?: boolean
     description?: string
     objects: IUPDLObject[]
     cameras?: IUPDLCamera[]

--- a/apps/updl/base/src/nodes/space/SpaceNode.ts
+++ b/apps/updl/base/src/nodes/space/SpaceNode.ts
@@ -252,7 +252,8 @@ export class SpaceNode extends BaseUPDLNode {
             name: spaceName,
             spaceType,
             settings,
-            isRootNode: true,
+            // Universo Platformo | Determine root node status from spaceType
+            isRootNode: spaceType === 'root',
             backgroundColor,
             skybox: {
                 enabled: enableSkybox,


### PR DESCRIPTION
## Summary
- derive `isRootNode` flag from `spaceType` in SpaceNode
- extend `IUPDLSpace` with `spaceType` and `isRootNode`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692fc3e140832386576ecb2e69a3cb