### PR TITLE
Rename ResourceDetail param to resourceId

### DIFF
--- a/apps/resources-frt/base/src/pages/ResourceDetail.tsx
+++ b/apps/resources-frt/base/src/pages/ResourceDetail.tsx
@@ -13,19 +13,17 @@ const ResourceDetail: React.FC = () => {
     const { resourceId } = useParams<{ resourceId: string }>()
     const [tab, setTab] = useState(0)
     const useTypedApi = useApi as UseApi
-    const resourceApi = useTypedApi<Resource>(getResource)
-    const revisionsApi = useTypedApi<Revision[]>(listRevisions)
-    const treeApi = useTypedApi<TreeNode>(getResourceTree)
+    const { request: resourceRequest, ...resourceApi } = useTypedApi<Resource>(getResource)
+    const { request: revisionsRequest, ...revisionsApi } = useTypedApi<Revision[]>(listRevisions)
+    const { request: treeRequest, ...treeApi } = useTypedApi<TreeNode>(getResourceTree)
 
     useEffect(() => {
         if (resourceId) {
-            resourceApi.request(resourceId)
-            revisionsApi.request(resourceId)
-            treeApi.request(resourceId)
+            resourceRequest(resourceId)
+            revisionsRequest(resourceId)
+            treeRequest(resourceId)
         }
-
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [resourceId])
+    }, [resourceId, resourceRequest, revisionsRequest, treeRequest])
 
     const getName = (obj: { titleEn: string; titleRu: string }) => (i18n.language === 'ru' ? obj.titleRu : obj.titleEn)
 

--- a/packages/ui/src/hooks/useApi.jsx
+++ b/packages/ui/src/hooks/useApi.jsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 
 export default (apiFunc) => {
     const [data, setData] = useState(null)
     const [error, setError] = useState(null)
     const [loading, setLoading] = useState(false)
 
-    const request = async (...args) => {
+    const request = useCallback(async (...args) => {
         setLoading(true)
         try {
             const result = await apiFunc(...args)
@@ -15,7 +15,7 @@ export default (apiFunc) => {
         } finally {
             setLoading(false)
         }
-    }
+    }, [apiFunc])
 
     return {
         data,


### PR DESCRIPTION
## Summary
- rename `id` route param to `resourceId`
- memoize `useApi` requests and remove `exhaustive-deps` suppression

## Testing
- `pnpm --filter flowise-ui lint` *(fails: None of the selected packages has a "lint" script)*
- `pnpm --filter flowise-ui build` *(fails: Failed to resolve entry for package "@universo/resources-frt")*
- `pnpm --filter @universo/resources-frt lint`
- `pnpm --filter @universo/resources-frt build`


------
https://chatgpt.com/codex/tasks/task_e_68b796aab1888323bd4838b27b9c2b53