### PR TITLE
GH379 Bump TypeORM to 0.3.26 in server packages

### DIFF
--- a/apps/finance-srv/base/package.json
+++ b/apps/finance-srv/base/package.json
@@ -21,7 +21,7 @@
   "license": "Omsk Open License",
   "dependencies": {
     "express": "^4.18.2",
-    "typeorm": "^0.3.6",
+    "typeorm": "^0.3.26",
     "typescript": "^5.4.5",
     "@supabase/supabase-js": "^2.39.0",
     "@universo/uniks-srv": "workspace:*"

--- a/apps/metaverse-srv/base/package.json
+++ b/apps/metaverse-srv/base/package.json
@@ -21,7 +21,7 @@
     "license": "Omsk Open License",
     "dependencies": {
         "express": "^4.18.2",
-        "typeorm": "^0.3.6",
+        "typeorm": "^0.3.26",
         "typescript": "^5.4.5",
         "@supabase/supabase-js": "^2.39.0",
         "zod": "^3.24.4"

--- a/apps/profile-srv/base/package.json
+++ b/apps/profile-srv/base/package.json
@@ -21,7 +21,7 @@
     "license": "Omsk Open License",
     "dependencies": {
         "express": "^4.18.2",
-        "typeorm": "^0.3.6",
+        "typeorm": "^0.3.26",
         "typescript": "^5.4.5",
         "@supabase/supabase-js": "^2.39.0"
     },

--- a/apps/publish-srv/base/package.json
+++ b/apps/publish-srv/base/package.json
@@ -30,7 +30,7 @@
     "license": "Omsk Open License",
     "dependencies": {
         "express": "^4.18.2",
-        "typeorm": "^0.3.6",
+        "typeorm": "^0.3.26",
         "typescript": "^5.4.5",
         "@universo-platformo/utils": "workspace:*"
     },

--- a/apps/resources-srv/base/package.json
+++ b/apps/resources-srv/base/package.json
@@ -22,7 +22,7 @@
     "license": "Omsk Open License",
     "dependencies": {
         "express": "^4.18.2",
-        "typeorm": "^0.3.6"
+        "typeorm": "^0.3.26"
     },
     "devDependencies": {
         "@types/express": "^4.17.21",

--- a/apps/uniks-srv/base/package.json
+++ b/apps/uniks-srv/base/package.json
@@ -21,7 +21,7 @@
     "license": "Omsk Open License",
     "dependencies": {
         "express": "^4.18.2",
-        "typeorm": "^0.3.6",
+        "typeorm": "^0.3.26",
         "typescript": "^5.4.5",
         "@supabase/supabase-js": "^2.39.0"
     },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -120,7 +120,7 @@
         "s3-streamlogger": "^1.11.0",
         "sanitize-html": "^2.11.0",
         "sqlite3": "^5.1.6",
-        "typeorm": "^0.3.6",
+        "typeorm": "^0.3.26",
         "uuid": "^9.0.1",
         "winston": "^3.9.0"
     },


### PR DESCRIPTION
Fixes #379 Update TypeORM to 0.3.26 in server packages.

# Description

Updates TypeORM dependency to ^0.3.26 across server packages and core server package.

## Changes Made

- Bump TypeORM to ^0.3.26 in @universo/publish-srv, @universo/profile-srv, @universo/uniks-srv, @universo/finance-srv, @universo/metaverse-srv, @universo/resources-srv
- Bump TypeORM to ^0.3.26 in packages/server

## Additional Work

- Built workspace dependencies to verify compilation of server packages

## Testing

- [x] Manual testing completed
- [ ] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #379 Update TypeORM to 0.3.26 in server packages.

# Описание

Обновляет зависимость TypeORM до ^0.3.26 во всех серверных пакетах и основном серверном пакете.

## Внесенные изменения

- Обновлён TypeORM до ^0.3.26 в @universo/publish-srv, @universo/profile-srv, @universo/uniks-srv, @universo/finance-srv, @universo/metaverse-srv, @universo/resources-srv
- Обновлён TypeORM до ^0.3.26 в packages/server

## Дополнительная работа

- Сборка рабочих пакетов для проверки успешной компиляции серверных пакетов

## Тестирование

- [x] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [x] Не внесено критических изменений

</details>