### PR TITLE
GH353 Align entity detail API with entityId route param

### DIFF
--- a/apps/entities-frt/base/src/api/entities.ts
+++ b/apps/entities-frt/base/src/api/entities.ts
@@ -2,7 +2,7 @@ import client from 'flowise-ui/src/api/client'
 import { Entity, Template, Status } from '../types'
 
 export const listEntities = (): Promise<{ data: Entity[] }> => client.get('/entities')
-export const getEntity = (id: string): Promise<{ data: Entity }> => client.get(`/entities/${id}`)
+export const getEntity = (entityId: string): Promise<{ data: Entity }> => client.get(`/entities/${entityId}`)
 export const createEntity = (body: Partial<Entity>): Promise<{ data: Entity }> => client.post('/entities', body)
 
 export const listTemplates = (): Promise<{ data: Template[] }> => client.get('/entities/templates')

--- a/apps/entities-frt/base/src/types.ts
+++ b/apps/entities-frt/base/src/types.ts
@@ -24,7 +24,9 @@ export interface Status {
     name: string
 }
 
-export type UseApi = <T, TArgs extends any[]>(apiFunc: (...args: TArgs) => Promise<{ data: T }>) => {
+export type UseApi = <T, TArgs extends any[]>(
+    apiFunc: (...args: TArgs) => Promise<{ data: T }>
+) => {
     data: T | null
     error: unknown
     loading: boolean


### PR DESCRIPTION
Fixes #353 Align entity detail API with entityId route parameter.

# Description

Align entity detail API and type definitions with `entityId` naming.

## Changes Made

- Replace `id` argument with `entityId` in entity API helper.
- Format `UseApi` type definition for lint consistency.

## Additional Work

- Lint run for `@universo/entities-frt`.

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #353 Align entity detail API with entityId route parameter.

# Описание

Унифицировали использование имени `entityId` в API и типах.

## Внесенные изменения

- Заменили аргумент `id` на `entityId` во вспомогательной функции API.
- Отформатировали определение типа `UseApi` для соблюдения линтинга.

## Дополнительная работа

- Запущен линтер для `@universo/entities-frt`.

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [x] Не внесено критических изменений

</details>