### PR TITLE
GH347 Sync entity fields with backend

### DIFF
--- a/apps/entities-frt/base/src/api/entities.ts
+++ b/apps/entities-frt/base/src/api/entities.ts
@@ -6,3 +6,4 @@ export const createEntity = (body: any) => client.post('/entities', body)
 
 export const listTemplates = () => client.get('/entities/templates')
 export const createTemplate = (body: any) => client.post('/entities/templates', body)
+export const listStatuses = () => client.get('/entities/statuses')

--- a/apps/entities-frt/base/src/pages/EntityDetail.tsx
+++ b/apps/entities-frt/base/src/pages/EntityDetail.tsx
@@ -8,14 +8,14 @@ import { getEntity } from '../api/entities'
 
 const EntityDetail: React.FC = () => {
     const { t } = useTranslation('entities')
-    const { id } = useParams<{ id: string }>()
+    const { entityId } = useParams<{ entityId: string }>()
     const [tab, setTab] = useState(0)
     const [entity, setEntity] = useState<any>(null)
     const entityApi = useApi(getEntity)
 
     useEffect(() => {
-        if (id) entityApi.request(id)
-    }, [id, entityApi])
+        if (entityId) entityApi.request(entityId)
+    }, [entityId]) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         if (entityApi.data) setEntity(entityApi.data)
@@ -31,7 +31,7 @@ const EntityDetail: React.FC = () => {
                 <Tab label={t('detail.owners')} />
                 <Tab label={t('detail.resources')} />
             </Tabs>
-            {tab === 0 && <Typography variant='body1'>{entity?.name}</Typography>}
+            {tab === 0 && <Typography variant='body1'>{entity?.titleEn}</Typography>}
             {tab === 1 && <Typography variant='body1'>{(entity?.owners || []).join(', ')}</Typography>}
             {tab === 2 && <ResourceConfigTree />}
         </Box>

--- a/apps/entities-frt/base/src/pages/EntityDialog.tsx
+++ b/apps/entities-frt/base/src/pages/EntityDialog.tsx
@@ -3,7 +3,7 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, M
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { ResourceConfigTree } from '@universo/resources-frt'
-import { createEntity, listTemplates } from '../api/entities'
+import { createEntity, listTemplates, listStatuses } from '../api/entities'
 
 interface EntityDialogProps {
     open: boolean
@@ -12,22 +12,33 @@ interface EntityDialogProps {
 
 const EntityDialog: React.FC<EntityDialogProps> = ({ open, onClose }) => {
     const { t } = useTranslation('entities')
-    const [name, setName] = useState('')
-    const [template, setTemplate] = useState('')
-    const [templates, setTemplates] = useState<string[]>([])
+    const [titleEn, setTitleEn] = useState('')
+    const [titleRu, setTitleRu] = useState('')
+    const [templateId, setTemplateId] = useState('')
+    const [statusId, setStatusId] = useState('')
+    const [templates, setTemplates] = useState<any[]>([])
+    const [statuses, setStatuses] = useState<any[]>([])
     const createApi = useApi(createEntity)
     const templatesApi = useApi(listTemplates)
+    const statusesApi = useApi(listStatuses)
 
     useEffect(() => {
-        if (open) templatesApi.request()
-    }, [open, templatesApi])
+        if (open) {
+            templatesApi.request()
+            statusesApi.request()
+        }
+    }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        if (templatesApi.data) setTemplates((templatesApi.data as any).map((t: any) => t.name))
+        if (templatesApi.data) setTemplates(templatesApi.data as any)
     }, [templatesApi.data])
 
+    useEffect(() => {
+        if (statusesApi.data) setStatuses(statusesApi.data as any)
+    }, [statusesApi.data])
+
     const handleSave = async () => {
-        await createApi.request({ name, template })
+        await createApi.request({ titleEn, titleRu, templateId, statusId })
         if (!createApi.error) onClose()
     }
 
@@ -35,11 +46,19 @@ const EntityDialog: React.FC<EntityDialogProps> = ({ open, onClose }) => {
         <Dialog open={open} onClose={onClose} fullWidth maxWidth='md'>
             <DialogTitle>{t('dialog.title')}</DialogTitle>
             <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField label={t('dialog.name')} value={name} onChange={(e) => setName(e.target.value)} fullWidth />
-                <TextField select label={t('dialog.template')} value={template} onChange={(e) => setTemplate(e.target.value)}>
-                    {templates.map((tName) => (
-                        <MenuItem key={tName} value={tName}>
-                            {tName}
+                <TextField label={t('dialog.titleEn')} value={titleEn} onChange={(e) => setTitleEn(e.target.value)} fullWidth />
+                <TextField label={t('dialog.titleRu')} value={titleRu} onChange={(e) => setTitleRu(e.target.value)} fullWidth />
+                <TextField select label={t('dialog.template')} value={templateId} onChange={(e) => setTemplateId(e.target.value)}>
+                    {templates.map((t) => (
+                        <MenuItem key={t.id} value={t.id}>
+                            {t.name}
+                        </MenuItem>
+                    ))}
+                </TextField>
+                <TextField select label={t('dialog.status')} value={statusId} onChange={(e) => setStatusId(e.target.value)}>
+                    {statuses.map((s) => (
+                        <MenuItem key={s.id} value={s.id}>
+                            {s.name}
                         </MenuItem>
                     ))}
                 </TextField>

--- a/apps/entities-frt/base/src/pages/EntityList.tsx
+++ b/apps/entities-frt/base/src/pages/EntityList.tsx
@@ -2,45 +2,54 @@ import React, { useState, useEffect } from 'react'
 import { Box, Paper, Table, TableBody, TableCell, TableHead, TableRow, TextField, MenuItem, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
-import { listEntities, listTemplates } from '../api/entities'
+import { listEntities, listTemplates, listStatuses } from '../api/entities'
 
 interface Entity {
     id: string
-    name: string
-    template: string
-    status: string
+    titleEn: string
+    titleRu: string
+    templateId: string
+    statusId: string
 }
-
-const statuses = ['Active', 'Archived']
 
 const EntityList: React.FC = () => {
     const { t } = useTranslation('entities')
     const [search, setSearch] = useState('')
-    const [template, setTemplate] = useState('')
-    const [status, setStatus] = useState('')
+    const [templateId, setTemplateId] = useState('')
+    const [statusId, setStatusId] = useState('')
     const [entities, setEntities] = useState<Entity[]>([])
-    const [templates, setTemplates] = useState<string[]>([])
+    const [templates, setTemplates] = useState<any[]>([])
+    const [statuses, setStatuses] = useState<any[]>([])
 
     const entitiesApi = useApi(listEntities)
     const templatesApi = useApi(listTemplates)
+    const statusesApi = useApi(listStatuses)
 
     useEffect(() => {
         entitiesApi.request()
         templatesApi.request()
-    }, [entitiesApi, templatesApi])
+        statusesApi.request()
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         if (entitiesApi.data) setEntities(entitiesApi.data)
     }, [entitiesApi.data])
 
     useEffect(() => {
-        if (templatesApi.data) setTemplates((templatesApi.data as any).map((t: any) => t.name))
+        if (templatesApi.data) setTemplates(templatesApi.data as any)
     }, [templatesApi.data])
 
+    useEffect(() => {
+        if (statusesApi.data) setStatuses(statusesApi.data as any)
+    }, [statusesApi.data])
+
     const filtered = entities.filter((e) => {
-        const matchSearch = e.name.toLowerCase().includes(search.toLowerCase()) || e.id.includes(search)
-        const matchTemplate = template ? e.template === template : true
-        const matchStatus = status ? e.status === status : true
+        const matchSearch =
+            e.titleEn.toLowerCase().includes(search.toLowerCase()) ||
+            e.titleRu.toLowerCase().includes(search.toLowerCase()) ||
+            e.id.includes(search)
+        const matchTemplate = templateId ? e.templateId === templateId : true
+        const matchStatus = statusId ? e.statusId === statusId : true
         return matchSearch && matchTemplate && matchStatus
     })
 
@@ -51,19 +60,19 @@ const EntityList: React.FC = () => {
         <Box display='flex' flexDirection='column' gap={2}>
             <Box display='flex' gap={2}>
                 <TextField label={t('list.search')} value={search} onChange={(e) => setSearch(e.target.value)} />
-                <TextField select label={t('list.template')} value={template} onChange={(e) => setTemplate(e.target.value)}>
+                <TextField select label={t('list.template')} value={templateId} onChange={(e) => setTemplateId(e.target.value)}>
                     <MenuItem value=''>{t('list.all')}</MenuItem>
-                    {templates.map((tName) => (
-                        <MenuItem key={tName} value={tName}>
-                            {tName}
+                    {templates.map((t) => (
+                        <MenuItem key={t.id} value={t.id}>
+                            {t.name}
                         </MenuItem>
                     ))}
                 </TextField>
-                <TextField select label={t('list.status')} value={status} onChange={(e) => setStatus(e.target.value)}>
+                <TextField select label={t('list.status')} value={statusId} onChange={(e) => setStatusId(e.target.value)}>
                     <MenuItem value=''>{t('list.all')}</MenuItem>
                     {statuses.map((s) => (
-                        <MenuItem key={s} value={s}>
-                            {s}
+                        <MenuItem key={s.id} value={s.id}>
+                            {s.name}
                         </MenuItem>
                     ))}
                 </TextField>
@@ -82,9 +91,9 @@ const EntityList: React.FC = () => {
                         {filtered.map((e) => (
                             <TableRow key={e.id}>
                                 <TableCell>{e.id}</TableCell>
-                                <TableCell>{e.name}</TableCell>
-                                <TableCell>{e.template}</TableCell>
-                                <TableCell>{e.status}</TableCell>
+                                <TableCell>{e.titleEn}</TableCell>
+                                <TableCell>{templates.find((t) => t.id === e.templateId)?.name}</TableCell>
+                                <TableCell>{statuses.find((s) => s.id === e.statusId)?.name}</TableCell>
                             </TableRow>
                         ))}
                     </TableBody>


### PR DESCRIPTION
Fixes #347 Sync entity fields with backend.

# Description

Align entity pages with backend schema and dynamic metadata.

## Changes Made

- Read entityId from router params
- Replace name/template with titleEn/titleRu and templateId/statusId
- Load statuses and templates from API instead of hardcoded arrays
- Trigger entity and template fetching effects once without API object deps

## Additional Work

- None

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [ ] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #347 Sync entity fields with backend.

# Описание

Привели страницы сущностей в соответствие со схемой бэкенда и динамическими данными.

## Внесенные изменения

- Чтение entityId из параметров роутера
- Замена полей name/template на titleEn/titleRu и templateId/statusId
- Загрузка статусов и шаблонов через API вместо жестко заданных массивов
- Хуки для загрузки данных теперь вызываются один раз без зависимостей от объектов API

## Дополнительная работа

- Нет

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [ ] Не внесено критических изменений
</details>