### PR TITLE
GH415 Document apps testing strategy

### DIFF
--- a/docs/testing/apps-testing-strategy.md
+++ b/docs/testing/apps-testing-strategy.md
@@ -62,7 +62,7 @@ Cross-app user journeys will be validated via **Cypress**. The Cypress workspace
 | uniks-frt | React module | Unit, component (Vitest), Cypress unik management | Supabase client mock, router providers | Unit ≥70%, Component ≥60%, E2E smoke |
 | uniks-srv | Node/Express service | Unit (Jest), integration (Jest + Supertest) | TypeORM DataSource, Supabase client | Unit ≥80%, Integration ≥65% |
 | universo-platformo-types | Shared TS library | Unit (Jest) for schema utilities | None | Unit ≥80% |
-| universo-platformo-utils | Shared TS library | Unit (Jest) for validators/serialisers | Optional zod schema mocks | Unit ≥80% |
+| universo-platformo-utils | Shared TS library | Unit (Jest) for validators/serialisers | Optional mocks for dependencies using Zod schemas | Unit ≥80% |
 | updl | Node tooling package | Unit (Jest) for AST transforms | Gulp/task runner stubs | Unit ≥70% |
 
 > **Note:** All packages join the central Cypress E2E plan through shared flows so long as their UI or API surfaces are available within the orchestrated environment. Coverage percentages express minimum line coverage targets per level.


### PR DESCRIPTION
Fixes #415 Document unified testing strategy for apps.

# Description

Document the agreed testing stack for backend and frontend apps, including migration guidance and package-specific coverage expectations.

## Changes Made

- Added `docs/testing/apps-testing-strategy.md` summarizing the current testing assets across apps.
- Recorded the shared toolchain decisions for Node services, React front-ends, and Cypress end-to-end coverage.
- Defined planned test levels, required mocks, and coverage goals for every package in the apps workspace.

## Additional Work

- Documentation updates

## Testing

- [ ] Manual testing completed
- [ ] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #415 Document unified testing strategy for apps.

# Описание

Задокументирован согласованный стек тестирования для бэкенд- и фронтенд-приложений, включая рекомендации по миграции и ожидания по покрытию для каждого пакета.

## Внесенные изменения

- Добавлен файл `docs/testing/apps-testing-strategy.md` с обзором текущих тестовых артефактов по приложениям.
- Зафиксированы общие решения по инструментам для Node-сервисов, React-фронтендов и e2e-покрытия Cypress.
- Определены планируемые уровни тестирования, необходимые заглушки и целевые показатели покрытия для каждого пакета в рабочем пространстве apps.

## Дополнительная работа

- Обновления документации

## Тестирование

- [ ] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>