### PR TITLE
GH999 Add typed entities and i18n hooks

### DIFF
--- a/apps/entities-frt/base/src/api/entities.ts
+++ b/apps/entities-frt/base/src/api/entities.ts
@@ -1,9 +1,10 @@
 import client from 'flowise-ui/src/api/client'
+import { Entity, Template, Status } from '../types'
 
-export const listEntities = (): Promise<any> => client.get('/entities')
-export const getEntity = (id: string): Promise<any> => client.get(`/entities/${id}`)
-export const createEntity = (body: any): Promise<any> => client.post('/entities', body)
+export const listEntities = (): Promise<{ data: Entity[] }> => client.get('/entities')
+export const getEntity = (id: string): Promise<{ data: Entity }> => client.get(`/entities/${id}`)
+export const createEntity = (body: Partial<Entity>): Promise<{ data: Entity }> => client.post('/entities', body)
 
-export const listTemplates = (): Promise<any> => client.get('/entities/templates')
-export const createTemplate = (body: any): Promise<any> => client.post('/entities/templates', body)
-export const listStatuses = (): Promise<any> => client.get('/entities/statuses')
+export const listTemplates = (): Promise<{ data: Template[] }> => client.get('/entities/templates')
+export const createTemplate = (body: Partial<Template>): Promise<{ data: Template }> => client.post('/entities/templates', body)
+export const listStatuses = (): Promise<{ data: Status[] }> => client.get('/entities/statuses')

--- a/apps/entities-frt/base/src/i18n/locales/en/entities.json
+++ b/apps/entities-frt/base/src/i18n/locales/en/entities.json
@@ -20,8 +20,10 @@
     },
     "dialog": {
       "title": "Entity",
-      "name": "Name",
+      "titleEn": "Title (EN)",
+      "titleRu": "Title (RU)",
       "template": "Template",
+      "status": "Status",
       "rootResource": "Root Resource",
       "owners": "Owners",
       "cancel": "Cancel",

--- a/apps/entities-frt/base/src/i18n/locales/ru/entities.json
+++ b/apps/entities-frt/base/src/i18n/locales/ru/entities.json
@@ -20,8 +20,10 @@
     },
     "dialog": {
       "title": "Сущность",
-      "name": "Название",
+      "titleEn": "Название (EN)",
+      "titleRu": "Название (RU)",
       "template": "Шаблон",
+      "status": "Статус",
       "rootResource": "Корневой ресурс",
       "owners": "Владельцы",
       "cancel": "Отмена",

--- a/apps/entities-frt/base/src/pages/EntityDetail.tsx
+++ b/apps/entities-frt/base/src/pages/EntityDetail.tsx
@@ -5,13 +5,15 @@ import { useParams } from 'react-router-dom'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { ResourceConfigTree } from '@universo/resources-frt'
 import { getEntity } from '../api/entities'
+import { Entity, UseApi } from '../types'
 
 const EntityDetail: React.FC = () => {
     const { t } = useTranslation('entities')
     const { entityId } = useParams<{ entityId: string }>()
     const [tab, setTab] = useState(0)
-    const [entity, setEntity] = useState<any>(null)
-    const entityApi = useApi(getEntity)
+    const [entity, setEntity] = useState<Entity | null>(null)
+    const useTypedApi = useApi as UseApi
+    const entityApi = useTypedApi<Entity>(getEntity)
 
     useEffect(() => {
         if (entityId) entityApi.request(entityId)

--- a/apps/entities-frt/base/src/pages/EntityDialog.tsx
+++ b/apps/entities-frt/base/src/pages/EntityDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { ResourceConfigTree } from '@universo/resources-frt'
 import { createEntity, listTemplates, listStatuses } from '../api/entities'
+import { Entity, Template, Status, UseApi } from '../types'
 
 interface EntityDialogProps {
     open: boolean
@@ -16,11 +17,12 @@ const EntityDialog: React.FC<EntityDialogProps> = ({ open, onClose }) => {
     const [titleRu, setTitleRu] = useState('')
     const [templateId, setTemplateId] = useState('')
     const [statusId, setStatusId] = useState('')
-    const [templates, setTemplates] = useState<any[]>([])
-    const [statuses, setStatuses] = useState<any[]>([])
-    const createApi = useApi(createEntity)
-    const templatesApi = useApi(listTemplates)
-    const statusesApi = useApi(listStatuses)
+    const [templates, setTemplates] = useState<Template[]>([])
+    const [statuses, setStatuses] = useState<Status[]>([])
+    const useTypedApi = useApi as UseApi
+    const createApi = useTypedApi<Entity>(createEntity)
+    const templatesApi = useTypedApi<Template[]>(listTemplates)
+    const statusesApi = useTypedApi<Status[]>(listStatuses)
 
     useEffect(() => {
         if (open) {
@@ -30,11 +32,11 @@ const EntityDialog: React.FC<EntityDialogProps> = ({ open, onClose }) => {
     }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        if (templatesApi.data) setTemplates(templatesApi.data as any)
+        if (templatesApi.data) setTemplates(templatesApi.data)
     }, [templatesApi.data])
 
     useEffect(() => {
-        if (statusesApi.data) setStatuses(statusesApi.data as any)
+        if (statusesApi.data) setStatuses(statusesApi.data)
     }, [statusesApi.data])
 
     const handleSave = async () => {
@@ -64,7 +66,7 @@ const EntityDialog: React.FC<EntityDialogProps> = ({ open, onClose }) => {
                 </TextField>
                 <ResourceConfigTree />
                 <TextField label={t('dialog.owners')} fullWidth />
-                {createApi.error && <Typography color='error'>{t('dialog.error')}</Typography>}
+                {Boolean(createApi.error) && <Typography color='error'>{t('dialog.error')}</Typography>}
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose}>{t('dialog.cancel')}</Button>

--- a/apps/entities-frt/base/src/pages/EntityList.tsx
+++ b/apps/entities-frt/base/src/pages/EntityList.tsx
@@ -3,14 +3,7 @@ import { Box, Paper, Table, TableBody, TableCell, TableHead, TableRow, TextField
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { listEntities, listTemplates, listStatuses } from '../api/entities'
-
-interface Entity {
-    id: string
-    titleEn: string
-    titleRu: string
-    templateId: string
-    statusId: string
-}
+import { Entity, Template, Status, UseApi } from '../types'
 
 const EntityList: React.FC = () => {
     const { t } = useTranslation('entities')
@@ -18,12 +11,13 @@ const EntityList: React.FC = () => {
     const [templateId, setTemplateId] = useState('')
     const [statusId, setStatusId] = useState('')
     const [entities, setEntities] = useState<Entity[]>([])
-    const [templates, setTemplates] = useState<any[]>([])
-    const [statuses, setStatuses] = useState<any[]>([])
+    const [templates, setTemplates] = useState<Template[]>([])
+    const [statuses, setStatuses] = useState<Status[]>([])
 
-    const entitiesApi = useApi(listEntities)
-    const templatesApi = useApi(listTemplates)
-    const statusesApi = useApi(listStatuses)
+    const useTypedApi = useApi as UseApi
+    const entitiesApi = useTypedApi<Entity[]>(listEntities)
+    const templatesApi = useTypedApi<Template[]>(listTemplates)
+    const statusesApi = useTypedApi<Status[]>(listStatuses)
 
     useEffect(() => {
         entitiesApi.request()
@@ -36,11 +30,11 @@ const EntityList: React.FC = () => {
     }, [entitiesApi.data])
 
     useEffect(() => {
-        if (templatesApi.data) setTemplates(templatesApi.data as any)
+        if (templatesApi.data) setTemplates(templatesApi.data)
     }, [templatesApi.data])
 
     useEffect(() => {
-        if (statusesApi.data) setStatuses(statusesApi.data as any)
+        if (statusesApi.data) setStatuses(statusesApi.data)
     }, [statusesApi.data])
 
     const filtered = entities.filter((e) => {

--- a/apps/entities-frt/base/src/pages/TemplateDialog.tsx
+++ b/apps/entities-frt/base/src/pages/TemplateDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { ResourceConfigTree } from '@universo/resources-frt'
 import { createTemplate } from '../api/entities'
+import { Template, UseApi } from '../types'
 
 interface TemplateDialogProps {
     open: boolean
@@ -14,7 +15,8 @@ const TemplateDialog: React.FC<TemplateDialogProps> = ({ open, onClose }) => {
     const { t } = useTranslation('entities')
     const [name, setName] = useState('')
     const [description, setDescription] = useState('')
-    const createApi = useApi(createTemplate)
+    const useTypedApi = useApi as UseApi
+    const createApi = useTypedApi<Template>(createTemplate)
 
     const handleSave = async () => {
         await createApi.request({ name, description })
@@ -34,7 +36,7 @@ const TemplateDialog: React.FC<TemplateDialogProps> = ({ open, onClose }) => {
                     multiline
                 />
                 <ResourceConfigTree />
-                {createApi.error && <Typography color='error'>{t('templates.dialog.error')}</Typography>}
+                {Boolean(createApi.error) && <Typography color='error'>{t('templates.dialog.error')}</Typography>}
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose}>{t('templates.dialog.cancel')}</Button>

--- a/apps/entities-frt/base/src/pages/TemplateList.tsx
+++ b/apps/entities-frt/base/src/pages/TemplateList.tsx
@@ -3,16 +3,13 @@ import { Box, Paper, Table, TableBody, TableCell, TableHead, TableRow, Typograph
 import { useTranslation } from 'react-i18next'
 import useApi from 'flowise-ui/src/hooks/useApi'
 import { listTemplates } from '../api/entities'
-
-interface Template {
-    id: string
-    name: string
-}
+import { Template, UseApi } from '../types'
 
 const TemplateList: React.FC = () => {
     const { t } = useTranslation('entities')
     const [templates, setTemplates] = useState<Template[]>([])
-    const templatesApi = useApi(listTemplates)
+    const useTypedApi = useApi as UseApi
+    const templatesApi = useTypedApi<Template[]>(listTemplates)
 
     useEffect(() => {
         templatesApi.request()

--- a/apps/entities-frt/base/src/types.ts
+++ b/apps/entities-frt/base/src/types.ts
@@ -1,0 +1,32 @@
+export interface Owner {
+    id: string
+    userId: string
+    role: string
+    isPrimary: boolean
+}
+
+export interface Entity {
+    id: string
+    titleEn: string
+    titleRu: string
+    templateId: string
+    statusId: string
+    owners?: Owner[]
+}
+
+export interface Template {
+    id: string
+    name: string
+}
+
+export interface Status {
+    id: string
+    name: string
+}
+
+export type UseApi = <T>(apiFunc: (...args: any[]) => Promise<{ data: T }>) => {
+    data: T | null
+    error: unknown
+    loading: boolean
+    request: (...args: any[]) => Promise<void>
+}


### PR DESCRIPTION
Fixes #999

# Description

Introduce type-safe entity, template and owner interfaces and integrate generics for API hooks. Migrate remaining UI strings to locales and ensure stable keys.

## Changes Made

- Define Entity, Template, Status and Owner interfaces with shared UseApi helper.
- Type API methods and useApi calls across entity pages.
- Move dialog field labels into i18n files and reference them.
- Ensure lists use entity or template IDs as keys.

## Additional Work

- Build outputs for resources-frt and entities-frt to verify types.

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #999

# Описание

Добавлены типы сущностей, шаблонов и владельцев, применены дженерики для useApi, строки интерфейса вынесены в локали и использованы стабильные ключи.

## Внесенные изменения

- Определены интерфейсы Entity, Template, Status и Owner и общий помощник UseApi.
- Типизированы API-методы и вызовы useApi во всех страницах.
- Перенесены подписи диалогов в файлы i18n и подключены.
- Списки используют идентификаторы сущностей и шаблонов как ключи.

## Дополнительная работа

- Собраны пакеты resources-frt и entities-frt для проверки типов.

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>

------
https://chatgpt.com/codex/tasks/task_e_68b7579732c88323a4802004a8e4f400