### PR TITLE
GH000 follow-up: stabilize resource tree building and types

### DIFF
--- a/apps/resources-srv/base/src/routes/__tests__/composition.test.ts
+++ b/apps/resources-srv/base/src/routes/__tests__/composition.test.ts
@@ -1,32 +1,24 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { Router, Request, Response } from 'express'
+import { DataSource } from 'typeorm'
 import { createResourcesRouter } from '../resourcesRoutes'
 import { Resource } from '../../database/entities/Resource'
 import { ResourceComposition } from '../../database/entities/ResourceComposition'
 
-const getHandler = (router: any, method: string, path: string) => {
-    const layer = router.stack.find((l: any) => l.route?.path === path && l.route?.methods?.[method])
+const getHandler = (router: Router, method: string, path: string) => {
+    const layer = (router as any).stack.find((l: any) => l.route?.path === path && l.route?.methods?.[method])
     assert.ok(layer, `${method.toUpperCase()} ${path} route not found`)
     return layer.route.stack[0].handle
 }
 
 test('builds nested tree from single query', async () => {
     let calls = 0
-    const dataSource: any = {
+    const dataSource: Partial<DataSource> = {
         isInitialized: true,
         query: async () => {
             calls++
             return [
-                {
-                    resource_id: '1',
-                    resource: { id: '1' },
-                    comp_id: null,
-                    parent_resource_id: null,
-                    quantity: null,
-                    sort_order: null,
-                    is_required: null,
-                    config: null
-                },
                 {
                     resource_id: '2',
                     resource: { id: '2' },
@@ -36,6 +28,16 @@ test('builds nested tree from single query', async () => {
                     sort_order: 0,
                     is_required: false,
                     config: {}
+                },
+                {
+                    resource_id: '1',
+                    resource: { id: '1' },
+                    comp_id: null,
+                    parent_resource_id: null,
+                    quantity: null,
+                    sort_order: null,
+                    is_required: null,
+                    config: null
                 },
                 {
                     resource_id: '3',
@@ -50,21 +52,23 @@ test('builds nested tree from single query', async () => {
             ]
         }
     }
-    const router = createResourcesRouter((_req, _res, next) => next(), dataSource)
+    const router = createResourcesRouter((_req, _res, next) => next(), dataSource as DataSource)
     const handler = getHandler(router, 'get', '/:id/tree')
-    const req: any = { params: { id: '1' } }
-    let body: any
-    const res: any = {
-        json: (b: any) => {
+    const req: Partial<Request> = { params: { id: '1' } }
+    let body: unknown
+    const res: Partial<Response> = {
+        json: (b: unknown) => {
             body = b
+            return res as Response
         },
-        status: () => res
+        status: () => res as Response
     }
-    await handler(req, res)
+    await handler(req as Request, res as Response)
     assert.equal(calls, 1)
-    assert.equal(body.resource.id, '1')
-    assert.equal(body.children[0].child.resource.id, '2')
-    assert.equal(body.children[0].child.children[0].child.resource.id, '3')
+    const root = body as any
+    assert.equal(root.resource.id, '1')
+    assert.equal(root.children[0].child.resource.id, '2')
+    assert.equal(root.children[0].child.children[0].child.resource.id, '3')
 })
 
 test('prevents cycles when adding child', async () => {
@@ -76,30 +80,29 @@ test('prevents cycles when adding child', async () => {
             saved = true
         }
     }
-    const dataSource: any = {
+    const dataSource: Partial<DataSource> = {
         isInitialized: true,
-        getRepository: (entity: any) => {
+        getRepository: ((entity: any) => {
             if (entity === Resource) return resourceRepo
             if (entity === ResourceComposition) return compositionRepo
             return {}
-        },
+        }) as any,
         query: async () => [{ found: true }]
     }
-    const router = createResourcesRouter((_req, _res, next) => next(), dataSource)
+    const router = createResourcesRouter((_req, _res, next) => next(), dataSource as DataSource)
     const handler = getHandler(router, 'post', '/:id/children')
-    const req: any = { params: { id: '1' }, body: { childId: '2' } }
-    const res: any = {
-        statusCode: 0,
-        body: null,
+    const req: Partial<Request> = { params: { id: '1' }, body: { childId: '2' } }
+    const res: Partial<Response> & { statusCode?: number; body?: unknown } = {
         status(code: number) {
             this.statusCode = code
-            return this
+            return this as Response
         },
-        json(b: any) {
+        json(b: unknown) {
             this.body = b
+            return this as Response
         }
     }
-    await handler(req, res)
+    await handler(req as Request, res as Response)
     assert.equal(res.statusCode, 400)
     assert.deepEqual(res.body, { error: 'Cycle detected' })
     assert.equal(saved, false)


### PR DESCRIPTION
## Summary
- make cycle validation query use `SELECT EXISTS`
- build resource tree without relying on row order and keep camelCase
- tighten test mocks by replacing `any` with typed Partial objects

## Testing
- `pnpm --filter @universo/resources-srv lint`
- `pnpm --filter @universo/resources-srv build`
- `pnpm --filter @universo/resources-srv test`


------
https://chatgpt.com/codex/tasks/task_e_68b78a7bbba88323b0166d4651ccf0d0