### PR TITLE
GH128 Update library versions for PlayCanvas build metadata

### DIFF
--- a/apps/publish-frt/base/src/builders/common/types.ts
+++ b/apps/publish-frt/base/src/builders/common/types.ts
@@ -17,10 +17,7 @@ export interface BuildResult {
         markerValue: string
         templateId?: string
         templateInfo?: TemplateInfo
-        libraryVersions: {
-            arjs: string
-            aframe: string
-        }
+        libraryVersions: Record<string, string>
     }
 }
 

--- a/apps/publish-frt/base/src/builders/playcanvas/PlayCanvasBuilder.ts
+++ b/apps/publish-frt/base/src/builders/playcanvas/PlayCanvasBuilder.ts
@@ -58,7 +58,11 @@ export class PlayCanvasBuilder extends BaseBuilder {
                     buildTime: Date.now(),
                     markerType: options.markerType || '',
                     markerValue: options.markerValue || '',
-                    libraryVersions: { arjs: '', aframe: '' }
+                    libraryVersions: {
+                        playcanvas:
+                            (options.libraryConfig as any)?.playcanvas?.version ||
+                            '2.9.0'
+                    }
                 }
             }
         } catch (error) {


### PR DESCRIPTION
Fix #128 Capture PlayCanvas version in build metadata

## Summary
- allow any library version map in `BuildResult`
- capture PlayCanvas version from build options or default to 2.9.0

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm build` *(fails: turbo not found)*
- `npx tsc -p apps/publish-frt/base/tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869326437bc8323ad7f94a3d9edc695