### PR TITLE
GH320 Refactor ResourceConfigTree import in entities frontend

### DIFF
--- a/apps/entities-frt/base/src/pages/EntityDetail.tsx
+++ b/apps/entities-frt/base/src/pages/EntityDetail.tsx
@@ -3,7 +3,7 @@ import { Box, Tab, Tabs, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import useApi from 'flowise-ui/src/hooks/useApi'
-import ResourceConfigTree from '@apps/resources-frt/base/src/components/ResourceConfigTree'
+import { ResourceConfigTree } from '@universo/resources-frt'
 import { getEntity } from '../api/entities'
 
 const EntityDetail: React.FC = () => {

--- a/apps/entities-frt/base/src/pages/EntityDialog.tsx
+++ b/apps/entities-frt/base/src/pages/EntityDialog.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, MenuItem, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
-import ResourceConfigTree from '@apps/resources-frt/base/src/components/ResourceConfigTree'
+import { ResourceConfigTree } from '@universo/resources-frt'
 import { createEntity, listTemplates } from '../api/entities'
 
 interface EntityDialogProps {

--- a/apps/entities-frt/base/src/pages/TemplateDialog.tsx
+++ b/apps/entities-frt/base/src/pages/TemplateDialog.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
-import ResourceConfigTree from '@apps/resources-frt/base/src/components/ResourceConfigTree'
+import { ResourceConfigTree } from '@universo/resources-frt'
 import { createTemplate } from '../api/entities'
 
 interface TemplateDialogProps {

--- a/apps/entities-frt/base/src/types/resources-frt.d.ts
+++ b/apps/entities-frt/base/src/types/resources-frt.d.ts
@@ -1,5 +1,0 @@
-declare module '@apps/resources-frt/base/src/components/ResourceConfigTree' {
-    import React from 'react'
-    const ResourceConfigTree: React.ComponentType<any>
-    export default ResourceConfigTree
-}


### PR DESCRIPTION
Fixes #320 Refactor ResourceConfigTree import in entities frontend.

# Description

Refactors entities frontend to use ResourceConfigTree from @universo/resources-frt and remove custom module declaration.

## Changes Made

- Replace path-based imports with package import for ResourceConfigTree
- Remove obsolete type declaration file
- Ensure resources package remains listed as dependency

## Additional Work

- Built resources and entities packages to verify type resolution
- Ran lint on entities package

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #320 Refactor ResourceConfigTree import in entities frontend.

# Описание

Пакет сущностей теперь использует ResourceConfigTree из @universo/resources-frt, удаляя самописное объявление модуля.

## Внесенные изменения

- Замена импорта по пути на импорт из пакета ResourceConfigTree
- Удалён устаревший файл объявления типов
- Сохранена зависимость на @universo/resources-frt

## Дополнительная работа

- Сборка пакетов resources и entities для проверки разрешения типов
- Запуск линтера для пакета entities

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>