### PR TITLE
GH359 Parallelize reference lookups in resource creation

### DIFF
--- a/apps/resources-srv/base/package.json
+++ b/apps/resources-srv/base/package.json
@@ -8,7 +8,8 @@
         "clean": "rimraf dist",
         "build": "pnpm run clean && tsc",
         "dev": "tsc -w",
-        "lint": "eslint --ext .ts src/"
+        "lint": "eslint --ext .ts src/",
+        "test": "node --test dist/**/*.test.js"
     },
     "keywords": [
         "universo",

--- a/apps/resources-srv/base/src/routes/__tests__/createResource.test.ts
+++ b/apps/resources-srv/base/src/routes/__tests__/createResource.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createResourcesRouter } from '../resourcesRoutes'
+import { ResourceCategory } from '../../database/entities/ResourceCategory'
+import { ResourceState } from '../../database/entities/ResourceState'
+import { StorageType } from '../../database/entities/StorageType'
+import { Resource } from '../../database/entities/Resource'
+import { ResourceRevision } from '../../database/entities/ResourceRevision'
+import { ResourceComposition } from '../../database/entities/ResourceComposition'
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const getHandler = (router: any) => {
+    const layer = router.stack.find((l: any) => l.route?.path === '/' && l.route?.methods?.post)
+    assert.ok(layer, 'POST / route not found')
+    return layer.route.stack[0].handle
+}
+
+test('creates resource with concurrent lookups', async () => {
+    const startTimes: Record<string, number> = {}
+    const makeRepo = (key: string) => ({
+        findOne: async () => {
+            startTimes[key] = Date.now()
+            await delay(50)
+            return {}
+        }
+    })
+
+    const categoryRepo = makeRepo('category')
+    const stateRepo = makeRepo('state')
+    const storageRepo = makeRepo('storage')
+    const resourceRepo = { create: () => ({}), save: async () => {} }
+    const revisionRepo = {}
+    const compositionRepo = {}
+
+    const dataSource: any = {
+        isInitialized: true,
+        getRepository: (entity: any) => {
+            if (entity === ResourceCategory) return categoryRepo
+            if (entity === ResourceState) return stateRepo
+            if (entity === StorageType) return storageRepo
+            if (entity === Resource) return resourceRepo
+            if (entity === ResourceRevision) return revisionRepo
+            if (entity === ResourceComposition) return compositionRepo
+            throw new Error('Unknown entity')
+        }
+    }
+
+    const router = createResourcesRouter((_req, _res, next) => next(), dataSource)
+    const handler = getHandler(router)
+
+    const req: any = { body: { categoryId: '1', stateId: '2', storageTypeId: '3' }, params: {} }
+    const res: any = {
+        statusCode: 0,
+        status(code: number) {
+            this.statusCode = code
+            return this
+        },
+        json() {}
+    }
+
+    await handler(req, res)
+
+    assert.equal(res.statusCode, 201)
+    const times = Object.values(startTimes) as number[]
+    const duration = Math.max(...times) - Math.min(...times)
+    assert.ok(duration < 50)
+})
+
+test('returns 400 when any reference missing', async () => {
+    const categoryRepo = { findOne: async () => null }
+    const stateRepo = { findOne: async () => ({}) }
+    const storageRepo = { findOne: async () => ({}) }
+    const resourceRepo = { create: () => ({}), save: async () => {} }
+    const revisionRepo = {}
+    const compositionRepo = {}
+
+    const dataSource: any = {
+        isInitialized: true,
+        getRepository: (entity: any) => {
+            if (entity === ResourceCategory) return categoryRepo
+            if (entity === ResourceState) return stateRepo
+            if (entity === StorageType) return storageRepo
+            if (entity === Resource) return resourceRepo
+            if (entity === ResourceRevision) return revisionRepo
+            if (entity === ResourceComposition) return compositionRepo
+            throw new Error('Unknown entity')
+        }
+    }
+
+    const router = createResourcesRouter((_req, _res, next) => next(), dataSource)
+    const handler = getHandler(router)
+
+    const req: any = { body: { categoryId: '1', stateId: '2', storageTypeId: '3' }, params: {} }
+    const res: any = {
+        statusCode: 0,
+        status(code: number) {
+            this.statusCode = code
+            return this
+        },
+        json() {}
+    }
+
+    await handler(req, res)
+    assert.equal(res.statusCode, 400)
+})

--- a/apps/resources-srv/base/src/routes/resourcesRoutes.ts
+++ b/apps/resources-srv/base/src/routes/resourcesRoutes.ts
@@ -132,9 +132,11 @@ export function createResourcesRouter(ensureAuth: RequestHandler, dataSource: Da
             }
             const { categoryRepo, stateRepo, storageRepo, resourceRepo } = getRepositories(dataSource)
             const { categoryId, stateId, storageTypeId, slug, titleEn, titleRu, descriptionEn, descriptionRu, metadata } = req.body
-            const category = await categoryRepo.findOne({ where: { id: categoryId } })
-            const state = await stateRepo.findOne({ where: { id: stateId } })
-            const storageType = await storageRepo.findOne({ where: { id: storageTypeId } })
+            const [category, state, storageType] = await Promise.all([
+                categoryRepo.findOne({ where: { id: categoryId } }),
+                stateRepo.findOne({ where: { id: stateId } }),
+                storageRepo.findOne({ where: { id: storageTypeId } })
+            ])
             if (!category || !state || !storageType) return res.status(400).json({ error: 'Invalid references' })
             const resource = resourceRepo.create({
                 category,


### PR DESCRIPTION
Fixes #359 Parallelize reference lookups in resource creation.

# Description
Replaces sequential repository lookups in `POST /resources` with a concurrent `Promise.all` and validates related entities.

## Changes Made
- Fetch category, state and storage type concurrently when creating a resource
- Return HTTP 400 if any referenced entity is missing
- Add regression tests covering parallel lookups and missing reference handling

## Additional Work
- Test additions

## Testing
- [ ] Manual testing completed
- [x] Automated tests pass
- [ ] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #359 Parallelize reference lookups in resource creation.

# Описание
Заменяет последовательные обращения к репозиториям в `POST /resources` на параллельный `Promise.all` и добавляет проверку связей.

## Внесенные изменения
- Параллельное получение категории, состояния и типа хранения при создании ресурса
- Возврат HTTP 400 при отсутствии любой связанной сущности
- Добавлены регрессионные тесты для параллельных запросов и обработки отсутствующих ссылок

## Дополнительная работа
- Добавлены тесты

## Тестирование
- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [ ] Не внесено критических изменений
</details>