### PR TITLE
GH433 Add vitest coverage for core processors

### DIFF
--- a/apps/template-mmoomm/base/README.md
+++ b/apps/template-mmoomm/base/README.md
@@ -91,3 +91,11 @@ pnpm build:cjs
 pnpm build:esm
 pnpm build:types
 ```
+
+### Testing
+
+```bash
+pnpm --filter @universo/template-mmoomm test
+```
+
+Automated Vitest checks guard PlayCanvas mode detection, ensuring multiplayer lead collection flows keep working as described above.

--- a/apps/template-mmoomm/base/package.json
+++ b/apps/template-mmoomm/base/package.json
@@ -30,7 +30,8 @@
         "clean": "rimraf dist",
         "dev": "tsc -p tsconfig.json --watch",
         "lint": "eslint src --ext .ts,.tsx",
-        "lint:fix": "eslint src --ext .ts,.tsx --fix"
+        "lint:fix": "eslint src --ext .ts,.tsx --fix",
+        "test": "vitest run --config vitest.config.ts"
     },
     "keywords": [
         "mmoomm",
@@ -50,6 +51,7 @@
     "devDependencies": {
         "@types/node": "^20.0.0",
         "typescript": "^5.4.5",
-        "rimraf": "^5.0.0"
+        "rimraf": "^5.0.0",
+        "vitest": "^2.1.4"
     }
 }

--- a/apps/template-mmoomm/base/src/playcanvas/utils/__tests__/ModeDetector.test.ts
+++ b/apps/template-mmoomm/base/src/playcanvas/utils/__tests__/ModeDetector.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { ModeDetector } from '../ModeDetector'
+
+describe('ModeDetector', () => {
+  const multiplayerFlow = {
+    multiScene: {
+      totalScenes: 3,
+      scenes: [
+        {
+          spaceId: 'auth',
+          spaceData: {
+            leadCollection: {
+              collectName: true,
+              collectEmail: false,
+              collectPhone: false,
+            },
+            entities: [],
+          },
+          dataNodes: [],
+          objectNodes: [],
+        },
+        {
+          spaceId: 'game',
+          spaceData: {
+            entities: [{ id: 'ship', components: [] }],
+          },
+          dataNodes: [
+            {
+              id: 'question-1',
+              dataType: 'question',
+              content: 'Launch?',
+            },
+          ],
+          objectNodes: [],
+        },
+        {
+          spaceId: 'results',
+          spaceData: {},
+          dataNodes: [],
+          objectNodes: [],
+        },
+      ],
+    },
+  }
+
+  it('detects multiplayer flows based on lead collection lobby', () => {
+    const info = ModeDetector.detectMultiplayerMode(multiplayerFlow as any)
+
+    expect(info.isMultiplayer).toBe(true)
+    expect(info.authSpace?.spaceId).toBe('auth')
+    expect(info.gameSpace?.spaceId).toBe('game')
+  })
+
+  it('prefers explicit game mode option over auto detection', () => {
+    const optionMode = ModeDetector.determineGameMode(multiplayerFlow as any, { gameMode: 'singleplayer' })
+    expect(optionMode).toBe('singleplayer')
+
+    const autoMode = ModeDetector.determineGameMode(multiplayerFlow as any, {})
+    expect(autoMode).toBe('multiplayer')
+  })
+
+  it('reports content availability for both single and multi scene flows', () => {
+    const emptyFlow = {}
+    expect(ModeDetector.hasContent(emptyFlow as any)).toBe(false)
+
+    const singleSceneFlow = {
+      updlSpace: {
+        entities: [{ id: 'entity', components: [] }],
+      },
+    }
+
+    expect(ModeDetector.hasContent(singleSceneFlow as any)).toBe(true)
+    expect(ModeDetector.hasContent(multiplayerFlow as any)).toBe(true)
+  })
+})

--- a/apps/template-mmoomm/base/src/playcanvas/utils/__tests__/ModeDetector.test.ts
+++ b/apps/template-mmoomm/base/src/playcanvas/utils/__tests__/ModeDetector.test.ts
@@ -1,51 +1,77 @@
 import { describe, expect, it } from 'vitest'
 
+import type { IFlowData, IUPDLMultiScene, IUPDLScene, IUPDLSpace } from '../../common/types'
 import { ModeDetector } from '../ModeDetector'
 
+const createScene = (overrides: Partial<IUPDLScene>): IUPDLScene => ({
+  spaceId: 'default-space',
+  spaceData: {},
+  dataNodes: [],
+  objectNodes: [],
+  isLast: false,
+  order: 0,
+  ...overrides,
+})
+
+const createMultiSceneFlow = (multiScene: Partial<IUPDLMultiScene>): IFlowData => ({
+  multiScene: {
+    scenes: [],
+    currentSceneIndex: 0,
+    totalScenes: 0,
+    isCompleted: false,
+    ...multiScene,
+  },
+})
+
+const createSingleSceneSpace = (space: Partial<IUPDLSpace>): IFlowData => ({
+  updlSpace: {
+    id: 'space-id',
+    name: 'Single Scene Space',
+    objects: [],
+    ...space,
+  },
+})
+
 describe('ModeDetector', () => {
-  const multiplayerFlow = {
-    multiScene: {
-      totalScenes: 3,
-      scenes: [
-        {
-          spaceId: 'auth',
-          spaceData: {
-            leadCollection: {
-              collectName: true,
-              collectEmail: false,
-              collectPhone: false,
-            },
-            entities: [],
+  const multiplayerFlow: IFlowData = createMultiSceneFlow({
+    totalScenes: 3,
+    scenes: [
+      createScene({
+        spaceId: 'auth',
+        order: 0,
+        spaceData: {
+          leadCollection: {
+            collectName: true,
+            collectEmail: false,
+            collectPhone: false,
           },
-          dataNodes: [],
-          objectNodes: [],
+          entities: [],
         },
-        {
-          spaceId: 'game',
-          spaceData: {
-            entities: [{ id: 'ship', components: [] }],
+      }),
+      createScene({
+        spaceId: 'game',
+        order: 1,
+        spaceData: {
+          entities: [{ id: 'ship', components: [] }],
+        },
+        dataNodes: [
+          {
+            id: 'question-1',
+            dataType: 'question',
+            content: 'Launch?',
           },
-          dataNodes: [
-            {
-              id: 'question-1',
-              dataType: 'question',
-              content: 'Launch?',
-            },
-          ],
-          objectNodes: [],
-        },
-        {
-          spaceId: 'results',
-          spaceData: {},
-          dataNodes: [],
-          objectNodes: [],
-        },
-      ],
-    },
-  }
+        ],
+      }),
+      createScene({
+        spaceId: 'results',
+        order: 2,
+        isLast: true,
+      }),
+    ],
+  })
 
   it('detects multiplayer flows based on lead collection lobby', () => {
-    const info = ModeDetector.detectMultiplayerMode(multiplayerFlow as any)
+    const info = ModeDetector.detectMultiplayerMode(multiplayerFlow)
 
     expect(info.isMultiplayer).toBe(true)
     expect(info.authSpace?.spaceId).toBe('auth')
@@ -53,24 +79,27 @@ describe('ModeDetector', () => {
   })
 
   it('prefers explicit game mode option over auto detection', () => {
-    const optionMode = ModeDetector.determineGameMode(multiplayerFlow as any, { gameMode: 'singleplayer' })
+    const optionMode = ModeDetector.determineGameMode(multiplayerFlow, { gameMode: 'singleplayer' })
     expect(optionMode).toBe('singleplayer')
 
-    const autoMode = ModeDetector.determineGameMode(multiplayerFlow as any, {})
+    const autoMode = ModeDetector.determineGameMode(multiplayerFlow, {})
     expect(autoMode).toBe('multiplayer')
   })
 
   it('reports content availability for both single and multi scene flows', () => {
-    const emptyFlow = {}
-    expect(ModeDetector.hasContent(emptyFlow as any)).toBe(false)
+    const emptyFlow: IFlowData = {}
+    expect(ModeDetector.hasContent(emptyFlow)).toBe(false)
 
-    const singleSceneFlow = {
-      updlSpace: {
-        entities: [{ id: 'entity', components: [] }],
-      },
-    }
+    const singleSceneFlow = createSingleSceneSpace({
+      entities: [{ id: 'entity', components: [] }],
+      datas: [],
+      components: [],
+      events: [],
+      actions: [],
+      universo: [],
+    })
 
-    expect(ModeDetector.hasContent(singleSceneFlow as any)).toBe(true)
-    expect(ModeDetector.hasContent(multiplayerFlow as any)).toBe(true)
+    expect(ModeDetector.hasContent(singleSceneFlow)).toBe(true)
+    expect(ModeDetector.hasContent(multiplayerFlow)).toBe(true)
   })
 })

--- a/apps/template-mmoomm/base/vitest.config.ts
+++ b/apps/template-mmoomm/base/vitest.config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import baseConfig from '../../../tools/testing/frontend/vitest.base.config'
+import { loadTsconfigAliases } from '../../../tools/testing/frontend/loadTsconfigAliases'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const srcDir = path.resolve(__dirname, 'src')
+const tsconfigAliases = loadTsconfigAliases(path.resolve(__dirname, 'tsconfig.json'), __dirname)
+
+const sanitizedBaseConfig = {
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test ?? {}),
+    setupFiles: [],
+  },
+}
+
+export default mergeConfig(
+  sanitizedBaseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        ...tsconfigAliases,
+        '@': srcDir,
+        '@universo-platformo/utils': path.resolve(__dirname, '..', '..', 'universo-platformo-utils', 'base', 'src'),
+        '@universo-platformo/types': path.resolve(__dirname, '..', '..', 'universo-platformo-types', 'base', 'src'),
+      },
+    },
+    test: {
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      exclude: ['dist/**', 'node_modules/**'],
+      setupFiles: [],
+      coverage: {
+        enabled: false,
+        reporter: ['text', 'json-summary'],
+        reportsDirectory: path.resolve(__dirname, 'coverage'),
+      },
+    },
+  }),
+)

--- a/apps/template-quiz/base/README.md
+++ b/apps/template-quiz/base/README.md
@@ -201,6 +201,14 @@ pnpm lint
 pnpm lint:fix
 ```
 
+### Testing
+
+```bash
+pnpm --filter @universo/template-quiz test
+```
+
+The Vitest suite keeps AR.js quiz serialization, lead capture, and scoring flows in sync with the documented behaviour.
+
 ## Integration
 
 This package is designed to integrate with:

--- a/apps/template-quiz/base/package.json
+++ b/apps/template-quiz/base/package.json
@@ -30,7 +30,8 @@
         "clean": "rimraf dist",
         "dev": "tsc -p tsconfig.json --watch",
         "lint": "eslint src --ext .ts,.tsx",
-        "lint:fix": "eslint src --ext .ts,.tsx --fix"
+        "lint:fix": "eslint src --ext .ts,.tsx --fix",
+        "test": "vitest run --config vitest.config.ts"
     },
     "keywords": [
         "quiz",
@@ -49,6 +50,7 @@
     "devDependencies": {
         "@types/node": "^20.0.0",
         "typescript": "^5.4.5",
-        "rimraf": "^5.0.0"
+        "rimraf": "^5.0.0",
+        "vitest": "^2.1.4"
     }
 }

--- a/apps/template-quiz/base/src/arjs/__tests__/ARJSQuizBuilder.test.ts
+++ b/apps/template-quiz/base/src/arjs/__tests__/ARJSQuizBuilder.test.ts
@@ -1,67 +1,82 @@
 import { describe, expect, it } from 'vitest'
 
+import type { IFlowData } from '../../common/types'
+import type { IUPDLData, IUPDLMultiScene, IUPDLScene, IUPDLSpace } from '@universo-platformo/types'
 import { ARJSQuizBuilder } from '../ARJSQuizBuilder'
+
+const createScene = (overrides: Partial<IUPDLScene>): IUPDLScene => ({
+  spaceId: 'scene',
+  spaceData: {},
+  dataNodes: [],
+  objectNodes: [],
+  isLast: false,
+  order: 0,
+  ...overrides,
+})
+
+const createMultiScene = (scenes: IUPDLScene[]): IUPDLMultiScene => ({
+  scenes,
+  currentSceneIndex: 0,
+  totalScenes: scenes.length,
+  isCompleted: false,
+})
+
+const createSingleSceneFlow = (space: Partial<IUPDLSpace>): IFlowData => ({
+  updlSpace: {
+    id: 'quiz-space',
+    name: 'Quiz Space',
+    objects: [],
+    ...space,
+  },
+})
 
 describe('ARJSQuizBuilder', () => {
   it('renders lead collection form and points counter for multi-scene quizzes', async () => {
     const builder = new ARJSQuizBuilder()
 
-    const multiScene = {
-      totalScenes: 3,
-      currentSceneIndex: 0,
-      isCompleted: false,
-      scenes: [
-        {
-          spaceId: 'auth',
-          order: 0,
-          isLast: false,
-          isResultsScene: false,
-          nextSceneId: 'game',
-          spaceData: {
-            leadCollection: {
-              collectName: true,
-              collectEmail: false,
-              collectPhone: false,
-            },
+    const multiScene: IUPDLMultiScene = createMultiScene([
+      createScene({
+        spaceId: 'auth',
+        order: 0,
+        nextSceneId: 'game',
+        spaceData: {
+          leadCollection: {
+            collectName: true,
+            collectEmail: false,
+            collectPhone: false,
           },
-          dataNodes: [],
-          objectNodes: [],
         },
-        {
-          spaceId: 'game',
-          order: 1,
-          isLast: false,
-          isResultsScene: false,
-          nextSceneId: 'game-results',
-          spaceData: {
-            showPoints: true,
+      }),
+      createScene({
+        spaceId: 'game',
+        order: 1,
+        nextSceneId: 'game-results',
+        spaceData: {
+          showPoints: true,
+        },
+        dataNodes: [
+          {
+            id: 'question-1',
+            name: 'Question 1',
+            dataType: 'Question',
+            content: 'Who pilots the MMOOMM flagship?',
+            isCorrect: true,
+            enablePoints: true,
+            pointsValue: 3,
           },
-          dataNodes: [
-            {
-              id: 'question-1',
-              dataType: 'question',
-              content: 'Who pilots the MMOOMM flagship?',
-              isCorrect: true,
-              enablePoints: true,
-              pointsValue: 3,
-            },
-          ],
-          objectNodes: [],
-        },
-        {
-          spaceId: 'game-results',
-          order: 2,
-          isLast: true,
-          isResultsScene: true,
-          nextSceneId: undefined,
-          spaceData: {},
-          dataNodes: [],
-          objectNodes: [],
-        },
-      ],
-    }
+        ],
+      }),
+      createScene({
+        spaceId: 'game-results',
+        order: 2,
+        isLast: true,
+        isResultsScene: true,
+      }),
+    ])
 
-    const html = await builder.build({ multiScene })
+    const multiSceneFlow: IFlowData = { multiScene }
+
+    const html = await builder.build(multiSceneFlow)
 
     expect(html).toContain('id="lead-collection-form"')
     expect(html).toContain('id="multi-scene-quiz-container"')
@@ -71,33 +86,34 @@ describe('ARJSQuizBuilder', () => {
   it('builds single-scene quiz markup from prepared UPDL space data', async () => {
     const builder = new ARJSQuizBuilder()
 
-    const flowData = {
-      updlSpace: {
-        objects: [],
-        cameras: [],
-        lights: [],
-        datas: [
-          {
-            id: 'question-1',
-            dataType: 'Question',
-            content: 'Select the correct AR marker',
-            isCorrect: false,
-            enablePoints: false,
-            pointsValue: 0,
-          },
-          {
-            id: 'answer-1',
-            dataType: 'Answer',
-            content: 'Hiro marker',
-            isCorrect: true,
-            enablePoints: true,
-            pointsValue: 1,
-          },
-        ],
+    const singleSceneData: IUPDLData[] = [
+      {
+        id: 'question-1',
+        name: 'Question 1',
+        dataType: 'Question',
+        content: 'Select the correct AR marker',
+        isCorrect: false,
+        enablePoints: false,
+        pointsValue: 0,
       },
-    }
+      {
+        id: 'answer-1',
+        name: 'Answer 1',
+        dataType: 'Answer',
+        content: 'Hiro marker',
+        isCorrect: true,
+        enablePoints: true,
+        pointsValue: 1,
+      },
+    ]
 
-    const html = await builder.build(flowData as any, { markerType: 'preset', markerValue: 'hiro' })
+    const flowData: IFlowData = createSingleSceneFlow({
+      cameras: [],
+      lights: [],
+      datas: singleSceneData,
+    })
+
+    const html = await builder.build(flowData, { markerType: 'preset', markerValue: 'hiro' })
 
     expect(html).toContain('<!-- AR.js Marker - Template: quiz -->')
     expect(html).toContain('window.canvasId')

--- a/apps/template-quiz/base/src/arjs/__tests__/ARJSQuizBuilder.test.ts
+++ b/apps/template-quiz/base/src/arjs/__tests__/ARJSQuizBuilder.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { ARJSQuizBuilder } from '../ARJSQuizBuilder'
+
+describe('ARJSQuizBuilder', () => {
+  it('renders lead collection form and points counter for multi-scene quizzes', async () => {
+    const builder = new ARJSQuizBuilder()
+
+    const multiScene = {
+      totalScenes: 3,
+      currentSceneIndex: 0,
+      isCompleted: false,
+      scenes: [
+        {
+          spaceId: 'auth',
+          order: 0,
+          isLast: false,
+          isResultsScene: false,
+          nextSceneId: 'game',
+          spaceData: {
+            leadCollection: {
+              collectName: true,
+              collectEmail: false,
+              collectPhone: false,
+            },
+          },
+          dataNodes: [],
+          objectNodes: [],
+        },
+        {
+          spaceId: 'game',
+          order: 1,
+          isLast: false,
+          isResultsScene: false,
+          nextSceneId: 'game-results',
+          spaceData: {
+            showPoints: true,
+          },
+          dataNodes: [
+            {
+              id: 'question-1',
+              dataType: 'question',
+              content: 'Who pilots the MMOOMM flagship?',
+              isCorrect: true,
+              enablePoints: true,
+              pointsValue: 3,
+            },
+          ],
+          objectNodes: [],
+        },
+        {
+          spaceId: 'game-results',
+          order: 2,
+          isLast: true,
+          isResultsScene: true,
+          nextSceneId: undefined,
+          spaceData: {},
+          dataNodes: [],
+          objectNodes: [],
+        },
+      ],
+    }
+
+    const html = await builder.build({ multiScene })
+
+    expect(html).toContain('id="lead-collection-form"')
+    expect(html).toContain('id="multi-scene-quiz-container"')
+    expect(html).toContain('id="points-counter"')
+  })
+
+  it('builds single-scene quiz markup from prepared UPDL space data', async () => {
+    const builder = new ARJSQuizBuilder()
+
+    const flowData = {
+      updlSpace: {
+        objects: [],
+        cameras: [],
+        lights: [],
+        datas: [
+          {
+            id: 'question-1',
+            dataType: 'Question',
+            content: 'Select the correct AR marker',
+            isCorrect: false,
+            enablePoints: false,
+            pointsValue: 0,
+          },
+          {
+            id: 'answer-1',
+            dataType: 'Answer',
+            content: 'Hiro marker',
+            isCorrect: true,
+            enablePoints: true,
+            pointsValue: 1,
+          },
+        ],
+      },
+    }
+
+    const html = await builder.build(flowData as any, { markerType: 'preset', markerValue: 'hiro' })
+
+    expect(html).toContain('<!-- AR.js Marker - Template: quiz -->')
+    expect(html).toContain('window.canvasId')
+    expect(html).toContain('Select the correct AR marker')
+  })
+})

--- a/apps/template-quiz/base/vitest.config.ts
+++ b/apps/template-quiz/base/vitest.config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import baseConfig from '../../../tools/testing/frontend/vitest.base.config'
+import { loadTsconfigAliases } from '../../../tools/testing/frontend/loadTsconfigAliases'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const srcDir = path.resolve(__dirname, 'src')
+const tsconfigAliases = loadTsconfigAliases(path.resolve(__dirname, 'tsconfig.json'), __dirname)
+
+const sanitizedBaseConfig = {
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test ?? {}),
+    setupFiles: [],
+  },
+}
+
+export default mergeConfig(
+  sanitizedBaseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        ...tsconfigAliases,
+        '@': srcDir,
+        '@universo-platformo/utils': path.resolve(__dirname, '..', '..', 'universo-platformo-utils', 'base', 'src'),
+        '@universo-platformo/types': path.resolve(__dirname, '..', '..', 'universo-platformo-types', 'base', 'src'),
+      },
+    },
+    test: {
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      exclude: ['dist/**', 'node_modules/**'],
+      setupFiles: [],
+      coverage: {
+        enabled: false,
+        reporter: ['text', 'json-summary'],
+        reportsDirectory: path.resolve(__dirname, 'coverage'),
+      },
+    },
+  }),
+)

--- a/apps/universo-platformo-types/base/README.md
+++ b/apps/universo-platformo-types/base/README.md
@@ -16,3 +16,11 @@ Install (workspace):
 -   This package lives at `apps/universo-platformo-types/base` and is consumed via `workspace:*` by other packages in the monorepo.
 
 License: Omsk Open License
+
+## Testing
+
+Run the type-level regression tests with Vitest:
+
+```bash
+pnpm --filter @universo-platformo/types test
+```

--- a/apps/universo-platformo-types/base/package.json
+++ b/apps/universo-platformo-types/base/package.json
@@ -21,13 +21,15 @@
         "build:esm": "tsc -p tsconfig.esm.json",
         "build:types": "tsc -p tsconfig.types.json",
         "dev": "tsc -p tsconfig.json --watch",
-        "lint": "eslint --ext .ts src/"
-        },
+        "lint": "eslint --ext .ts src/",
+        "test": "vitest run --config vitest.config.ts"
+    },
     "license": "Omsk Open License",
     "devDependencies": {
         "@types/node": "^20.11.17",
         "eslint": "^8.56.0",
         "rimraf": "^5.0.5",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vitest": "^2.1.4"
     }
 }

--- a/apps/universo-platformo-types/base/src/__tests__/branding.test.ts
+++ b/apps/universo-platformo-types/base/src/__tests__/branding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { brand } from '../common/branding'
+import { UpIntentType } from '../common/enums'
+import { UP_PROTOCOL_VERSION } from '../protocol/version'
+
+describe('Universo Platformo types', () => {
+  it('keeps brand helper as a transparent identity at runtime', () => {
+    const branded = brand<'entity', 'EntityId'>('entity-42')
+    expect(branded).toBe('entity-42')
+  })
+
+  it('exposes canonical intent constants used by networking DTOs', () => {
+    const intents = Object.values(UpIntentType)
+    expect(intents).toContain('use_module')
+    expect(new Set(intents).size).toBe(intents.length)
+  })
+
+  it('locks protocol version to a semantic version string', () => {
+    expect(UP_PROTOCOL_VERSION).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/)
+  })
+})

--- a/apps/universo-platformo-types/base/vitest.config.ts
+++ b/apps/universo-platformo-types/base/vitest.config.ts
@@ -1,0 +1,41 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import baseConfig from '../../../tools/testing/frontend/vitest.base.config'
+import { loadTsconfigAliases } from '../../../tools/testing/frontend/loadTsconfigAliases'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const srcDir = path.resolve(__dirname, 'src')
+const tsconfigAliases = loadTsconfigAliases(path.resolve(__dirname, 'tsconfig.json'), __dirname)
+
+const sanitizedBaseConfig = {
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test ?? {}),
+    setupFiles: [],
+  },
+}
+
+export default mergeConfig(
+  sanitizedBaseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        ...tsconfigAliases,
+        '@': srcDir,
+      },
+    },
+    test: {
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      exclude: ['dist/**', 'node_modules/**'],
+      setupFiles: [],
+      coverage: {
+        enabled: false,
+        reporter: ['text', 'json-summary'],
+        reportsDirectory: path.resolve(__dirname, 'coverage'),
+      },
+    },
+  }),
+)

--- a/apps/universo-platformo-utils/base/README.md
+++ b/apps/universo-platformo-utils/base/README.md
@@ -16,3 +16,11 @@ Install (workspace):
 -   This package lives at `apps/universo-platformo-utils/base` and is consumed via `workspace:*` by other packages in the monorepo.
 
 License: Omsk Open License
+
+## Testing
+
+Run Vitest against the workspace package to exercise UPDL serialization helpers:
+
+```bash
+pnpm --filter @universo-platformo/utils test
+```

--- a/apps/universo-platformo-utils/base/package.json
+++ b/apps/universo-platformo-utils/base/package.json
@@ -21,7 +21,8 @@
         "build:esm": "tsc -p tsconfig.esm.json",
         "build:types": "tsc -p tsconfig.types.json",
         "dev": "tsc -p tsconfig.json --watch",
-        "lint": "eslint --ext .ts src/"
+        "lint": "eslint --ext .ts src/",
+        "test": "vitest run --config vitest.config.ts"
     },
     "license": "Omsk Open License",
     "dependencies": {
@@ -32,6 +33,7 @@
         "@types/node": "^20.11.17",
         "eslint": "^8.56.0",
         "rimraf": "^5.0.5",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vitest": "^2.1.4"
     }
 }

--- a/apps/universo-platformo-utils/base/src/updl/__tests__/UPDLProcessor.test.ts
+++ b/apps/universo-platformo-utils/base/src/updl/__tests__/UPDLProcessor.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+
+import { UPDLProcessor } from '../UPDLProcessor'
+
+describe('UPDLProcessor', () => {
+  it('builds a single UPDL space with entity relationships preserved', () => {
+    const flowData = {
+      nodes: [
+        {
+          id: 'space-1',
+          data: {
+            name: 'Space',
+            inputs: {
+              name: 'Main Space',
+              showPoints: true,
+            },
+          },
+        },
+        {
+          id: 'entity-1',
+          data: {
+            name: 'Entity',
+            inputs: {
+              name: 'Player',
+              entityType: 'avatar',
+              transform: { position: { x: 1, y: 2, z: 3 } },
+            },
+          },
+        },
+        {
+          id: 'component-1',
+          data: {
+            name: 'Component',
+            inputs: {
+              componentType: 'render',
+              color: '#ffaa00',
+            },
+          },
+        },
+        {
+          id: 'event-1',
+          data: {
+            name: 'Event',
+            inputs: {
+              eventType: 'onClick',
+            },
+          },
+        },
+        {
+          id: 'action-1',
+          data: {
+            name: 'Action',
+            inputs: {
+              actionType: 'navigate',
+              target: 'results',
+            },
+          },
+        },
+        {
+          id: 'data-1',
+          data: {
+            name: 'Data',
+            inputs: {
+              dataType: 'Question',
+              content: 'How many moons does Mars have?',
+              pointsValue: 10,
+              enablePoints: true,
+            },
+          },
+        },
+      ],
+      edges: [
+        { id: 'edge-entity-space', source: 'entity-1', target: 'space-1' },
+        { id: 'edge-component-entity', source: 'component-1', target: 'entity-1' },
+        { id: 'edge-event-entity', source: 'event-1', target: 'entity-1' },
+        { id: 'edge-action-event', source: 'action-1', target: 'event-1' },
+        { id: 'edge-data-space', source: 'data-1', target: 'space-1' },
+      ],
+    }
+
+    const { updlSpace } = UPDLProcessor.processFlowData(JSON.stringify(flowData))
+
+    expect(updlSpace).toBeDefined()
+    expect(updlSpace?.entities).toHaveLength(1)
+    const [entity] = updlSpace!.entities!
+    expect(entity.components).toHaveLength(1)
+    expect(entity.components[0].componentType).toBe('render')
+    expect(entity.events).toHaveLength(1)
+    expect(entity.events[0].eventType).toBe('onClick')
+    expect(entity.events[0].actions).toHaveLength(1)
+    expect(entity.events[0].actions?.[0].actionType).toBe('navigate')
+    expect(updlSpace?.datas?.[0].pointsValue).toBe(10)
+    expect(updlSpace?.showPoints).toBe(true)
+  })
+
+  it('detects multi-scene flows and propagates lead collection + scoring flags', () => {
+    const flowData = {
+      nodes: [
+        {
+          id: 'space-auth',
+          data: {
+            name: 'Space',
+            inputs: {
+              name: 'Auth Scene',
+              collectLeadName: true,
+            },
+          },
+        },
+        {
+          id: 'space-game',
+          data: {
+            name: 'Space',
+            inputs: {
+              name: 'Game Scene',
+              showPoints: true,
+            },
+          },
+        },
+        {
+          id: 'entity-game',
+          data: {
+            name: 'Entity',
+            inputs: {
+              name: 'Spaceship',
+            },
+          },
+        },
+        {
+          id: 'data-auth',
+          data: {
+            name: 'Data',
+            inputs: {
+              dataType: 'Lead',
+              content: 'collect lead data',
+            },
+          },
+        },
+        {
+          id: 'data-game',
+          data: {
+            name: 'Data',
+            inputs: {
+              dataType: 'Question',
+              content: 'What is MMOOMM?',
+              enablePoints: true,
+              pointsValue: 5,
+            },
+          },
+        },
+      ],
+      edges: [
+        { id: 'edge-auth-game', source: 'space-auth', target: 'space-game' },
+        { id: 'edge-auth-data', source: 'data-auth', target: 'space-auth' },
+        { id: 'edge-game-data', source: 'data-game', target: 'space-game' },
+        { id: 'edge-entity-space', source: 'entity-game', target: 'space-game' },
+      ],
+    }
+
+    const { multiScene } = UPDLProcessor.processFlowData(JSON.stringify(flowData))
+
+    expect(multiScene).toBeDefined()
+    expect(multiScene?.totalScenes).toBe(3)
+    expect(multiScene?.scenes[0].spaceData.leadCollection.collectName).toBe(true)
+    expect(multiScene?.scenes[1].spaceData.showPoints).toBe(true)
+    expect(multiScene?.scenes[1].dataNodes[0].pointsValue).toBe(5)
+    expect(multiScene?.scenes[2].isResultsScene).toBe(true)
+  })
+})

--- a/apps/universo-platformo-utils/base/vitest.config.ts
+++ b/apps/universo-platformo-utils/base/vitest.config.ts
@@ -1,0 +1,41 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import baseConfig from '../../../tools/testing/frontend/vitest.base.config'
+import { loadTsconfigAliases } from '../../../tools/testing/frontend/loadTsconfigAliases'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const srcDir = path.resolve(__dirname, 'src')
+const tsconfigAliases = loadTsconfigAliases(path.resolve(__dirname, 'tsconfig.json'), __dirname)
+
+const sanitizedBaseConfig = {
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test ?? {}),
+    setupFiles: [],
+  },
+}
+
+export default mergeConfig(
+  sanitizedBaseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        ...tsconfigAliases,
+        '@': srcDir,
+      },
+    },
+    test: {
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      exclude: ['dist/**', 'node_modules/**'],
+      setupFiles: [],
+      coverage: {
+        enabled: false,
+        reporter: ['text', 'json-summary'],
+        reportsDirectory: path.resolve(__dirname, 'coverage'),
+      },
+    },
+  }),
+)

--- a/apps/updl/base/README.md
+++ b/apps/updl/base/README.md
@@ -100,6 +100,14 @@ The build process consists of two stages:
 -   `pnpm dev` - Runs the build in development mode with file watching.
 -   `pnpm lint` - Checks the code with the linter.
 
+### Testing
+
+```bash
+pnpm --filter updl test
+```
+
+The Vitest suite validates Flowise node ports and lead-collection flags to keep the editor experience aligned with the README guidance.
+
 ## Focus of the Module
 
 This module is intentionally focused **only on node definitions**:

--- a/apps/updl/base/package.json
+++ b/apps/updl/base/package.json
@@ -8,7 +8,8 @@
         "clean": "rimraf dist",
         "build": "pnpm run clean && tsc && gulp",
         "dev": "tsc -w",
-        "lint": "eslint --ext .ts,.tsx src/"
+        "lint": "eslint --ext .ts,.tsx src/",
+        "test": "vitest run --config vitest.config.ts"
     },
     "keywords": [
         "updl",
@@ -31,6 +32,7 @@
         "@types/node": "^20.11.17",
         "eslint": "^8.56.0",
         "gulp": "^4.0.2",
-        "rimraf": "^5.0.5"
+        "rimraf": "^5.0.5",
+        "vitest": "^2.1.4"
     }
 }

--- a/apps/updl/base/src/nodes/space/__tests__/SpaceNode.test.ts
+++ b/apps/updl/base/src/nodes/space/__tests__/SpaceNode.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { SpaceNode } from '../SpaceNode'
+
+describe('SpaceNode', () => {
+  it('exposes lead collection toggles described in the README', () => {
+    const node = new SpaceNode()
+
+    const collectName = node.inputs.find((input) => input.name === 'collectLeadName')
+    const collectEmail = node.inputs.find((input) => input.name === 'collectLeadEmail')
+    const collectPhone = node.inputs.find((input) => input.name === 'collectLeadPhone')
+
+    expect(collectName?.type).toBe('boolean')
+    expect(collectEmail?.type).toBe('boolean')
+    expect(collectPhone?.type).toBe('boolean')
+    expect(collectName?.additionalParams).toBe(true)
+  })
+
+  it('maps connection ports for core UPDL nodes when converted to UPDL format', () => {
+    const node = new SpaceNode()
+
+    const updlNode = node.toUPDLNode({
+      id: 'space-1',
+      inputs: {},
+      positionX: 0,
+      positionY: 0,
+    } as any)
+
+    const portIds = updlNode.metadata?.inputs?.map((port: any) => port.id) ?? []
+
+    expect(portIds).toContain('spaces')
+    expect(portIds).toContain('data')
+    expect(portIds).toContain('entities')
+    expect(portIds).toContain('universo')
+  })
+})

--- a/apps/updl/base/src/nodes/space/__tests__/SpaceNode.test.ts
+++ b/apps/updl/base/src/nodes/space/__tests__/SpaceNode.test.ts
@@ -1,6 +1,43 @@
 import { describe, expect, it } from 'vitest'
 
+import type { INodeData } from '../../interfaces'
+import type { UPDLNodePort } from '../../../interfaces/UPDLInterfaces'
 import { SpaceNode } from '../SpaceNode'
+
+const createNodeData = (overrides?: Partial<INodeData>): INodeData => ({
+  id: 'space-1',
+  inputs: {},
+  positionX: 0,
+  positionY: 0,
+  ...overrides,
+})
+
+const isUPDLNodePort = (value: unknown): value is UPDLNodePort => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  return 'id' in value && 'name' in value && 'type' in value
+}
+
+type MetadataWithInputs = { inputs?: unknown }
+
+const hasInputs = (metadata: unknown): metadata is MetadataWithInputs =>
+  typeof metadata === 'object' && metadata !== null && 'inputs' in metadata
+
+const extractInputPorts = (metadata: unknown): UPDLNodePort[] => {
+  if (!hasInputs(metadata)) {
+    return []
+  }
+
+  const { inputs } = metadata
+
+  if (!Array.isArray(inputs)) {
+    return []
+  }
+
+  return inputs.filter(isUPDLNodePort)
+}
 
 describe('SpaceNode', () => {
   it('exposes lead collection toggles described in the README', () => {
@@ -19,14 +56,9 @@ describe('SpaceNode', () => {
   it('maps connection ports for core UPDL nodes when converted to UPDL format', () => {
     const node = new SpaceNode()
 
-    const updlNode = node.toUPDLNode({
-      id: 'space-1',
-      inputs: {},
-      positionX: 0,
-      positionY: 0,
-    } as any)
+    const updlNode = node.toUPDLNode(createNodeData())
 
-    const portIds = updlNode.metadata?.inputs?.map((port: any) => port.id) ?? []
+    const portIds = extractInputPorts(updlNode.metadata).map((port) => port.id)
 
     expect(portIds).toContain('spaces')
     expect(portIds).toContain('data')

--- a/apps/updl/base/vitest.config.ts
+++ b/apps/updl/base/vitest.config.ts
@@ -1,0 +1,41 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import baseConfig from '../../../tools/testing/frontend/vitest.base.config'
+import { loadTsconfigAliases } from '../../../tools/testing/frontend/loadTsconfigAliases'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const srcDir = path.resolve(__dirname, 'src')
+const tsconfigAliases = loadTsconfigAliases(path.resolve(__dirname, 'tsconfig.json'), __dirname)
+
+const sanitizedBaseConfig = {
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test ?? {}),
+    setupFiles: [],
+  },
+}
+
+export default mergeConfig(
+  sanitizedBaseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        ...tsconfigAliases,
+        '@': srcDir,
+      },
+    },
+    test: {
+      environment: 'node',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      exclude: ['dist/**', 'node_modules/**'],
+      setupFiles: [],
+      coverage: {
+        enabled: false,
+        reporter: ['text', 'json-summary'],
+        reportsDirectory: path.resolve(__dirname, 'coverage'),
+      },
+    },
+  }),
+)


### PR DESCRIPTION
Fixes #433 Add Vitest regression coverage for core processors.

# Description

Add Vitest configurations and regression suites for UPDL serialization utilities, AR.js quiz builders, and PlayCanvas helpers.

## Changes Made

- Added reusable Vitest configs for utils, types, UPDL, quiz, and MMOOMM template packages with workspace-aware aliases.
- Covered UPDLProcessor flow parsing, ARJSQuizBuilder multi-scene rendering, and ModeDetector heuristics with targeted unit tests.
- Updated package scripts and READMEs to document running the new suites without touching build artifacts in `dist/`.

## Additional Work

This section includes supplementary work completed as part of this PR:

- Adjusted package manifests to include Vitest dependencies and commands.
- Ensured shared configs ignore `dist/` outputs and skip frontend-only setup files.
- Documented workspace test commands across affected packages.

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #433 Add Vitest regression coverage for core processors.

# Описание

Добавлены конфигурации Vitest и регрессионные наборы для сериализации UPDL, AR.js билдеров и вспомогательных модулей PlayCanvas.

## Внесенные изменения

- Добавлены переиспользуемые конфиги Vitest для пакетов utils, types, UPDL, quiz и MMOOMM с учётом рабочих пространств.
- Покрыты модульными тестами разбор UPDLProcessor, мульти-сценовый рендер ARJSQuizBuilder и эвристики ModeDetector.
- Обновлены скрипты пакетов и README с инструкциями по запуску новых наборов без затрагивания артефактов сборки в `dist/`.

## Дополнительная работа

Этот раздел включает дополнительную работу, выполненную в рамках данного PR:

- Обновлены манифесты пакетов для добавления зависимостей и команд Vitest.
- Настроены общие конфигурации для игнорирования выходов `dist/` и пропуска фронтендовых setup-файлов.
- Задокументированы команды запуска тестов в затронутых пакетах.

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>

------
https://chatgpt.com/codex/tasks/task_e_68ccb7c0d66c8323a11d3178ee699b04