### PR TITLE
GH349 Update entities module build configuration

### DIFF
--- a/apps/entities-frt/base/gulpfile.ts
+++ b/apps/entities-frt/base/gulpfile.ts
@@ -4,6 +4,7 @@ function copyStaticFiles() {
   return gulp
     .src(['src/**/*.svg', 'src/**/*.png', 'src/**/*.jpg', 'src/**/*.json', 'src/**/*.css'], { base: 'src' })
     .pipe(gulp.dest('dist'))
+    .pipe(gulp.dest('dist/esm'))
 }
 
 export default gulp.series(copyStaticFiles)

--- a/apps/entities-frt/base/package.json
+++ b/apps/entities-frt/base/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist",
-    "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json && gulp",
+    "build": "pnpm run clean && tsc -p tsconfig.json && tsc -p tsconfig.esm.json && gulp",
     "dev": "tsc -w",
     "lint": "eslint --ext .ts,.tsx src/"
   },
@@ -19,10 +19,17 @@
   "author": "Vladimir Levadnij and Teknokomo",
   "license": "Omsk Open License",
   "dependencies": {
-    "react": "^18.2.0",
-    "typescript": "^5.4.5",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
+    "@mui/lab": "5.0.0-alpha.156",
+    "@mui/material": "5.15.0",
     "@universo/resources-frt": "workspace:*",
-    "flowise-ui": "workspace:*"
+    "flowise-ui": "workspace:*",
+    "i18next": "^24.2.2",
+    "react": "^18.2.0",
+    "react-i18next": "^15.4.1",
+    "react-router-dom": "~6.3.0",
+    "typescript": "^5.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.11.17",

--- a/apps/entities-frt/base/src/api/entities.ts
+++ b/apps/entities-frt/base/src/api/entities.ts
@@ -1,9 +1,9 @@
 import client from 'flowise-ui/src/api/client'
 
-export const listEntities = () => client.get('/entities')
-export const getEntity = (id: string) => client.get(`/entities/${id}`)
-export const createEntity = (body: any) => client.post('/entities', body)
+export const listEntities = (): Promise<any> => client.get('/entities')
+export const getEntity = (id: string): Promise<any> => client.get(`/entities/${id}`)
+export const createEntity = (body: any): Promise<any> => client.post('/entities', body)
 
-export const listTemplates = () => client.get('/entities/templates')
-export const createTemplate = (body: any) => client.post('/entities/templates', body)
-export const listStatuses = () => client.get('/entities/statuses')
+export const listTemplates = (): Promise<any> => client.get('/entities/templates')
+export const createTemplate = (body: any): Promise<any> => client.post('/entities/templates', body)
+export const listStatuses = (): Promise<any> => client.get('/entities/statuses')

--- a/apps/entities-frt/base/tsconfig.esm.json
+++ b/apps/entities-frt/base/tsconfig.esm.json
@@ -3,10 +3,17 @@
   "compilerOptions": {
     "module": "ESNext",
     "outDir": "./dist/esm",
-    "declaration": false,
+    "declaration": true,
     "moduleResolution": "Bundler",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }

--- a/apps/entities-frt/base/tsconfig.json
+++ b/apps/entities-frt/base/tsconfig.json
@@ -2,8 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020", "DOM"],
-    "declaration": false,
+    "lib": [
+      "ES2020",
+      "DOM"
+    ],
+    "declaration": true,
     "sourceMap": true,
     "outDir": "./dist",
     "strict": true,
@@ -15,11 +18,19 @@
     "allowJs": true,
     "baseUrl": ".",
     "paths": {
-      "*": ["*"],
-      "@apps/resources-frt/base/src/*": ["../resources-frt/base/src/*"]
+      "*": [
+        "*"
+      ]
     },
     "moduleResolution": "node"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
Fixes #349 Update Entities build configuration and dependencies.

# Description

Update build configuration for Entities frontend module to generate declarations and include required dependencies.

## Changes Made

- Enabled declaration files and removed unused resources alias in TypeScript configs
- Prepended clean step to build script and extended gulp to copy assets to ESM output
- Added MUI, i18n, router and Emotion dependencies; fixed API typings

## Additional Work

- Updated API return types for stable builds
- Built dependent resources package

## Testing

- [x] Manual testing completed
- [ ] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #349 Update Entities build configuration and dependencies.

# Описание

Обновлена конфигурация сборки фронтенд‑модуля Entities для генерации деклараций и подключения необходимых зависимостей.

## Внесенные изменения

- Включена генерация declaration‑файлов и удален неиспользуемый alias ресурсов в настройках TypeScript
- В команду сборки добавлен предварительный шаг очистки и расширен gulp для копирования ассетов в ESM‑директорию
- Добавлены зависимости MUI, i18n, router и Emotion; исправлены типы API

## Дополнительная работа

- Обновлены возвращаемые типы API для стабильной сборки
- Выполнена сборка зависимого пакета resources

## Тестирование

- [x] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>