### PR TITLE
GH324 Enable dual CJS/ESM builds for resources and entities frontends

### DIFF
--- a/apps/entities-frt/base/package.json
+++ b/apps/entities-frt/base/package.json
@@ -3,14 +3,19 @@
   "version": "0.1.0",
   "description": "Frontend module for Entities management",
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist",
-    "build": "pnpm run clean && tsc && gulp",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json && gulp",
     "dev": "tsc -w",
     "lint": "eslint --ext .ts,.tsx src/"
   },
-  "keywords": ["universo", "entities", "frontend"],
+  "keywords": [
+    "universo",
+    "entities",
+    "frontend"
+  ],
   "author": "Vladimir Levadnij and Teknokomo",
   "license": "Omsk Open License",
   "dependencies": {

--- a/apps/entities-frt/base/tsconfig.esm.json
+++ b/apps/entities-frt/base/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm",
+    "declaration": false,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/apps/resources-frt/base/package.json
+++ b/apps/resources-frt/base/package.json
@@ -3,14 +3,19 @@
     "version": "0.1.0",
     "description": "Frontend module for Resources management",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
         "clean": "rimraf dist",
-        "build": "pnpm run clean && tsc && gulp",
+        "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json && gulp",
         "dev": "tsc -w",
         "lint": "eslint --ext .ts,.tsx,.jsx src/"
     },
-    "keywords": ["universo", "resources", "frontend"],
+    "keywords": [
+        "universo",
+        "resources",
+        "frontend"
+    ],
     "author": "Vladimir Levadnij and Teknokomo",
     "license": "Omsk Open License",
     "dependencies": {

--- a/apps/resources-frt/base/tsconfig.esm.json
+++ b/apps/resources-frt/base/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm",
+    "declaration": false,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
Fixes #324 Enable dual CJS/ESM builds for resources and entities frontends.

# Description

Adds ES Module build configuration to @universo/resources-frt and @universo/entities-frt packages, enabling dual CommonJS/ESM output.

## Changes Made

- Added tsconfig.esm.json with ESNext configuration for resources and entities front-ends
- Updated package.json for both packages with module entry and dual build script
- Compiled packages via pnpm --filter build to verify CJS and ESM outputs

## Additional Work

- Configuration updates: new tsconfig.esm.json files for resources-frt and entities-frt

## Testing

- [x] Manual testing completed
- [ ] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #324 Enable dual CJS/ESM builds for resources and entities frontends.

# Описание

Добавлены конфигурации сборки ES Module в пакеты @universo/resources-frt и @universo/entities-frt, что позволяет получать одновременно CommonJS и ES Module.

## Внесенные изменения

- Добавлены файлы tsconfig.esm.json с настройками ESNext для фронтендов ресурсов и сущностей
- Обновлены package.json обоих пакетов, добавлены module и обновлён скрипт сборки
- Выполнена сборка пакетов через pnpm --filter build для проверки вывода CJS и ESM

## Дополнительная работа

- Обновление конфигурации: новые файлы tsconfig.esm.json для resources-frt и entities-frt

## Тестирование

- [x] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>