### PR TITLE
Initialize UPDL builders

### DIFF
--- a/packages/ui/src/index.jsx
+++ b/packages/ui/src/index.jsx
@@ -16,9 +16,13 @@ import { Provider } from 'react-redux'
 import { SnackbarProvider } from 'notistack'
 import ConfirmContextProvider from '@/store/context/ConfirmContextProvider'
 import { ReactFlowContext } from '@/store/context/ReactFlowContext'
+import { setupBuilders } from '@apps/publish-frt/base/src/builders'
 
 const container = document.getElementById('root')
 const root = createRoot(container)
+
+// Universo Platformo | initialize UPDL builders
+setupBuilders()
 
 root.render(
     <React.StrictMode>


### PR DESCRIPTION
## Summary
- initialize UPDL builders before rendering the UI

## Testing
- `pnpm exec eslint packages/ui/src/index.jsx`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68695dfffdbc832380eb5530e552f322