### PR TITLE
GH0 Stabilize useApi hook and document usage

### DIFF
--- a/apps/analytics-frt/base/README.md
+++ b/apps/analytics-frt/base/README.md
@@ -4,3 +4,15 @@ Frontend module for displaying quiz analytics in Universo Platformo.
 
 This app exposes a single React component **AnalyticsPage** located in `src/pages/Analytics.jsx`.
 It is imported in the main Flowise frontend via the `@apps/analytics-frt` alias.
+
+## API Usage
+
+Use the shared `useApi` hook for data fetching. Include the returned `request` function in effect dependency arrays to keep requests to a single execution on mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```

--- a/apps/entities-frt/base/README.md
+++ b/apps/entities-frt/base/README.md
@@ -68,6 +68,18 @@ pnpm --filter @universo/entities-frt build
 pnpm --filter @universo/entities-frt lint
 ```
 
+### API Usage
+
+Server interactions use the shared `useApi` hook. Include the returned `request` function in effect dependency arrays so requests run only once when components mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```
+
 ## Related Documentation
 - [Entities Application Docs](../../../docs/en/applications/entities/README.md)
 - [Backend Service](../entities-srv/base/README.md)

--- a/apps/finance-frt/base/README.md
+++ b/apps/finance-frt/base/README.md
@@ -53,6 +53,18 @@ pnpm dev
 pnpm build --filter @universo/finance-frt
 ```
 
+### API Usage
+
+Server requests should use the shared `useApi` hook. Include the returned `request` function in effect dependency arrays to ensure calls run only once when components mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```
+
 ## Related Documentation
 
 - [Finance Backend Documentation](../finance-srv/base/README.md)

--- a/apps/metaverse-frt/base/README.md
+++ b/apps/metaverse-frt/base/README.md
@@ -47,3 +47,15 @@ The module registers its translation bundle (EN/RU) in the global i18n during UI
 -   Uses the shared authenticated API client; it forwards the Authorization header and refreshes on 401.
 -   No secrets are stored here; server-side RLS enforces access by membership and visibility.
 -   Future work: membership management (roles), default metaverse toggle, link editor (create/remove/visualize).
+
+## API Usage
+
+Use the shared `useApi` hook for backend requests. Add the returned `request` function to effect dependency arrays so calls execute only once when components mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```

--- a/apps/resources-frt/base/README.md
+++ b/apps/resources-frt/base/README.md
@@ -65,6 +65,18 @@ pnpm --filter @universo/resources-frt build
 pnpm --filter @universo/resources-frt lint
 ```
 
+### API Usage
+
+Use the shared `useApi` hook for server requests. Include the returned `request` function in effect dependency arrays to trigger calls once on mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```
+
 ## Related Documentation
 - [Resources Application Docs](../../../docs/en/applications/resources/README.md)
 - [Backend Service](../resources-srv/base/README.md)

--- a/apps/resources-frt/base/src/pages/__tests__/useApiOnce.test.tsx
+++ b/apps/resources-frt/base/src/pages/__tests__/useApiOnce.test.tsx
@@ -1,0 +1,25 @@
+import { render, waitFor } from '@testing-library/react'
+import React, { useEffect, useState } from 'react'
+import { vi, expect, test } from 'vitest'
+import useApi from 'flowise-ui/src/hooks/useApi'
+
+const apiFunc = vi.fn(async () => ({ data: null }))
+
+function TestComponent() {
+    const { request } = useApi(apiFunc)
+    const [_, setTick] = useState(0)
+    useEffect(() => {
+        request()
+    }, [request])
+    useEffect(() => {
+        setTick(1)
+    }, [])
+    return null
+}
+
+test('useApi request fires only once on mount', async () => {
+    render(<TestComponent />)
+    await waitFor(() => {
+        expect(apiFunc).toHaveBeenCalledTimes(1)
+    })
+})

--- a/apps/uniks-frt/base/README.md
+++ b/apps/uniks-frt/base/README.md
@@ -95,6 +95,18 @@ pnpm dev
 pnpm build --filter @universo/uniks-frt
 ```
 
+### API Usage
+
+Use the shared `useApi` hook for backend calls. Include the returned `request` function in effect dependency arrays so requests execute only once when components mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```
+
 ## Configuration
 
 The application uses the following configuration:

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -14,6 +14,18 @@ Install:
 npm i flowise-ui
 ```
 
+## useApi Hook
+
+When calling backend endpoints, use the `useApi` hook and include the returned `request` function in effect dependency arrays. The hook keeps the API function in a ref so that requests run only once on mount:
+
+```javascript
+const { request } = useApi(fetchList)
+
+useEffect(() => {
+    request()
+}, [request])
+```
+
 ## License
 
 Source code in this repository is made available under the [Apache License Version 2.0](https://github.com/FlowiseAI/Flowise/blob/master/LICENSE.md).

--- a/packages/ui/src/hooks/useApi.jsx
+++ b/packages/ui/src/hooks/useApi.jsx
@@ -1,21 +1,24 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 
 export default (apiFunc) => {
     const [data, setData] = useState(null)
     const [error, setError] = useState(null)
     const [loading, setLoading] = useState(false)
 
+    const apiRef = useRef(apiFunc)
+    apiRef.current = apiFunc
+
     const request = useCallback(async (...args) => {
         setLoading(true)
         try {
-            const result = await apiFunc(...args)
+            const result = await apiRef.current(...args)
             setData(result.data)
         } catch (err) {
             setError(err || 'Unexpected Error!')
         } finally {
             setLoading(false)
         }
-    }, [apiFunc])
+    }, [])
 
     return {
         data,


### PR DESCRIPTION
Fixes #0

# Description

Stabilizes the useApi hook with useRef to prevent unnecessary re-renders and documents the usage pattern across packages.

## Changes Made

- wrap API callbacks in useRef and expose stable request function
- add unit test confirming single request on mount
- document useApi usage in package READMEs

## Additional Work

- documentation updates
- test additions

## Testing

- [x] Manual testing completed
- [x] Automated tests pass
- [ ] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #0

# Описание

Стабилизирован хук useApi с помощью useRef для предотвращения лишних ререндеров и задокументирован шаблон его использования.

## Внесенные изменения

- обернуты API‑колбэки в useRef и предоставлена стабильная функция request
- добавлен юнит‑тест, подтверждающий однократный запрос при монтировании
- обновлены README пакетов с инструкцией по использованию useApi

## Дополнительная работа

- обновление документации
- добавление тестов

## Тестирование

- [x] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [ ] Не внесено критических изменений
</details>

------
https://chatgpt.com/codex/tasks/task_e_68b98b349c8c8323845e6fe35c6b4cb0