### PR TITLE
GH0 Rename ResourceDetail param to resourceId

### DIFF
--- a/apps/resources-frt/base/src/pages/ResourceDetail.tsx
+++ b/apps/resources-frt/base/src/pages/ResourceDetail.tsx
@@ -10,7 +10,7 @@ import { Resource, Revision, TreeNode, UseApi } from '../types'
 
 const ResourceDetail: React.FC = () => {
     const { t, i18n } = useTranslation('resources')
-    const { id } = useParams<{ id: string }>()
+    const { resourceId } = useParams<{ resourceId: string }>()
     const [tab, setTab] = useState(0)
     const useTypedApi = useApi as UseApi
     const resourceApi = useTypedApi<Resource>(getResource)
@@ -18,14 +18,14 @@ const ResourceDetail: React.FC = () => {
     const treeApi = useTypedApi<TreeNode>(getResourceTree)
 
     useEffect(() => {
-        if (id) {
-            resourceApi.request(id)
-            revisionsApi.request(id)
-            treeApi.request(id)
+        if (resourceId) {
+            resourceApi.request(resourceId)
+            revisionsApi.request(resourceId)
+            treeApi.request(resourceId)
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [id])
+    }, [resourceId])
 
     const getName = (obj: { titleEn: string; titleRu: string }) => (i18n.language === 'ru' ? obj.titleRu : obj.titleEn)
 


### PR DESCRIPTION
Fixes #0

# Description

Renames the ResourceDetail route parameter from `id` to `resourceId` to match routing and ensure data loading.

## Changes Made

- Use `useParams<{ resourceId: string }>` in ResourceDetail and update API calls.
- Replace local `id` references with `resourceId`.

## Additional Work

- None.

## Testing

- [x] `pnpm --filter @universo/resources-frt lint`
- [x] `pnpm --filter @universo/resources-frt build`

<details>
<summary>In Russian</summary>

Исправляет #0

# Описание

Переименован параметр маршрута ResourceDetail с `id` на `resourceId`, чтобы соответствовать маршрутизации и обеспечить загрузку данных.

## Внесенные изменения

- Использован `useParams<{ resourceId: string }>` в ResourceDetail и обновлены вызовы API.
- Локальные ссылки `id` заменены на `resourceId`.

## Дополнительная работа

- Нет.

## Тестирование

- [x] `pnpm --filter @universo/resources-frt lint`
- [x] `pnpm --filter @universo/resources-frt build`
</details>

------
https://chatgpt.com/codex/tasks/task_e_68b79360a7488323992f4d1c69a6ab5c