### PR TITLE
GH#151 Implement basic entity/component export support

### DIFF
--- a/apps/publish-frt/base/src/builders/common/UPDLProcessor.ts
+++ b/apps/publish-frt/base/src/builders/common/UPDLProcessor.ts
@@ -260,6 +260,11 @@ export class UPDLProcessor {
         const cameraNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'camera')
         const lightNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'light')
         const dataNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'data')
+        const entityNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'entity')
+        const componentNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'component')
+        const eventNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'event')
+        const actionNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'action')
+        const universoNodes = nodes.filter((node) => node.data?.name?.toLowerCase() === 'universo')
 
         const objects: IUPDLObject[] = objectNodes.map((node) => {
             const nodeData = node.data || {}
@@ -348,6 +353,69 @@ export class UPDLProcessor {
             }
         })
 
+        const components = componentNodes.map((node) => {
+            const nodeData = node.data || {}
+            const inputs = nodeData.inputs || {}
+            let props
+            try {
+                props = inputs.props ? JSON.parse(inputs.props as string) : {}
+            } catch {
+                props = {}
+            }
+            return {
+                id: node.id,
+                componentType: inputs.componentType || 'render',
+                primitive: inputs.primitive,
+                color: inputs.color,
+                scriptName: inputs.scriptName,
+                props
+            }
+        })
+
+        const entities = entityNodes.map((node) => {
+            const nodeData = node.data || {}
+            const inputs = nodeData.inputs || {}
+            let transform
+            try {
+                transform = inputs.transform ? JSON.parse(inputs.transform as string) : undefined
+            } catch {
+                transform = undefined
+            }
+            return {
+                id: node.id,
+                name: nodeData.label || 'Entity',
+                entityType: inputs.entityType,
+                transform,
+                tags: inputs.tags ? (Array.isArray(inputs.tags) ? inputs.tags : [inputs.tags]) : [],
+                components: [],
+                events: []
+            }
+        })
+
+        const events = eventNodes.map((node) => {
+            const nodeData = node.data || {}
+            const inputs = nodeData.inputs || {}
+            return {
+                id: node.id,
+                eventType: inputs.eventType || 'generic',
+                source: inputs.source,
+                actions: []
+            }
+        })
+
+        const actions = actionNodes.map((node) => {
+            const nodeData = node.data || {}
+            const inputs = nodeData.inputs || {}
+            return {
+                id: node.id,
+                actionType: inputs.actionType || 'custom',
+                target: inputs.target,
+                params: inputs.params || {}
+            }
+        })
+
+        const universo = universoNodes.map((node) => ({ id: node.id, data: node.data }))
+
         return {
             id: spaceNode.id,
             name: spaceData.label || 'UPDL Space',
@@ -355,6 +423,11 @@ export class UPDLProcessor {
             cameras,
             lights,
             datas,
+            entities,
+            components,
+            events,
+            actions,
+            universo,
             showPoints: spaceData.inputs?.showPoints || false,
             leadCollection: {
                 collectName: spaceData.inputs?.collectLeadName || false,
@@ -388,7 +461,9 @@ export class UPDLProcessor {
             } else {
                 // Build single UPDL space
                 const updlSpace = this.buildUPDLSpaceFromNodes(nodes)
-                console.log(`[UPDLProcessor] Single space built: ${updlSpace.objects.length} objects`)
+                console.log(
+                    `[UPDLProcessor] Single space built: ${updlSpace.entities?.length || 0} entities, ${updlSpace.objects.length} objects`
+                )
                 return { updlSpace }
             }
         } catch (error) {

--- a/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/PlayCanvasMMOOMMBuilder.ts
+++ b/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/PlayCanvasMMOOMMBuilder.ts
@@ -244,16 +244,16 @@ window.app = app;
         // Extract base nodes using parent method
         const baseNodes = this.extractNodes(flowData)
 
-        // For now, return empty arrays for high-level nodes until we have real UPDL data
-        // This is a placeholder that can be extended when we have actual MMOOMM node data
+        const firstSpace = baseNodes.spaces[0] || {}
+
         return {
             spaces: baseNodes.spaces,
-            entities: [], // Will be populated from actual Entity nodes
-            components: [], // Will be populated from actual Component nodes
-            events: [], // Will be populated from actual Event nodes
-            actions: [], // Will be populated from actual Action nodes
+            entities: (firstSpace as any).entities || [],
+            components: (firstSpace as any).components || [],
+            events: (firstSpace as any).events || [],
+            actions: (firstSpace as any).actions || [],
             data: baseNodes.data,
-            universo: [] // Will be populated from actual Universo nodes
+            universo: (firstSpace as any).universo || []
         }
     }
 

--- a/apps/publish-srv/base/src/types/publication.types.ts
+++ b/apps/publish-srv/base/src/types/publication.types.ts
@@ -68,6 +68,55 @@ export interface IUPDLObject extends IUPDLBaseObject {
 }
 
 /**
+ * UPDL Component attached to an entity
+ */
+export interface IUPDLComponent {
+    id: string
+    componentType: string
+    primitive?: string
+    color?: string
+    scriptName?: string
+    props?: Record<string, any>
+}
+
+/**
+ * UPDL Entity representing a scene object with transform
+ */
+export interface IUPDLEntity {
+    id: string
+    name?: string
+    entityType?: string
+    transform?: {
+        position?: IUPDLPosition
+        rotation?: IUPDLRotation
+        scale?: IUPDLPosition
+    }
+    tags?: string[]
+    components?: IUPDLComponent[]
+    events?: IUPDLEvent[]
+}
+
+/**
+ * UPDL Event triggering actions
+ */
+export interface IUPDLEvent {
+    id: string
+    eventType: string
+    source?: string
+    actions?: IUPDLAction[]
+}
+
+/**
+ * UPDL Action executed by events
+ */
+export interface IUPDLAction {
+    id: string
+    actionType: string
+    target?: string
+    params?: Record<string, any>
+}
+
+/**
  * UPDL Camera
  */
 export interface IUPDLCamera extends IUPDLBaseObject {
@@ -124,6 +173,11 @@ export interface IUPDLSpace {
     cameras?: IUPDLCamera[]
     lights?: IUPDLLight[]
     datas?: IUPDLData[]
+    entities?: IUPDLEntity[]
+    components?: IUPDLComponent[]
+    events?: IUPDLEvent[]
+    actions?: IUPDLAction[]
+    universo?: any[]
     // Universo Platformo | Points system display option
     showPoints?: boolean
     // Universo Platformo | Lead data collection settings


### PR DESCRIPTION
Fix #151 Extend PlayCanvas MMOOMM template with entity rendering.

## Summary
- extend publication types with Entity and Component abstractions
- parse new high-level nodes in `UPDLProcessor`
- expose these nodes in `PlayCanvasMMOOMMBuilder`

## Testing
- `pnpm lint` *(fails: Unsupported engine)*
- `pnpm build` *(incomplete due to script termination)*

------
https://chatgpt.com/codex/tasks/task_e_68729f427fcc83238a4c58a0415376d1