### PR TITLE
GH130 Fix save settings when flow changes

### DIFF
--- a/apps/publish-frt/base/src/features/arjs/ARJSPublisher.jsx
+++ b/apps/publish-frt/base/src/features/arjs/ARJSPublisher.jsx
@@ -1,7 +1,7 @@
 // Universo Platformo | AR.js Publisher
 // React component for publishing AR.js experiences using streaming mode
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getCurrentUrlIds, ARJSPublishApi, ChatflowsApi } from '../../api'
 
@@ -51,6 +51,11 @@ try {
  */
 const ARJSPublisher = ({ flow, unikId, onPublish, onCancel, initialConfig }) => {
     const { t } = useTranslation('publish')
+    // Universo Platformo | reference to latest flow.id
+    const flowIdRef = useRef(flow?.id)
+    useEffect(() => {
+        flowIdRef.current = flow?.id
+    }, [flow?.id])
 
     // CRITICAL DEBUG: Diagnose flow.id undefined issue
     useEffect(() => {
@@ -96,12 +101,14 @@ const ARJSPublisher = ({ flow, unikId, onPublish, onCancel, initialConfig }) => 
 
     // Universo Platformo | Function to save current settings
     const saveCurrentSettings = async () => {
-        if (!flow?.id || DEMO_MODE || settingsLoading) {
+        // Universo Platformo | always save with the latest flow.id
+        const currentFlowId = flowIdRef.current
+        if (!currentFlowId || DEMO_MODE || settingsLoading) {
             return
         }
 
         try {
-            await ChatflowsApi.saveSettings(flow.id, {
+            await ChatflowsApi.saveSettings(currentFlowId, {
                 isPublic: isPublic,
                 projectTitle: projectTitle,
                 markerType: markerType,
@@ -131,7 +138,7 @@ const ARJSPublisher = ({ flow, unikId, onPublish, onCancel, initialConfig }) => 
 
             return () => clearTimeout(debounceTimeout)
         }
-    }, [projectTitle, markerType, markerValue, generationMode, arjsVersion, arjsSource, aframeVersion, aframeSource, settingsLoading])
+    }, [projectTitle, markerType, markerValue, generationMode, arjsVersion, arjsSource, aframeVersion, aframeSource, settingsLoading, flow?.id]) // Universo Platformo | re-run when flow changes
 
     // Universo Platformo | Load saved settings when component mounts
     useEffect(() => {

--- a/apps/publish-frt/base/src/features/playcanvas/PlayCanvasPublisher.jsx
+++ b/apps/publish-frt/base/src/features/playcanvas/PlayCanvasPublisher.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
     Box,
@@ -21,6 +21,11 @@ const DEFAULT_TEMPLATE = 'mmoomm'
 
 const PlayCanvasPublisher = ({ flow }) => {
     const { t } = useTranslation('publish')
+    // Universo Platformo | keep latest flow.id for delayed saves
+    const flowIdRef = useRef(flow?.id)
+    useEffect(() => {
+        flowIdRef.current = flow?.id
+    }, [flow?.id])
     const [projectTitle, setProjectTitle] = useState(flow?.name || '')
     const [isPublic, setIsPublic] = useState(false)
     const [templateId, setTemplateId] = useState(DEFAULT_TEMPLATE)
@@ -54,9 +59,11 @@ const PlayCanvasPublisher = ({ flow }) => {
     }, [flow?.id])
 
     const saveSettings = async () => {
-        if (!flow?.id) return
+        // Universo Platformo | always use the latest flow.id
+        const currentFlowId = flowIdRef.current
+        if (!currentFlowId) return
         try {
-            await PlayCanvasPublicationApi.savePlayCanvasSettings(flow.id, {
+            await PlayCanvasPublicationApi.savePlayCanvasSettings(currentFlowId, {
                 isPublic,
                 projectTitle,
                 generationMode: 'streaming',
@@ -73,7 +80,7 @@ const PlayCanvasPublisher = ({ flow }) => {
             const tId = setTimeout(saveSettings, 500)
             return () => clearTimeout(tId)
         }
-    }, [projectTitle, isPublic, templateId, libraryVersion, loading])
+    }, [projectTitle, isPublic, templateId, libraryVersion, loading, flow?.id]) // Universo Platformo | re-run when flow changes
 
     if (loading) return (
         <Box sx={{ p: 2 }}><CircularProgress /></Box>


### PR DESCRIPTION
Fix #130 Fix saving settings when flow changes

## Summary
- track the latest `flow.id` with refs in PlayCanvas and AR.js publishers
- re-run auto-save effect when the flow changes

## Testing
- `pnpm install`
- `pnpm build`
- `pnpm lint` *(fails: config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869378f3da483238d37be34b4f6cac4