### PR TITLE
GH338 Refactor resource API hooks and types

### DIFF
--- a/apps/resources-frt/base/src/pages/ResourceList.tsx
+++ b/apps/resources-frt/base/src/pages/ResourceList.tsx
@@ -5,21 +5,7 @@ import TreeItem from '@mui/lab/TreeItem'
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { listCategories, listResources } from '../api/resources'
-
-interface Category {
-    id: string
-    titleEn: string
-    titleRu: string
-    parentCategory?: { id: string }
-    children?: Category[]
-}
-
-interface Resource {
-    id: string
-    titleEn: string
-    titleRu: string
-    category?: { id: string }
-}
+import { Category, Resource, UseApi } from '../types'
 
 const buildTree = (cats: Category[]): Category[] => {
     const map: Record<string, Category> = {}
@@ -40,20 +26,23 @@ const ResourceList: React.FC = () => {
     const [selected, setSelected] = useState<string | null>(null)
     const [categories, setCategories] = useState<Category[]>([])
     const [resources, setResources] = useState<Resource[]>([])
-    const categoriesApi = useApi(listCategories)
-    const resourcesApi = useApi(listResources)
+    const useTypedApi = useApi as UseApi
+    const categoriesApi = useTypedApi<Category[]>(listCategories)
+    const resourcesApi = useTypedApi<Resource[]>(listResources)
 
     useEffect(() => {
         categoriesApi.request()
         resourcesApi.request()
-    }, [categoriesApi, resourcesApi])
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     useEffect(() => {
-        if (categoriesApi.data) setCategories(buildTree(categoriesApi.data as any))
+        if (categoriesApi.data) setCategories(buildTree(categoriesApi.data))
     }, [categoriesApi.data])
 
     useEffect(() => {
-        if (resourcesApi.data) setResources(resourcesApi.data as any)
+        if (resourcesApi.data) setResources(resourcesApi.data)
     }, [resourcesApi.data])
 
     const getName = (obj: { titleEn: string; titleRu: string }) => (i18n.language === 'ru' ? obj.titleRu : obj.titleEn)

--- a/apps/resources-frt/base/src/types.ts
+++ b/apps/resources-frt/base/src/types.ts
@@ -1,0 +1,33 @@
+export interface Category {
+    id: string
+    titleEn: string
+    titleRu: string
+    parentCategory?: { id: string }
+    children?: Category[]
+}
+
+export interface Resource {
+    id: string
+    titleEn: string
+    titleRu: string
+    category?: { id: string }
+}
+
+export interface Revision {
+    id: string
+    version: string
+}
+
+export interface TreeNode {
+    resource: Resource
+    children?: { child: TreeNode }[]
+}
+
+export type UseApi = <T>(
+    apiFunc: (...args: any[]) => Promise<{ data: T }>
+) => {
+    data: T | null
+    error: any
+    loading: boolean
+    request: (...args: any[]) => Promise<void>
+}


### PR DESCRIPTION
Fixes #338 Refactor resource pages to use typed interfaces.

# Description

Streamlines resource pages to request data once on mount and adds shared interfaces for type safety.

## Changes Made

- Fetch categories and resources only once by removing API hooks from dependency arrays
- Request resource details, revisions and tree a single time during mount
- Introduce `Category`, `Resource`, `Revision`, `TreeNode` interfaces and typed `useApi` calls
- Replace `any` casts with typed structures

## Additional Work

- none

## Testing

- [x] `pnpm --filter @universo/resources-frt lint`
- [x] `pnpm --filter @universo/resources-frt build`
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #338 Refactor resource pages to use typed interfaces.

# Описание

Оптимизированы страницы ресурсов: запросы выполняются один раз при монтировании и добавлены общие интерфейсы для типобезопасности.

## Внесенные изменения

- Удалены зависимости в эффектах, получающие категории и ресурсы, запросы выполняются только при монтировании
- Запросы деталей ресурса, ревизий и дерева выполняются один раз при монтировании
- Введены интерфейсы `Category`, `Resource`, `Revision`, `TreeNode` и типизированные вызовы `useApi`
- Приведения типа `any` заменены на типизированные структуры

## Дополнительная работа

- отсутствует

## Тестирование

- [x] `pnpm --filter @universo/resources-frt lint`
- [x] `pnpm --filter @universo/resources-frt build`
- [x] Критических изменений не внесено
</details>