### PR TITLE
GH322 Add resources and entities routes to UI

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -68,6 +68,7 @@
         "@universo/uniks-frt": "workspace:*",
         "@universo/space-builder-frt": "workspace:*",
         "@universo/metaverse-frt": "workspace:*",
+        "@universo/resources-frt": "workspace:*",
         "@universo/entities-frt": "workspace:*"
     },
     "scripts": {

--- a/packages/ui/src/i18n/index.js
+++ b/packages/ui/src/i18n/index.js
@@ -75,7 +75,8 @@ import { profileTranslations } from '@apps/profile-frt/base/src/i18n'
 import { financeTranslations } from '@apps/finance-frt/base/src/i18n'
 import { uniksTranslations } from '@apps/uniks-frt/base/src/i18n'
 import { metaverseTranslations } from '@apps/metaverse-frt/base/src/i18n'
-import { entitiesTranslations } from '@apps/entities-frt/base/src/i18n'
+import { resourcesTranslations } from '@universo/resources-frt'
+import { entitiesTranslations } from '@universo/entities-frt'
 import { templateMmoommTranslations } from '@apps/template-mmoomm/base/src/i18n'
 import { templateQuizTranslations } from '@apps/template-quiz/base/src/i18n'
 
@@ -109,6 +110,7 @@ i18n.use(LanguageDetector)
                     analytics: analyticsTranslations.en.analytics,
                     profile: profileTranslations.en.profile,
                     metaverse: metaverseTranslations.en.metaverse,
+                    resources: resourcesTranslations.en.resources,
                     entities: entitiesTranslations.en.entities
                 },
                 ru: {
@@ -135,6 +137,7 @@ i18n.use(LanguageDetector)
                     analytics: analyticsTranslations.ru.analytics,
                     profile: profileTranslations.ru.profile,
                     metaverse: metaverseTranslations.ru.metaverse,
+                    resources: resourcesTranslations.ru.resources,
                     entities: entitiesTranslations.ru.entities
                 }
             },
@@ -172,6 +175,7 @@ i18n.use(LanguageDetector)
                 'metaverse',
                 'templateMmoomm',
                 'templateQuiz',
+                'resources',
                 'entities'
             ],
             defaultNS: 'translation',

--- a/packages/ui/src/layout/MainLayout/Sidebar/MenuList/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Sidebar/MenuList/index.jsx
@@ -3,8 +3,8 @@ import { useLocation } from 'react-router-dom'
 import NavGroup from './NavGroup'
 import dashboard from '@/menu-items/dashboard'
 import unikDashboard from '@apps/uniks-frt/base/src/menu-items/unikDashboard'
-import resourcesDashboard from '@apps/resources-frt/base/src/menu-items/resourcesDashboard'
-import entitiesDashboard from '@apps/entities-frt/base/src/menu-items/entitiesDashboard'
+import { resourcesDashboard } from '@universo/resources-frt'
+import { entitiesDashboard } from '@universo/entities-frt'
 
 const MenuList = () => {
     const location = useLocation()

--- a/packages/ui/src/routes/MainRoutes.jsx
+++ b/packages/ui/src/routes/MainRoutes.jsx
@@ -14,6 +14,10 @@ const PublicFlowView = Loadable(lazy(() => import('@apps/publish-frt/base/src/pa
 const Auth = Loadable(lazy(() => import('@/views/up-auth/Auth')))
 const UnikList = Loadable(lazy(() => import('@apps/uniks-frt/base/src/pages/UnikList.jsx')))
 const MetaverseList = Loadable(lazy(() => import('@apps/metaverse-frt/base/src/pages/MetaverseList.jsx')))
+const ResourceList = Loadable(lazy(() => import('@universo/resources-frt').then((m) => ({ default: m.ResourceList }))))
+const ResourceDetail = Loadable(lazy(() => import('@universo/resources-frt').then((m) => ({ default: m.ResourceDetail }))))
+const EntityList = Loadable(lazy(() => import('@universo/entities-frt').then((m) => ({ default: m.EntityList }))))
+const EntityDetail = Loadable(lazy(() => import('@universo/entities-frt').then((m) => ({ default: m.EntityDetail }))))
 
 // Workspace dashboard component
 const UnikDetail = Loadable(lazy(() => import('@apps/uniks-frt/base/src/pages/UnikDetail.jsx')))
@@ -197,6 +201,38 @@ const MainRoutes = {
             element: (
                 <AuthGuard>
                     <MetaverseList />
+                </AuthGuard>
+            )
+        },
+        {
+            path: '/resources',
+            element: (
+                <AuthGuard>
+                    <ResourceList />
+                </AuthGuard>
+            )
+        },
+        {
+            path: '/resources/:resourceId',
+            element: (
+                <AuthGuard>
+                    <ResourceDetail />
+                </AuthGuard>
+            )
+        },
+        {
+            path: '/entities',
+            element: (
+                <AuthGuard>
+                    <EntityList />
+                </AuthGuard>
+            )
+        },
+        {
+            path: '/entities/:entityId',
+            element: (
+                <AuthGuard>
+                    <EntityDetail />
                 </AuthGuard>
             )
         },


### PR DESCRIPTION
Fixes #322 Integrate resources and entities modules into UI.

# Description

Adds resources and entities modules to the UI, wiring routes, sidebar dashboards, and i18n.

## Changes Made

- Depend on @universo/resources-frt and @universo/entities-frt in UI package
- Add ResourceList/Detail and EntityList/Detail routes guarded by AuthGuard
- Load resources and entities dashboards from workspace packages
- Merge resources and entities translations into i18n

## Additional Work

- Built workspace packages for resources and entities
- Updated sidebar menu logic for nested resource and entity routes

## Testing

- [ ] Manual testing completed
- [ ] Automated tests pass
- [ ] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #322 Integrate resources and entities modules into UI.

# Описание

Добавляет в интерфейс модули ресурсов и сущностей, связывая маршруты, боковые панели и i18n.

## Внесенные изменения

- Добавлена зависимость от @universo/resources-frt и @universo/entities-frt в пакете UI
- Добавлены маршруты ResourceList/Detail и EntityList/Detail, защищенные AuthGuard
- Подключены дашборды ресурсов и сущностей из рабочих пакетов в боковое меню
- Объединены переводы ресурсов и сущностей в i18n

## Дополнительная работа

- Собраны рабочие пакеты ресурсов и сущностей
- Обновлена логика бокового меню для вложенных маршрутов ресурсов и сущностей

## Тестирование

- [ ] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [ ] Не внесено критических изменений
</details>