### PR TITLE
fix(resources-frt): default ResourceConfigTree props

### DIFF
--- a/apps/resources-frt/base/src/components/ResourceConfigTree.tsx
+++ b/apps/resources-frt/base/src/components/ResourceConfigTree.tsx
@@ -10,8 +10,8 @@ export interface ResourceNode {
 }
 
 interface ResourceConfigTreeProps {
-    nodes: ResourceNode[]
-    onChange: (nodes: ResourceNode[]) => void
+    nodes?: ResourceNode[]
+    onChange?: (nodes: ResourceNode[]) => void
 }
 
 const createNode = (): ResourceNode => ({ key: uuidv4(), resourceId: '', children: [] })
@@ -31,7 +31,7 @@ const removeNode = (list: ResourceNode[], key: string): ResourceNode[] =>
 const updateNodeId = (list: ResourceNode[], key: string, value: string): ResourceNode[] =>
     list.map((n) => (n.key === key ? { ...n, resourceId: value } : { ...n, children: updateNodeId(n.children, key, value) }))
 
-const ResourceConfigTree: React.FC<ResourceConfigTreeProps> = ({ nodes, onChange }) => {
+const ResourceConfigTree: React.FC<ResourceConfigTreeProps> = ({ nodes = [], onChange = () => {} }) => {
     const { t } = useTranslation('resources')
 
     const renderNodes = (list: ResourceNode[]) =>


### PR DESCRIPTION
## Summary
- allow using `ResourceConfigTree` without passing `nodes` and `onChange`
- default to empty list and no-op handler to keep existing callers compiling

## Testing
- `pnpm --filter @universo/resources-frt lint`
- `pnpm --filter @universo/resources-frt build`
- `pnpm --filter @universo/entities-frt build`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe08b1c48323b3e9fddaf3aed277