### PR TITLE
GH417 Add shared backend testing utilities

### DIFF
--- a/tools/testing/backend/README.md
+++ b/tools/testing/backend/README.md
@@ -1,0 +1,73 @@
+# Backend testing utilities
+
+Reusable Jest configuration, setup helpers, and mocks for backend services live in this folder. They provide a consistent testing experience across all Universo Platformo Node applications.
+
+## Base Jest configuration
+
+Add the shared configuration to a backend app by importing the base config from `tools/testing/backend/jest.base.config.cjs` and extending it if necessary:
+
+```js
+// apps/example-srv/base/jest.config.cjs
+const baseConfig = require('../../tools/testing/backend/jest.base.config.cjs')
+
+module.exports = {
+  ...baseConfig,
+  displayName: 'example-srv',
+  // Add overrides such as custom coverage exclusions when needed.
+}
+```
+
+The base configuration provides:
+
+- `ts-jest` preset with the workspace `tsconfig.json` so path aliases just work.
+- Node test environment, source roots, and default `testMatch` patterns.
+- Consistent coverage collection that excludes generated artefacts.
+- `setupFilesAfterEnv` pointing to `setupAfterEnv.ts` (described below).
+- Module name mapping for `@testing/backend/*` so tests can import shared helpers without relative paths.
+
+## Runtime setup (`setupAfterEnv.ts`)
+
+The setup file runs after the Jest environment is created and is responsible for:
+
+- Registering reusable globals: `createMockSupabaseClient`, `createMockRepository`, `createMockQueryBuilder`, and `createMockDataSource`.
+- Providing a default mock implementation for `@supabase/supabase-js`'s `createClient`.
+- Adding the custom matcher `toHaveBeenCalledOnceWith` to Jest's `expect`.
+- Clearing mocks after every test and forcing `NODE_ENV` to `test` when it is not defined.
+
+All helpers are exported so they can be imported explicitly as well:
+
+```ts
+import { createMockDataSource } from '@testing/backend/setupAfterEnv'
+```
+
+## TypeORM helpers (`typeormMocks.ts`)
+
+`createMockQueryBuilder`, `createMockRepository`, and `createMockDataSource` create deeply mocked TypeORM primitives used by service unit tests. They are chainable by default and expose the most common terminal methods (`getOne`, `getMany`, `execute`, etc.).
+
+```ts
+import { createMockDataSource } from '@testing/backend/typeormMocks'
+
+const dataSource = createMockDataSource()
+const repository = dataSource.getRepository(MyEntity)
+repository.findOne.mockResolvedValue(mockEntity)
+```
+
+A convenience `asMockRepository` cast helper is also provided for safely treating existing repositories as mocks inside tests.
+
+## Supabase client mock
+
+`createMockSupabaseClient` produces an object compatible with the Supabase JavaScript client. It includes the most common query builder methods (`select`, `insert`, `eq`, `single`, etc.), auth helpers, storage buckets, and edge function invocation. Consumers can provide overrides:
+
+```ts
+const supabase = createMockSupabaseClient({
+  auth: {
+    getSession: jest.fn().mockResolvedValue({ data: { session: mockSession } })
+  }
+})
+```
+
+Because `setupAfterEnv.ts` automatically assigns this factory to `global.createMockSupabaseClient`, tests may use it without importing when preferred.
+
+## Path aliases
+
+The repository root `tsconfig.json` defines the `@testing/backend/*` path alias. Any backend package that relies on the shared utilities should ensure its TypeScript configuration extends or respects the root options so the alias resolves inside editors and during type-checking.

--- a/tools/testing/backend/README.md
+++ b/tools/testing/backend/README.md
@@ -45,7 +45,7 @@ import { createMockDataSource } from '@testing/backend/setupAfterEnv'
 `createMockQueryBuilder`, `createMockRepository`, and `createMockDataSource` create deeply mocked TypeORM primitives used by service unit tests. They are chainable by default and expose the most common terminal methods (`getOne`, `getMany`, `execute`, etc.).
 
 ```ts
-import { createMockDataSource } from '@testing/backend/typeormMocks'
+import { createMockDataSource } from '@testing/backend/setupAfterEnv'
 
 const dataSource = createMockDataSource()
 const repository = dataSource.getRepository(MyEntity)

--- a/tools/testing/backend/jest.base.config.cjs
+++ b/tools/testing/backend/jest.base.config.cjs
@@ -1,0 +1,35 @@
+const path = require('path')
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..')
+
+/**
+ * Shared Jest configuration for backend services.
+ * Individual apps can import and extend this base configuration
+ * to keep testing behaviour consistent across the monorepo.
+ */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  setupFilesAfterEnv: [path.join(__dirname, 'setupAfterEnv.ts')],
+  testMatch: ['**/__tests__/**/*.test.[tj]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
+  moduleNameMapper: {
+    '^@testing/backend/(.*)$': path.join(__dirname, '$1'),
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{ts,tsx}',
+    '!<rootDir>/src/**/*.d.ts',
+    '!<rootDir>/src/**/__tests__/**',
+    '!<rootDir>/src/**/tests/**'
+  ],
+  coverageDirectory: '<rootDir>/coverage',
+  coverageReporters: ['text', 'lcov', 'cobertura'],
+  globals: {
+    'ts-jest': {
+      tsconfig: path.join(repoRoot, 'tsconfig.json'),
+      isolatedModules: true
+    }
+  }
+}

--- a/tools/testing/backend/setupAfterEnv.ts
+++ b/tools/testing/backend/setupAfterEnv.ts
@@ -173,12 +173,9 @@ jest.mock('@supabase/supabase-js', () => {
 })
 
 global.createMockSupabaseClient = createMockSupabaseClient
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-global.createMockRepository = createMockRepository as any
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-global.createMockQueryBuilder = createMockQueryBuilder as any
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-global.createMockDataSource = createMockDataSource as any
+global.createMockRepository = createMockRepository
+global.createMockQueryBuilder = createMockQueryBuilder
+global.createMockDataSource = createMockDataSource
 
 export {
   createMockSupabaseClient,

--- a/tools/testing/backend/setupAfterEnv.ts
+++ b/tools/testing/backend/setupAfterEnv.ts
@@ -1,0 +1,193 @@
+import { afterEach, expect, jest } from '@jest/globals'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import {
+  createMockDataSource,
+  createMockQueryBuilder,
+  createMockRepository,
+  asMockRepository,
+  type MockDataSource,
+  type MockRepository,
+  type MockSelectQueryBuilder,
+  type TransactionalEntityManager
+} from './typeormMocks'
+
+type SupabaseClientMock = jest.Mocked<SupabaseClient<any, any, any>>
+
+type QueryResult = {
+  select: jest.Mock<any, any>
+  insert: jest.Mock<any, any>
+  update: jest.Mock<any, any>
+  upsert: jest.Mock<any, any>
+  'delete': jest.Mock<any, any>
+  eq: jest.Mock<any, any>
+  neq: jest.Mock<any, any>
+  'in': jest.Mock<any, any>
+  contains: jest.Mock<any, any>
+  order: jest.Mock<any, any>
+  range: jest.Mock<any, any>
+  limit: jest.Mock<any, any>
+  single: jest.Mock<any, any>
+  maybeSingle: jest.Mock<any, any>
+  throwOnError: jest.Mock<any, any>
+}
+
+const createQueryResult = (): QueryResult => {
+  const result = {} as QueryResult
+  const chain = () => jest.fn().mockReturnValue(result)
+
+  Object.assign(result, {
+    select: chain(),
+    insert: chain(),
+    update: chain(),
+    upsert: chain(),
+    'delete': chain(),
+    eq: chain(),
+    neq: chain(),
+    'in': chain(),
+    contains: chain(),
+    order: chain(),
+    range: chain(),
+    limit: chain(),
+    single: jest.fn(),
+    maybeSingle: jest.fn(),
+    throwOnError: chain()
+  })
+
+  return result
+}
+
+const createMockSupabaseClient = (
+  overrides: Partial<SupabaseClientMock> = {}
+): SupabaseClientMock => {
+  const queryResult = createQueryResult()
+  const storageBucket = {
+    upload: jest.fn(),
+    download: jest.fn(),
+    remove: jest.fn()
+  }
+
+  const client = {
+    auth: {
+      getSession: jest.fn(),
+      getUser: jest.fn(),
+      signInWithPassword: jest.fn(),
+      signUp: jest.fn(),
+      signOut: jest.fn(),
+      refreshSession: jest.fn()
+    },
+    from: jest.fn(() => ({ ...queryResult })),
+    rpc: jest.fn(),
+    storage: {
+      from: jest.fn(() => ({ ...storageBucket }))
+    },
+    functions: {
+      invoke: jest.fn()
+    },
+    channel: jest.fn(),
+    getChannels: jest.fn(() => []),
+    removeChannel: jest.fn(),
+    removeAllChannels: jest.fn(),
+    on: jest.fn(),
+    removeAllListeners: jest.fn()
+  } as unknown as SupabaseClientMock
+
+  return Object.assign(client, overrides)
+}
+
+type JestMock = { mock: { calls: unknown[][] } }
+
+declare global {
+  // eslint-disable-next-line no-var
+  var createMockSupabaseClient: (
+    overrides?: Partial<SupabaseClientMock>
+  ) => SupabaseClientMock
+  // eslint-disable-next-line no-var
+  var createMockRepository: typeof createMockRepository
+  // eslint-disable-next-line no-var
+  var createMockQueryBuilder: typeof createMockQueryBuilder
+  // eslint-disable-next-line no-var
+  var createMockDataSource: typeof createMockDataSource
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveBeenCalledOnceWith(...expected: unknown[]): R
+    }
+
+    interface Expect {
+      toHaveBeenCalledOnceWith(...expected: unknown[]): void
+    }
+
+    interface InverseAsymmetricMatchers {
+      toHaveBeenCalledOnceWith(...expected: unknown[]): void
+    }
+  }
+}
+
+expect.extend({
+  toHaveBeenCalledOnceWith(received: unknown, ...expected: unknown[]) {
+    const matcherName = 'toHaveBeenCalledOnceWith'
+    const passMessage = () =>
+      `expected mock not to be called once with ${this.utils.printExpected(expected)}`
+    const failMessage = (error: string) =>
+      `${matcherName} expected a Jest mock. ${error}`
+
+    if (!received || typeof received !== 'function' || !(received as JestMock).mock) {
+      return {
+        pass: false,
+        message: () => failMessage('The received value is not a mock function.')
+      }
+    }
+
+    const { calls } = (received as JestMock).mock
+    const pass = calls.length === 1 && this.equals(calls[0], expected)
+
+    return {
+      pass,
+      message: () =>
+        pass
+          ? passMessage()
+          : `expected mock to be called exactly once with ${this.utils.printExpected(expected)} but received ${this.utils.printReceived(calls)}`
+    }
+  }
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'test'
+}
+
+jest.mock('@supabase/supabase-js', () => {
+  const actual = jest.requireActual('@supabase/supabase-js') as Record<string, unknown>
+
+  return {
+    __esModule: true,
+    ...actual,
+    createClient: jest.fn(() => createMockSupabaseClient())
+  }
+})
+
+global.createMockSupabaseClient = createMockSupabaseClient
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+global.createMockRepository = createMockRepository as any
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+global.createMockQueryBuilder = createMockQueryBuilder as any
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+global.createMockDataSource = createMockDataSource as any
+
+export {
+  createMockSupabaseClient,
+  createMockRepository,
+  createMockQueryBuilder,
+  createMockDataSource,
+  asMockRepository,
+  MockDataSource,
+  MockRepository,
+  MockSelectQueryBuilder,
+  TransactionalEntityManager
+}

--- a/tools/testing/backend/typeormMocks.ts
+++ b/tools/testing/backend/typeormMocks.ts
@@ -92,7 +92,7 @@ export const createMockRepository = <Entity>(
   const queryBuilder = createMockQueryBuilder<Entity>(queryBuilderOverrides)
   const manager = {
     transaction: jest.fn(async <T>(run: (transactionManager: EntityManager) => Promise<T> | T) => {
-      return run?.(manager as unknown as EntityManager) ?? (undefined as unknown as T)
+      return run(manager as unknown as EntityManager)
     })
   } as unknown as EntityManager
 

--- a/tools/testing/backend/typeormMocks.ts
+++ b/tools/testing/backend/typeormMocks.ts
@@ -151,7 +151,7 @@ export const createMockDataSource = (
 
   const manager = {
     transaction: jest.fn(async (callback: (manager: EntityManager) => Promise<unknown> | unknown) => {
-      return callback?.(manager as unknown as EntityManager)
+      return callback(manager as unknown as EntityManager)
     })
   } as unknown as TransactionalEntityManager
 

--- a/tools/testing/backend/typeormMocks.ts
+++ b/tools/testing/backend/typeormMocks.ts
@@ -1,0 +1,171 @@
+import type {
+  DataSource,
+  EntityManager,
+  EntityTarget,
+  Repository
+} from 'typeorm'
+
+export interface MockSelectQueryBuilder<Entity> {
+  select: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  addSelect: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  leftJoin: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  leftJoinAndSelect: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  innerJoin: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  innerJoinAndSelect: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  where: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  andWhere: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  orWhere: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  orderBy: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  groupBy: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  having: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  offset: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  limit: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  skip: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  take: jest.Mock<MockSelectQueryBuilder<Entity>, any>
+  getOne: jest.Mock<Promise<Entity | null>, []>
+  getMany: jest.Mock<Promise<Entity[]>, []>
+  getRawOne: jest.Mock<Promise<unknown>, []>
+  getRawMany: jest.Mock<Promise<unknown[]>, []>
+  getRawAndEntities: jest.Mock<Promise<{ raw: unknown[]; entities: Entity[] }>, []>
+  getCount: jest.Mock<Promise<number>, []>
+  execute: jest.Mock<Promise<unknown>, []>
+}
+
+const createChainableMethod = <Entity>(): jest.Mock<MockSelectQueryBuilder<Entity>, any> =>
+  jest.fn().mockReturnThis()
+
+export const createMockQueryBuilder = <Entity>(
+  overrides: Partial<MockSelectQueryBuilder<Entity>> = {}
+): MockSelectQueryBuilder<Entity> => {
+  const builder: MockSelectQueryBuilder<Entity> = {
+    select: createChainableMethod(),
+    addSelect: createChainableMethod(),
+    leftJoin: createChainableMethod(),
+    leftJoinAndSelect: createChainableMethod(),
+    innerJoin: createChainableMethod(),
+    innerJoinAndSelect: createChainableMethod(),
+    where: createChainableMethod(),
+    andWhere: createChainableMethod(),
+    orWhere: createChainableMethod(),
+    orderBy: createChainableMethod(),
+    groupBy: createChainableMethod(),
+    having: createChainableMethod(),
+    offset: createChainableMethod(),
+    limit: createChainableMethod(),
+    skip: createChainableMethod(),
+    take: createChainableMethod(),
+    getOne: jest.fn(),
+    getMany: jest.fn(),
+    getRawOne: jest.fn(),
+    getRawMany: jest.fn(),
+    getRawAndEntities: jest.fn(),
+    getCount: jest.fn(),
+    execute: jest.fn()
+  }
+
+  return Object.assign(builder, overrides)
+}
+
+export interface MockRepository<Entity> {
+  find: jest.Mock<Promise<Entity[]>, any>
+  findOne: jest.Mock<Promise<Entity | null>, any>
+  findOneBy: jest.Mock<Promise<Entity | null>, any>
+  findOneOrFail: jest.Mock<Promise<Entity>, any>
+  findBy: jest.Mock<Promise<Entity[]>, any>
+  count: jest.Mock<Promise<number>, any>
+  create: jest.Mock<Entity, any>
+  save: jest.Mock<Promise<Entity>, any>
+  insert: jest.Mock<Promise<unknown>, any>
+  update: jest.Mock<Promise<unknown>, any>
+  delete: jest.Mock<Promise<unknown>, any>
+  softDelete: jest.Mock<Promise<unknown>, any>
+  restore: jest.Mock<Promise<unknown>, any>
+  createQueryBuilder: jest.Mock<MockSelectQueryBuilder<Entity>, []>
+  manager: EntityManager
+  queryBuilder: MockSelectQueryBuilder<Entity>
+}
+
+export const createMockRepository = <Entity>(
+  overrides: Partial<MockRepository<Entity>> = {},
+  queryBuilderOverrides: Partial<MockSelectQueryBuilder<Entity>> = {}
+): MockRepository<Entity> => {
+  const queryBuilder = createMockQueryBuilder<Entity>(queryBuilderOverrides)
+  const manager = {
+    transaction: jest.fn(async <T>(run: (transactionManager: EntityManager) => Promise<T> | T) => {
+      return run?.(manager as unknown as EntityManager) ?? (undefined as unknown as T)
+    })
+  } as unknown as EntityManager
+
+  const repository: MockRepository<Entity> = {
+    find: jest.fn(async () => []),
+    findOne: jest.fn(async () => null),
+    findOneBy: jest.fn(async () => null),
+    findOneOrFail: jest.fn(async () => {
+      throw new Error('Entity not found')
+    }),
+    findBy: jest.fn(async () => []),
+    count: jest.fn(async () => 0),
+    create: jest.fn((entity?: Entity) => (entity ?? ({} as Entity))),
+    save: jest.fn(async (entity?: Entity) => entity ?? ({} as Entity)),
+    insert: jest.fn(async () => ({})),
+    update: jest.fn(async () => ({})),
+    delete: jest.fn(async () => ({})),
+    softDelete: jest.fn(async () => ({})),
+    restore: jest.fn(async () => ({})),
+    createQueryBuilder: jest.fn(() => queryBuilder),
+    manager,
+    queryBuilder
+  }
+
+  return Object.assign(repository, overrides)
+}
+
+export type RepositoryFactory = <Entity>(target: EntityTarget<Entity>) => MockRepository<Entity>
+
+export interface TransactionalEntityManager extends EntityManager {
+  transaction: jest.Mock<Promise<unknown>, [(manager: EntityManager) => Promise<unknown> | unknown]>
+}
+
+export interface MockDataSource {
+  isInitialized: boolean
+  initialize: jest.Mock<Promise<DataSource>, []>
+  destroy: jest.Mock<Promise<void>, []>
+  getRepository: jest.Mock<MockRepository<any>, [EntityTarget<any>]>
+  manager: TransactionalEntityManager
+}
+
+export const createMockDataSource = (
+  repositoryFactory: RepositoryFactory | Record<string, MockRepository<any>> = {},
+  overrides: Partial<MockDataSource> = {}
+): MockDataSource => {
+  const resolvedFactory: RepositoryFactory = (target) => {
+    if (typeof repositoryFactory === 'function') {
+      return repositoryFactory(target)
+    }
+
+    const key = typeof target === 'function' ? target.name : String(target)
+    const repository = repositoryFactory[key]
+
+    return repository ?? createMockRepository()
+  }
+
+  const manager = {
+    transaction: jest.fn(async (callback: (manager: EntityManager) => Promise<unknown> | unknown) => {
+      return callback?.(manager as unknown as EntityManager)
+    })
+  } as unknown as TransactionalEntityManager
+
+  const dataSource: MockDataSource = {
+    isInitialized: true,
+    initialize: jest.fn(async () => dataSource as unknown as DataSource),
+    destroy: jest.fn(async () => undefined),
+    getRepository: jest.fn(resolvedFactory as RepositoryFactory),
+    manager
+  }
+
+  return Object.assign(dataSource, overrides)
+}
+
+export const asMockRepository = <Entity>(repository: Repository<Entity> | MockRepository<Entity>): MockRepository<Entity> => {
+  return repository as MockRepository<Entity>
+}

--- a/tools/testing/backend/typeormMocks.ts
+++ b/tools/testing/backend/typeormMocks.ts
@@ -131,6 +131,7 @@ export interface MockDataSource {
   initialize: jest.Mock<Promise<DataSource>, []>
   destroy: jest.Mock<Promise<void>, []>
   getRepository: jest.Mock<MockRepository<any>, [EntityTarget<any>]>
+  transaction: jest.Mock<Promise<unknown>, [(run: (manager: EntityManager) => Promise<unknown> | unknown)]>
   manager: TransactionalEntityManager
 }
 
@@ -160,6 +161,9 @@ export const createMockDataSource = (
     initialize: jest.fn(async () => dataSource as unknown as DataSource),
     destroy: jest.fn(async () => undefined),
     getRepository: jest.fn(resolvedFactory as RepositoryFactory),
+    transaction: jest.fn(async (run: (manager: EntityManager) => Promise<unknown> | unknown) => {
+      return manager.transaction(run)
+    }),
     manager
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@testing/backend/*": ["tools/testing/backend/*"]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #417 Roll out shared backend testing utilities across services.

# Description

Introduce a reusable backend Jest configuration together with shared mocks so service packages can standardise their test harnesses.

## Changes Made

- Added `tools/testing/backend/jest.base.config.cjs` to supply the ts-jest preset, Node environment defaults, module name mapping, coverage rules, and after-env hook.
- Implemented `tools/testing/backend/setupAfterEnv.ts` to register Supabase and TypeORM mocks as globals, extend Jest matchers, and install a default Supabase `createClient` mock.
- Created `tools/testing/backend/typeormMocks.ts`, documented usage in `README.md`, and registered the `@testing/backend/*` path alias in the root `tsconfig.json`.

## Additional Work

- Documented backend testing helper usage for service teams.
- Registered the shared testing path alias at the repository root.
- Attempted to run `pnpm --filter @universo/spaces-srv test -- --runTestsByPath src/tests/routes.test.ts`; it currently fails because the existing test suite expects `createSpacesRoutes` to receive a factory instead of a mocked `DataSource` instance.

## Testing

- [ ] Manual testing completed
- [ ] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #417 Roll out shared backend testing utilities across services.

# Описание

Внедрена переиспользуемая конфигурация Jest для бэкенда вместе с общими моками, чтобы сервисные пакеты могли стандартизировать тестовый стенд.

## Внесенные изменения

- Добавлен `tools/testing/backend/jest.base.config.cjs`, предоставляющий пресет ts-jest, настройки окружения Node, правила сопоставления модулей, сбор покрытия и подключение файла окружения.
- Реализован `tools/testing/backend/setupAfterEnv.ts`, регистрирующий моки Supabase и TypeORM в глобальном пространстве, расширяющий матчеры Jest и устанавливающий мок по умолчанию для `createClient` Supabase.
- Создан `tools/testing/backend/typeormMocks.ts`, добавлена документация в `README.md` и зарегистрирован алиас `@testing/backend/*` в корневом `tsconfig.json`.

## Дополнительная работа

- Задокументировано использование бэкенд-хелперов тестирования для команд сервисов.
- Зарегистрирован общий тестовый алиас в корне репозитория.
- Попытка запуска `pnpm --filter @universo/spaces-srv test -- --runTestsByPath src/tests/routes.test.ts` завершилась ошибкой, так как текущий набор тестов ожидает, что `createSpacesRoutes` примет фабрику вместо замоканного экземпляра `DataSource`.

## Тестирование

- [ ] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>