### PR TITLE
GH447 Fix Space Builder dialog hook order mismatch

### DIFF
--- a/apps/space-builder-frt/base/src/components/SpaceBuilderDialog.tsx
+++ b/apps/space-builder-frt/base/src/components/SpaceBuilderDialog.tsx
@@ -357,8 +357,7 @@ export const SpaceBuilderDialog: React.FC<SpaceBuilderDialogProps> = ({ open, on
         [busy, manualApplyBusy, onClose]
     )
 
-    const isDialogVisible = open
-    if (!isDialogVisible) return null
+    if (!open) return null
 
     const manualPreviewValue = manualMode ? manualText : previewText
     const disableConfigure = busy || manualApplyBusy || hasPendingManual

--- a/apps/space-builder-frt/base/src/components/SpaceBuilderDialog.tsx
+++ b/apps/space-builder-frt/base/src/components/SpaceBuilderDialog.tsx
@@ -636,7 +636,7 @@ export const SpaceBuilderDialog: React.FC<SpaceBuilderDialogProps> = ({ open, on
     return (
         <>
             <Dialog
-                open={isDialogVisible}
+                open={open}
                 onClose={handleDialogClose}
                 fullWidth
                 maxWidth='md'

--- a/apps/space-builder-frt/base/src/components/SpaceBuilderDialog.tsx
+++ b/apps/space-builder-frt/base/src/components/SpaceBuilderDialog.tsx
@@ -346,11 +346,6 @@ export const SpaceBuilderDialog: React.FC<SpaceBuilderDialogProps> = ({ open, on
 
     const hasPendingManual = manualMode && manualTouched
 
-    if (!open) return null
-    const manualPreviewValue = manualMode ? manualText : previewText
-    const disableConfigure = busy || manualApplyBusy || hasPendingManual
-    const disableGenerate = busy || manualApplyBusy || !quizPlan || hasPendingManual
-
     const handleDialogClose = useCallback(
         (event: React.SyntheticEvent | Event, _reason: 'backdropClick' | 'escapeKeyDown') => {
             if (busy || manualApplyBusy) {
@@ -361,6 +356,13 @@ export const SpaceBuilderDialog: React.FC<SpaceBuilderDialogProps> = ({ open, on
         },
         [busy, manualApplyBusy, onClose]
     )
+
+    const isDialogVisible = open
+    if (!isDialogVisible) return null
+
+    const manualPreviewValue = manualMode ? manualText : previewText
+    const disableConfigure = busy || manualApplyBusy || hasPendingManual
+    const disableGenerate = busy || manualApplyBusy || !quizPlan || hasPendingManual
 
     function handleManualToggle() {
         if (!quizPlan) return
@@ -635,7 +637,7 @@ export const SpaceBuilderDialog: React.FC<SpaceBuilderDialogProps> = ({ open, on
     return (
         <>
             <Dialog
-                open={open}
+                open={isDialogVisible}
                 onClose={handleDialogClose}
                 fullWidth
                 maxWidth='md'

--- a/apps/space-builder-frt/base/src/components/__tests__/SpaceBuilderDialog.manual.test.tsx
+++ b/apps/space-builder-frt/base/src/components/__tests__/SpaceBuilderDialog.manual.test.tsx
@@ -3,7 +3,7 @@ import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders, screen, waitFor, fireEvent, createTestI18n } from '@testing/frontend'
 
-import { SpaceBuilderDialog } from '../SpaceBuilderDialog'
+import { SpaceBuilderDialog, type SpaceBuilderDialogProps } from '../SpaceBuilderDialog'
 import type { QuizPlan } from '../../hooks/useSpaceBuilder'
 import enTranslations from '../../i18n/locales/en/main.json'
 
@@ -143,15 +143,19 @@ describe('SpaceBuilderDialog manual safeguards', () => {
             }
         })
 
+        const dialogProps: Omit<SpaceBuilderDialogProps, 'open'> = {
+            onClose,
+            onApply,
+            models: [
+                { key: 'model-a', label: 'Model A', provider: 'openai', modelName: 'gpt-4', credentialId: 'cred-a' }
+            ],
+            onError
+        }
+
         const initialRender = await renderWithProviders(
             <SpaceBuilderDialog
                 open={false}
-                onClose={onClose}
-                onApply={onApply}
-                models={[
-                    { key: 'model-a', label: 'Model A', provider: 'openai', modelName: 'gpt-4', credentialId: 'cred-a' }
-                ]}
-                onError={onError}
+                {...dialogProps}
             />,
             { i18n }
         )
@@ -162,12 +166,7 @@ describe('SpaceBuilderDialog manual safeguards', () => {
             initialRender.rerender(
                 <SpaceBuilderDialog
                     open
-                    onClose={onClose}
-                    onApply={onApply}
-                    models={[
-                        { key: 'model-a', label: 'Model A', provider: 'openai', modelName: 'gpt-4', credentialId: 'cred-a' }
-                    ]}
-                    onError={onError}
+                    {...dialogProps}
                 />
             )
         }).not.toThrow()

--- a/apps/space-builder-frt/base/src/components/__tests__/SpaceBuilderDialog.manual.test.tsx
+++ b/apps/space-builder-frt/base/src/components/__tests__/SpaceBuilderDialog.manual.test.tsx
@@ -133,6 +133,48 @@ describe('SpaceBuilderDialog manual safeguards', () => {
         vi.unstubAllGlobals()
     })
 
+    it('keeps hook order stable when opening after an initial closed render', async () => {
+        const onClose = vi.fn()
+        const onApply = vi.fn()
+        const onError = vi.fn()
+        const i18n = await createTestI18n({
+            resources: {
+                en: { translation: enTranslations }
+            }
+        })
+
+        const initialRender = await renderWithProviders(
+            <SpaceBuilderDialog
+                open={false}
+                onClose={onClose}
+                onApply={onApply}
+                models={[
+                    { key: 'model-a', label: 'Model A', provider: 'openai', modelName: 'gpt-4', credentialId: 'cred-a' }
+                ]}
+                onError={onError}
+            />,
+            { i18n }
+        )
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+        expect(() => {
+            initialRender.rerender(
+                <SpaceBuilderDialog
+                    open
+                    onClose={onClose}
+                    onApply={onApply}
+                    models={[
+                        { key: 'model-a', label: 'Model A', provider: 'openai', modelName: 'gpt-4', credentialId: 'cred-a' }
+                    ]}
+                    onError={onError}
+                />
+            )
+        }).not.toThrow()
+
+        await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    })
+
     it('disables revise action while manual edits are pending', async () => {
         const onClose = vi.fn()
         const { user } = await renderPreview(onClose)


### PR DESCRIPTION
Fixes #447 Stabilize Space Builder dialog hook order.

# Description

This PR stabilizes the hook sequence in `SpaceBuilderDialog` so that the dialog no longer crashes when it is initially rendered in a closed state and then opened from the Space Builder FAB.

## Changes Made

- Move the `handleDialogClose` hook above the visibility guard and introduce an `isDialogVisible` flag to keep the hook order constant.
- Update the dialog JSX to rely on the derived visibility flag for clarity.
- Add a regression test that renders the dialog closed first, then opens it to ensure no hook-order mismatch occurs.

## Additional Work

This section includes supplementary work completed as part of this PR:

- Added a new automated test covering the closed-to-open toggle scenario.

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #447 Stabilize Space Builder dialog hook order.

# Описание

В этом PR стабилизируется последовательность хуков в `SpaceBuilderDialog`, чтобы диалог больше не падал при изначальном рендере в закрытом состоянии и последующем открытии из Space Builder FAB.

## Внесенные изменения

- Перемещён хук `handleDialogClose` выше гарда видимости и добавлен флаг `isDialogVisible`, чтобы порядок хуков оставался постоянным.
- Обновлена JSX-разметка диалога для использования производного флага видимости.
- Добавлен регрессионный тест, который сначала рендерит диалог закрытым, а затем открывает его, убеждаясь в отсутствии рассинхронизации хуков.

## Дополнительная работа

Этот раздел включает дополнительную работу, выполненную в рамках данного PR:

- Добавлен новый автоматический тест, покрывающий сценарий переключения из закрытого состояния в открытое.

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>