### PR TITLE
GH0 Use @universo/template-quiz package in flowise-ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -69,7 +69,8 @@
         "@universo/space-builder-frt": "workspace:*",
         "@universo/metaverse-frt": "workspace:*",
         "@universo/resources-frt": "workspace:*",
-        "@universo/entities-frt": "workspace:*"
+        "@universo/entities-frt": "workspace:*",
+        "@universo/template-quiz": "workspace:*"
     },
     "scripts": {
         "dev": "vite",

--- a/packages/ui/src/i18n/index.js
+++ b/packages/ui/src/i18n/index.js
@@ -10,7 +10,6 @@ import ruTranslation from './locales/ru.json'
 import enAuthTranslation from './locales/en/views/auth.json'
 import ruAuthTranslation from './locales/ru/views/auth.json'
 
-
 // Universo Platformo | Import admin namespaces
 import enAdminTranslation from './locales/en/views/admin.json'
 import ruAdminTranslation from './locales/ru/views/admin.json'
@@ -78,7 +77,7 @@ import { metaverseTranslations } from '@apps/metaverse-frt/base/src/i18n'
 import { resourcesTranslations } from '@universo/resources-frt'
 import { entitiesTranslations } from '@universo/entities-frt'
 import { templateMmoommTranslations } from '@apps/template-mmoomm/base/src/i18n'
-import { templateQuizTranslations } from '@apps/template-quiz/base/src/i18n'
+import { templateQuizTranslations } from '@universo/template-quiz'
 
 // Universo Platformo | i18next initialization with namespaces support
 i18n.use(LanguageDetector)


### PR DESCRIPTION
Fixes #0

# Description

Replace legacy template-quiz references with the published package.

## Changes Made

- Add `@universo/template-quiz` workspace dependency to `flowise-ui`
- Import quiz translations from `@universo/template-quiz`

## Additional Work

- Ran `pnpm install`
- Attempted to build `flowise-ui`
- Linted modified files

## Testing

- [ ] Manual testing completed
- [ ] Automated tests pass
- [ ] No breaking changes introduced
- Attempted `pnpm --filter flowise-ui build` (fails: Failed to resolve entry for package `@universo/template-quiz`)

<details>
<summary>In Russian</summary>

Исправляет #0

# Описание

Заменены устаревшие ссылки на шаблон quiz на опубликованный пакет.

## Внесенные изменения

- Добавлена зависимость `@universo/template-quiz` в `flowise-ui`
- Импорт переводов квиза из `@universo/template-quiz`

## Дополнительная работа

- Выполнен `pnpm install`
- Попытка сборки `flowise-ui`
- Проведен линтинг измененных файлов

## Тестирование

- [ ] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [ ] Не внесено критических изменений
- Попытка `pnpm --filter flowise-ui build` (ошибка: Failed to resolve entry for package `@universo/template-quiz`)
</details>

------
https://chatgpt.com/codex/tasks/task_e_68b5ae3ca0b0832389aaf9e75bae2e75