### PR TITLE
GH132 Fix PlayCanvas library source path

### DIFF
--- a/apps/publish-frt/base/src/builders/common/AbstractTemplateBuilder.ts
+++ b/apps/publish-frt/base/src/builders/common/AbstractTemplateBuilder.ts
@@ -167,8 +167,8 @@ ${libraryScripts}
 
             case 'playcanvas':
                 return sourceType === 'kiberplano'
-                    ? `${baseUrls.kiberplano.playcanvas}/playcanvas/${version}/playcanvas.min.js`
-                    : `${baseUrls.official.playcanvas}/${version}/playcanvas.min.js`
+                    ? `/playcanvas/${version}/playcanvas.min.js`
+                    : `${baseUrls.official.playcanvas}/playcanvas-${version}.js`
 
             default:
                 console.warn(`[AbstractTemplateBuilder] Unknown library: ${libraryName}`)


### PR DESCRIPTION
Fix #132 Fix PlayCanvas library source path

## Summary
- update playcanvas path selection in `getLibrarySource`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68693d82a0088323a3c3b71079eeefb3