### PR TITLE
GH153 Update UPDL processing and PlayCanvas handlers

### DIFF
--- a/apps/publish-frt/base/README.md
+++ b/apps/publish-frt/base/README.md
@@ -454,6 +454,8 @@ AR quizzes are built using a chain of UPDL **Space** nodes. Each space may inclu
 
 Spaces can form a sequence via their `nextSpace` connection to create multi‑question quizzes. A space with no Data nodes can collect user info (`collectName`, `collectEmail`, `collectPhone`) and save it to Supabase leads. The final space in a chain can enable `showPoints` to display the participant score. Currently this score is stored in the `lead.phone` field as a temporary solution.
 
+High‑level nodes are connected in a chain: **Entity** holds **Components**, components can raise **Events**, and events run **Actions**. This relationship `Entity → Component → Event → Action` describes interactive behaviour used by builders such as PlayCanvas MMOOMM.
+
 ## Workflow
 
 The implementation uses streaming generation for AR.js from UPDL nodes with persistent configuration:

--- a/apps/publish-frt/base/src/builders/common/UPDLProcessor.ts
+++ b/apps/publish-frt/base/src/builders/common/UPDLProcessor.ts
@@ -246,7 +246,7 @@ export class UPDLProcessor {
      * Build a UPDL space from the flow nodes
      * Moved from buildUPDLflow.ts
      */
-    static buildUPDLSpaceFromNodes(nodes: IReactFlowNode[]): IUPDLSpace {
+    static buildUPDLSpaceFromNodes(nodes: IReactFlowNode[], edges: any[] = []): IUPDLSpace {
         // Find the space node
         const spaceNode = nodes.find((node) => node.data?.name?.toLowerCase() === 'space')
 
@@ -356,39 +356,85 @@ export class UPDLProcessor {
         const components = componentNodes.map((node) => {
             const nodeData = node.data || {}
             const inputs = nodeData.inputs || {}
+
             let props
-            try {
-                props = inputs.props ? JSON.parse(inputs.props as string) : {}
-            } catch {
+            if (inputs.props) {
+                if (typeof inputs.props === 'string') {
+                    try {
+                        props = JSON.parse(inputs.props)
+                    } catch {
+                        props = {}
+                    }
+                } else if (typeof inputs.props === 'object') {
+                    props = inputs.props
+                } else {
+                    props = {}
+                }
+            } else {
                 props = {}
             }
+
             return {
                 id: node.id,
-                componentType: inputs.componentType || 'render',
-                primitive: inputs.primitive,
-                color: inputs.color,
-                scriptName: inputs.scriptName,
-                props
+                data: {
+                    componentType: inputs.componentType || 'render',
+                    primitive: inputs.primitive,
+                    color: inputs.color,
+                    scriptName: inputs.scriptName,
+                    props
+                }
             }
         })
 
         const entities = entityNodes.map((node) => {
             const nodeData = node.data || {}
             const inputs = nodeData.inputs || {}
+
             let transform
-            try {
-                transform = inputs.transform ? JSON.parse(inputs.transform as string) : undefined
-            } catch {
-                transform = undefined
+            if (inputs.transform) {
+                let parsed: any = undefined
+                if (typeof inputs.transform === 'string') {
+                    try {
+                        parsed = JSON.parse(inputs.transform)
+                    } catch {
+                        parsed = undefined
+                    }
+                } else if (typeof inputs.transform === 'object') {
+                    parsed = inputs.transform
+                }
+                if (parsed) {
+                    transform = {}
+                    if (parsed.pos || parsed.position) {
+                        const pos = parsed.pos || parsed.position
+                        transform.position = Array.isArray(pos)
+                            ? { x: Number(pos[0]) || 0, y: Number(pos[1]) || 0, z: Number(pos[2]) || 0 }
+                            : pos
+                    }
+                    if (parsed.rot || parsed.rotation) {
+                        const rot = parsed.rot || parsed.rotation
+                        transform.rotation = Array.isArray(rot)
+                            ? { x: Number(rot[0]) || 0, y: Number(rot[1]) || 0, z: Number(rot[2]) || 0 }
+                            : rot
+                    }
+                    if (parsed.scale) {
+                        const sc = parsed.scale
+                        transform.scale = Array.isArray(sc)
+                            ? { x: Number(sc[0]) || 1, y: Number(sc[1]) || 1, z: Number(sc[2]) || 1 }
+                            : sc
+                    }
+                }
             }
+
             return {
                 id: node.id,
-                name: nodeData.label || 'Entity',
-                entityType: inputs.entityType,
-                transform,
-                tags: inputs.tags ? (Array.isArray(inputs.tags) ? inputs.tags : [inputs.tags]) : [],
-                components: [],
-                events: []
+                data: {
+                    name: nodeData.label || 'Entity',
+                    entityType: inputs.entityType,
+                    transform,
+                    tags: inputs.tags ? (Array.isArray(inputs.tags) ? inputs.tags : [inputs.tags]) : [],
+                    components: [],
+                    events: []
+                }
             }
         })
 
@@ -397,9 +443,11 @@ export class UPDLProcessor {
             const inputs = nodeData.inputs || {}
             return {
                 id: node.id,
-                eventType: inputs.eventType || 'generic',
-                source: inputs.source,
-                actions: []
+                data: {
+                    eventType: inputs.eventType || 'generic',
+                    source: inputs.source,
+                    actions: []
+                }
             }
         })
 
@@ -408,9 +456,32 @@ export class UPDLProcessor {
             const inputs = nodeData.inputs || {}
             return {
                 id: node.id,
-                actionType: inputs.actionType || 'custom',
-                target: inputs.target,
-                params: inputs.params || {}
+                data: {
+                    actionType: inputs.actionType || 'custom',
+                    target: inputs.target,
+                    params: inputs.params || {}
+                }
+            }
+        })
+
+        // Map edges to attach components and actions
+        const entityMap = new Map(entities.map((e) => [e.id, e]))
+        const componentMap = new Map(components.map((c) => [c.id, c]))
+        const eventMap = new Map(events.map((ev) => [ev.id, ev]))
+        const actionMap = new Map(actions.map((a) => [a.id, a]))
+
+        edges.forEach((edge) => {
+            const sourceId = edge.source
+            const targetId = edge.target
+            if (componentMap.has(sourceId) && entityMap.has(targetId)) {
+                const ent = entityMap.get(targetId)
+                ent.data.components.push(componentMap.get(sourceId))
+            } else if (eventMap.has(sourceId) && entityMap.has(targetId)) {
+                const ent = entityMap.get(targetId)
+                ent.data.events.push(eventMap.get(sourceId))
+            } else if (actionMap.has(sourceId) && eventMap.has(targetId)) {
+                const ev = eventMap.get(targetId)
+                ev.data.actions.push(actionMap.get(sourceId))
             }
         })
 
@@ -460,7 +531,7 @@ export class UPDLProcessor {
                 return { multiScene }
             } else {
                 // Build single UPDL space
-                const updlSpace = this.buildUPDLSpaceFromNodes(nodes)
+                const updlSpace = this.buildUPDLSpaceFromNodes(nodes, edges)
                 console.log(
                     `[UPDLProcessor] Single space built: ${updlSpace.entities?.length || 0} entities, ${updlSpace.objects.length} objects`
                 )

--- a/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/PlayCanvasMMOOMMBuilder.ts
+++ b/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/PlayCanvasMMOOMMBuilder.ts
@@ -76,6 +76,8 @@ export class PlayCanvasMMOOMMBuilder extends AbstractTemplateBuilder {
     private buildSingleScene(flowData: IFlowData, options: BuildOptions): string {
         const nodes = this.extractMMOOMMNodes(flowData)
 
+        console.log(`[PlayCanvasMMOOMMBuilder] Entities: ${nodes.entities.length}, Components: ${nodes.components.length}`)
+
         // Process all node types using handlers
         const spaceScript = this.spaceHandler.process(nodes.spaces[0], options)
         const entityScript = this.entityHandler.process(nodes.entities, options)
@@ -98,9 +100,6 @@ export class PlayCanvasMMOOMMBuilder extends AbstractTemplateBuilder {
             '',
             '// Entities with MMO capabilities',
             entityScript,
-            '',
-            '// MMO Components',
-            componentScript,
             '',
             '// Real-time Events',
             eventScript,
@@ -149,6 +148,8 @@ export class PlayCanvasMMOOMMBuilder extends AbstractTemplateBuilder {
             }
         })
 
+        console.log(`[PlayCanvasMMOOMMBuilder] Multi-scene totals: entities ${allEntities.length}, components ${allComponents.length}`)
+
         // Process using handlers
         const spaceScript = this.spaceHandler.process({ data: { type: 'root', id: 'multi-scene' } }, options)
         const entityScript = this.entityHandler.process(allEntities, options)
@@ -167,7 +168,6 @@ export class PlayCanvasMMOOMMBuilder extends AbstractTemplateBuilder {
             '',
             spaceScript,
             entityScript,
-            componentScript,
             eventScript,
             actionScript,
             dataScript,

--- a/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/handlers/ComponentHandler.ts
+++ b/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/handlers/ComponentHandler.ts
@@ -10,6 +10,16 @@ export class ComponentHandler {
         return components.map((component) => this.processComponent(component, options)).join('\n')
     }
 
+    attach(component: any, entityVar: string): string {
+        const type = component.data?.componentType || 'custom'
+        switch (type) {
+            case 'render':
+                return this.generateRenderAttachment(component, entityVar)
+            default:
+                return ''
+        }
+    }
+
     private processComponent(component: any, options: BuildOptions): string {
         const componentType = component.data?.componentType || 'custom'
         const componentId = component.data?.id || `component_${Math.random().toString(36).substr(2, 9)}`
@@ -39,6 +49,8 @@ export class ComponentHandler {
                 return this.generateNetworkingComponent(id, properties)
             case 'audio':
                 return this.generateAudioComponent(id, properties)
+            case 'render':
+                return this.generateRenderComponent(id, properties)
             default:
                 return this.generateCustomComponent(id, properties)
         }
@@ -132,6 +144,28 @@ export class ComponentHandler {
 `
     }
 
+    private generateRenderComponent(id: string, props: any): string {
+        return `
+    // Render component for MMO
+    const renderComponent = {
+        primitive: '${props.primitive || 'box'}',
+        color: '${props.color || '#ffffff'}',
+
+        applyToEntity(entity) {
+            entity.addComponent('model', { type: this.primitive });
+            const mcol_${id} = new pc.Color();
+            mcol_${id}.fromString(this.color);
+            const mat_${id} = new pc.StandardMaterial();
+            mat_${id}.diffuse = mcol_${id};
+            mat_${id}.update();
+            entity.model.material = mat_${id};
+        }
+    };
+
+    console.log('[MMO Component] Render component ${id} ready');
+`
+    }
+
     private generateCustomComponent(id: string, props: any): string {
         return `
     // Custom MMO component
@@ -146,5 +180,20 @@ export class ComponentHandler {
     
     console.log('[MMO Component] Custom component ${id} ready');
 `
+    }
+
+    private generateRenderAttachment(component: any, entityVar: string): string {
+        const primitive = component.data?.primitive || 'box'
+        const color = component.data?.color || '#ffffff'
+        return `
+    // Render component ${component.id}
+    ${entityVar}.addComponent('model', { type: '${primitive}' });
+    const mat_${component.id} = new pc.StandardMaterial();
+    const col_${component.id} = new pc.Color();
+    col_${component.id}.fromString('${color}');
+    mat_${component.id}.diffuse = col_${component.id};
+    mat_${component.id}.update();
+    ${entityVar}.model.material = mat_${component.id};
+    `
     }
 }

--- a/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/handlers/EntityHandler.ts
+++ b/apps/publish-frt/base/src/builders/templates/mmoomm/playcanvas/handlers/EntityHandler.ts
@@ -2,8 +2,10 @@
 // Handles Entity nodes with networking capabilities for MMO
 
 import { BuildOptions } from '../../../../common/types'
+import { ComponentHandler } from './ComponentHandler'
 
 export class EntityHandler {
+    private componentHandler = new ComponentHandler()
     /**
      * Process array of Entity nodes for MMO environment
      */
@@ -14,12 +16,13 @@ export class EntityHandler {
     }
 
     private processEntity(entity: any, options: BuildOptions): string {
-        const entityId = entity.data?.id || `entity_${Math.random().toString(36).substr(2, 9)}`
+        const entityId = entity.id || `entity_${Math.random().toString(36).substr(2, 9)}`
         const entityType = entity.data?.entityType || 'static'
         const position = entity.data?.transform?.position || { x: 0, y: 0, z: 0 }
         const rotation = entity.data?.transform?.rotation || { x: 0, y: 0, z: 0 }
         const scale = entity.data?.transform?.scale || { x: 1, y: 1, z: 1 }
         const isNetworked = entity.data?.networked || false
+        const components = entity.data?.components || []
 
         return `
 // MMO Entity: ${entityId}
@@ -35,6 +38,9 @@ export class EntityHandler {
     
     // Entity type specific setup
     ${this.generateEntityTypeLogic(entityType, entityId)}
+
+    // Attached components
+    ${ components.map((c: any) => this.componentHandler.attach(c, 'entity')).join('\n    ') }
     
     // Add to scene
     app.root.addChild(entity);

--- a/apps/updl/base/README.md
+++ b/apps/updl/base/README.md
@@ -74,6 +74,8 @@ The template system is primarily designed to process the 7 core high-level UPDL 
 
 **Note**: Other nodes (Object, Camera, Light) are legacy/testing nodes and may be significantly changed or removed in future versions. Focus development on the 7 core nodes.
 
+In a typical scene, **Entities** act as containers for **Components** which add behaviour or visuals. **Events** attached to an Entity trigger **Actions** when certain conditions occur. This chain `Entity → Component → Event → Action` defines interactive logic of the space.
+
 ### Connector Implementation Guide
 
 To ensure nodes connect correctly on the Flowise canvas, follow these rules:


### PR DESCRIPTION
Fix  #153 Enhance UPDL processing and PlayCanvas export, еxtend UPDLProcessor.buildUPDLSpaceFromNodes().

## Summary
- improve `buildUPDLSpaceFromNodes` to keep node data and map edges
- attach components and events using edges
- extend PlayCanvas template handlers to apply entity data
- implement render component type
- add debug logs in PlayCanvas builder
- document Entity→Component→Event→Action chain in READMEs

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6873ad643f488323af1e4302648fe0d3