### PR TITLE
GH341 Enable declarations and dual build for resources frontend

### DIFF
--- a/apps/resources-frt/base/gulpfile.ts
+++ b/apps/resources-frt/base/gulpfile.ts
@@ -1,7 +1,10 @@
 import gulp from 'gulp'
 
 function copyStaticFiles() {
-    return gulp.src(['src/**/*.svg', 'src/**/*.png', 'src/**/*.jpg', 'src/**/*.json', 'src/**/*.css'], { base: 'src' }).pipe(gulp.dest('dist'))
+    return gulp
+        .src(['src/**/*.svg', 'src/**/*.png', 'src/**/*.jpg', 'src/**/*.json', 'src/**/*.css'], { base: 'src' })
+        .pipe(gulp.dest('dist'))
+        .pipe(gulp.dest('dist/esm'))
 }
 
 export default gulp.series(copyStaticFiles)

--- a/apps/resources-frt/base/package.json
+++ b/apps/resources-frt/base/package.json
@@ -7,7 +7,7 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "clean": "rimraf dist",
-        "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json && gulp",
+        "build": "pnpm run clean && tsc -p tsconfig.json && tsc -p tsconfig.esm.json && gulp",
         "dev": "tsc -w",
         "lint": "eslint --ext .ts,.tsx,.jsx src/"
     },
@@ -19,7 +19,11 @@
     "author": "Vladimir Levadnij and Teknokomo",
     "license": "Omsk Open License",
     "dependencies": {
+        "@mui/lab": "5.0.0-alpha.156",
+        "@mui/material": "5.15.0",
+        "@tabler/icons-react": "^3.30.0",
         "react": "^18.2.0",
+        "react-i18next": "^15.4.1",
         "typescript": "^5.4.5",
         "uuid": "^9.0.0"
     },

--- a/apps/resources-frt/base/src/api/resources.ts
+++ b/apps/resources-frt/base/src/api/resources.ts
@@ -1,8 +1,8 @@
 import client from 'flowise-ui/src/api/client'
 
-export const listCategories = (): Promise<any> => client.get('/resources/categories')
-export const listResources = (): Promise<any> => client.get('/resources')
-export const getResource = (id: string): Promise<any> => client.get(`/resources/${id}`)
-export const listRevisions = (id: string): Promise<any> => client.get(`/resources/${id}/revisions`)
-export const getResourceTree = (id: string): Promise<any> => client.get(`/resources/${id}/tree`)
-export const createResource = (data: any): Promise<any> => client.post('/resources', data)
+export const listCategories = (): Promise<{ data: import('../types').Category[] }> => client.get('/resources/categories')
+export const listResources = (): Promise<{ data: import('../types').Resource[] }> => client.get('/resources')
+export const getResource = (id: string): Promise<{ data: import('../types').Resource }> => client.get(`/resources/${id}`)
+export const listRevisions = (id: string): Promise<{ data: import('../types').Revision[] }> => client.get(`/resources/${id}/revisions`)
+export const getResourceTree = (id: string): Promise<{ data: import('../types').TreeNode }> => client.get(`/resources/${id}/tree`)
+export const createResource = (data: any): Promise<{ data: import('../types').Resource }> => client.post('/resources', data)

--- a/apps/resources-frt/base/src/api/resources.ts
+++ b/apps/resources-frt/base/src/api/resources.ts
@@ -1,8 +1,8 @@
 import client from 'flowise-ui/src/api/client'
 
-export const listCategories = () => client.get('/resources/categories')
-export const listResources = () => client.get('/resources')
-export const getResource = (id: string) => client.get(`/resources/${id}`)
-export const listRevisions = (id: string) => client.get(`/resources/${id}/revisions`)
-export const getResourceTree = (id: string) => client.get(`/resources/${id}/tree`)
-export const createResource = (data: any) => client.post('/resources', data)
+export const listCategories = (): Promise<any> => client.get('/resources/categories')
+export const listResources = (): Promise<any> => client.get('/resources')
+export const getResource = (id: string): Promise<any> => client.get(`/resources/${id}`)
+export const listRevisions = (id: string): Promise<any> => client.get(`/resources/${id}/revisions`)
+export const getResourceTree = (id: string): Promise<any> => client.get(`/resources/${id}/tree`)
+export const createResource = (data: any): Promise<any> => client.post('/resources', data)

--- a/apps/resources-frt/base/tsconfig.esm.json
+++ b/apps/resources-frt/base/tsconfig.esm.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "outDir": "./dist/esm",
-    "declaration": false,
+    "declaration": true,
     "moduleResolution": "Bundler",
     "jsx": "react-jsx"
   },

--- a/apps/resources-frt/base/tsconfig.json
+++ b/apps/resources-frt/base/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "ES2020",
         "module": "commonjs",
         "lib": ["ES2020", "DOM"],
-        "declaration": false,
+        "declaration": true,
         "sourceMap": true,
         "outDir": "./dist",
         "strict": true,


### PR DESCRIPTION
Fixes #341 Enable declarations and dual build for resources frontend.

# Description

Adds TypeScript declaration generation and dual build output for the resources frontend package.

## Changes Made

- enable `declaration` in `tsconfig.json` and `tsconfig.esm.json`
- update `build` script to clean and compile both module formats before running gulp
- copy static assets to both `dist/` and `dist/esm/`
- include runtime dependencies `@mui/material`, `@mui/lab`, `@tabler/icons-react`, `react-i18next`
- add explicit return types to API utilities

## Additional Work

- none

## Testing

- [x] Manual testing completed
- [ ] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #341 Enable declarations and dual build for resources frontend.

# Описание

Добавлена генерация деклараций TypeScript и двойной вывод сборки для пакета фронтенда ресурсов.

## Внесенные изменения
- включён `declaration` в `tsconfig.json` и `tsconfig.esm.json`
- обновлён скрипт `build`, чтобы очищать и компилировать оба формата модулей перед запуском gulp
- копирование статических файлов в `dist/` и `dist/esm/`
- добавлены рантайм-зависимости `@mui/material`, `@mui/lab`, `@tabler/icons-react`, `react-i18next`
- добавлены явные возвращаемые типы для утилит API

## Дополнительная работа
- нет

## Тестирование
- [x] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>