### PR TITLE
GH330 Refactor resource routes to use per-request repositories

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -79,6 +79,7 @@
         "@universo/multiplayer-colyseus-srv": "workspace:*",
         "@universo/profile-srv": "workspace:*",
         "@universo/publish-srv": "workspace:*",
+        "@universo/resources-srv": "workspace:*",
         "@universo/space-builder-srv": "workspace:*",
         "@universo/entities-srv": "workspace:*",
         "@universo/uniks-srv": "workspace:*",


### PR DESCRIPTION
Fixes #330 Ensure per-request repository retrieval in resources service.

# Description
Refactors resource routes to initialize repositories per request and updates server dependencies.

## Changes Made
- Retrieve TypeORM repositories inside each route handler
- Add helper function `getRepositories` for resource routes
- Add workspace dependency `@universo/resources-srv` to server package

## Additional Work
- Dependency update in server package

## Testing
- [ ] Manual testing completed
- [ ] Automated tests pass
- [ ] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #330 Ensure per-request repository retrieval in resources service.

# Описание
Рефакторинг маршрутов ресурсов: инициализация репозиториев при каждом запросе и обновление зависимостей сервера.

## Внесенные изменения
- Получение репозиториев TypeORM внутри каждого обработчика
- Добавлен вспомогательный метод `getRepositories` для маршрутов ресурсов
- Добавлена рабочая зависимость `@universo/resources-srv` в пакет сервера

## Дополнительная работа
- Обновление зависимостей в пакете сервера

## Тестирование
- [ ] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [ ] Не внесено критических изменений
</details>