### PR TITLE
GH454 Restore chatflow adapter type safety

### DIFF
--- a/apps/spaces-srv/base/src/database/entities/Canvas.ts
+++ b/apps/spaces-srv/base/src/database/entities/Canvas.ts
@@ -72,5 +72,5 @@ export class Canvas {
 
     // Relationship with SpaceCanvas
     @OneToMany(() => SpaceCanvas, spaceCanvas => spaceCanvas.canvas)
-    spaceCanvases!: SpaceCanvas[]
+    spaceCanvases?: SpaceCanvas[]
 }

--- a/apps/spaces-srv/base/src/index.ts
+++ b/apps/spaces-srv/base/src/index.ts
@@ -7,6 +7,13 @@ export { SpacesController } from './controllers/spacesController'
 // Services
 export { SpacesService } from './services/spacesService'
 export { purgeSpacesForUnik, cleanupCanvasStorage } from './services/purgeUnikSpaces'
+export {
+    LegacyChatflowsService,
+    type LegacyChatflowDependencies,
+    type LegacyChatflowEntities,
+    type LegacyChatflowMetricsConfig,
+    type LegacyChatflowPublicCanvas
+} from './services/legacyChatflowsService'
 
 // Types
 export * from './types'

--- a/apps/spaces-srv/base/src/services/legacyChatflowsService.ts
+++ b/apps/spaces-srv/base/src/services/legacyChatflowsService.ts
@@ -1,0 +1,529 @@
+import { DataSource, EntityTarget, QueryRunner, Repository } from 'typeorm'
+import { StatusCodes } from 'http-status-codes'
+import { validate as validateUuid } from 'uuid'
+import { randomUUID } from 'crypto'
+import { Canvas, ChatflowType } from '../database/entities/Canvas'
+import { Space } from '../database/entities/Space'
+import { SpaceCanvas } from '../database/entities/SpaceCanvas'
+
+export interface LegacyChatflowEntities {
+    chatMessage: EntityTarget<any>
+    chatMessageFeedback: EntityTarget<any>
+    upsertHistory: EntityTarget<any>
+}
+
+export interface LegacyChatflowMetricsConfig {
+    chatflowCreatedCounter: string
+    agentflowCreatedCounter: string
+    successStatusLabel: string
+}
+
+export interface LegacyChatflowDependencies {
+    errorFactory: (status: number, message: string) => Error
+    removeFolderFromStorage: (chatflowId: string) => Promise<void>
+    updateDocumentStoreUsage: (chatflowId: string, usage?: string) => Promise<void>
+    containsBase64File: (payload: { flowData: string }) => boolean
+    updateFlowDataWithFilePaths: (chatflowId: string, flowData: string) => Promise<string>
+    constructGraphs: (nodes: any[], edges: any[]) => { graph: any; nodeDependencies: Record<string, number> }
+    getEndingNodes: (nodeDependencies: Record<string, number>, graph: any, nodes: any[]) => any[]
+    isFlowValidForStream: (nodes: any[], nodeData: any) => boolean
+    getAppVersion: () => Promise<string>
+    getTelemetryFlowObj: (nodes: any[], edges: any[]) => unknown
+    telemetry?: { sendTelemetry: (eventName: string, payload: Record<string, unknown>) => Promise<void> }
+    metricsProvider?: { incrementCounter: (metric: string, labels?: Record<string, unknown>) => void }
+    metricsConfig: LegacyChatflowMetricsConfig
+    logger: { warn: (...args: any[]) => void; error: (...args: any[]) => void }
+    getUploadsConfig: (chatflowId: string) => Promise<any>
+}
+
+export interface LegacyChatflowPublicCanvas {
+    id: string
+    name: string
+    flowData: string
+    isPublic?: boolean
+    type?: ChatflowType
+    unikId?: string
+    versionGroupId: string
+    versionUuid: string
+    versionLabel: string
+    versionDescription?: string
+    versionIndex: number
+    isActive: boolean
+}
+
+export class LegacyChatflowsService {
+    constructor(
+        private readonly getDataSource: () => DataSource,
+        private readonly entities: LegacyChatflowEntities,
+        private readonly deps: LegacyChatflowDependencies
+    ) {}
+
+    private get dataSource(): DataSource {
+        return this.getDataSource()
+    }
+
+    private get canvasRepository(): Repository<Canvas> {
+        return this.dataSource.getRepository(Canvas)
+    }
+
+    private get spaceRepository(): Repository<Space> {
+        return this.dataSource.getRepository(Space)
+    }
+
+    private get spaceCanvasRepository(): Repository<SpaceCanvas> {
+        return this.dataSource.getRepository(SpaceCanvas)
+    }
+
+    private get chatMessageRepository(): Repository<any> {
+        return this.dataSource.getRepository(this.entities.chatMessage)
+    }
+
+    private get chatMessageFeedbackRepository(): Repository<any> {
+        return this.dataSource.getRepository(this.entities.chatMessageFeedback)
+    }
+
+    private get upsertHistoryRepository(): Repository<any> {
+        return this.dataSource.getRepository(this.entities.upsertHistory)
+    }
+
+    private ensureVersioningFields(chatflow: Partial<Canvas>): void {
+        if (!chatflow.versionGroupId) {
+            chatflow.versionGroupId = randomUUID()
+        }
+        if (!chatflow.versionUuid) {
+            chatflow.versionUuid = randomUUID()
+        }
+        if (!chatflow.versionLabel) {
+            chatflow.versionLabel = 'v1'
+        }
+        if (typeof chatflow.versionIndex !== 'number' || Number.isNaN(chatflow.versionIndex)) {
+            chatflow.versionIndex = 1
+        }
+        if (typeof chatflow.isActive !== 'boolean') {
+            chatflow.isActive = true
+        }
+    }
+
+    private createError(status: number, message: string): Error {
+        return this.deps.errorFactory(status, message)
+    }
+
+    async checkIfChatflowIsValidForStreaming(chatflowId: string): Promise<{ isStreaming: boolean }> {
+        try {
+            const chatflow = await this.canvasRepository.findOne({ where: { id: chatflowId } })
+            if (!chatflow) {
+                throw this.createError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
+            }
+
+            let chatflowConfig: Record<string, any> = {}
+            if (chatflow.chatbotConfig) {
+                chatflowConfig = JSON.parse(chatflow.chatbotConfig)
+                if (chatflowConfig?.postProcessing?.enabled === true) {
+                    return { isStreaming: false }
+                }
+            }
+
+            const parsedFlowData = JSON.parse(chatflow.flowData)
+            const nodes = parsedFlowData.nodes ?? []
+            const edges = parsedFlowData.edges ?? []
+            const { graph, nodeDependencies } = this.deps.constructGraphs(nodes, edges)
+            const endingNodes = this.deps.getEndingNodes(nodeDependencies, graph, nodes)
+
+            let isStreaming = false
+            for (const endingNode of endingNodes) {
+                const endingNodeData = endingNode.data
+                const isEndingNode = endingNodeData?.outputs?.output === 'EndingNode'
+                if (isEndingNode) {
+                    return { isStreaming: false }
+                }
+                isStreaming = this.deps.isFlowValidForStream(nodes, endingNodeData)
+            }
+
+            if (endingNodes.filter((node: any) => node.data.category === 'Multi Agents' || node.data.category === 'Sequential Agents').length > 0) {
+                return { isStreaming: true }
+            }
+
+            return { isStreaming }
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.checkIfChatflowIsValidForStreaming - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async checkIfChatflowIsValidForUploads(chatflowId: string): Promise<any> {
+        try {
+            return await this.deps.getUploadsConfig(chatflowId)
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.checkIfChatflowIsValidForUploads - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async deleteChatflow(chatflowId: string, unikId?: string): Promise<any> {
+        try {
+            let chatflow: Canvas | null
+            if (unikId) {
+                chatflow = await this.canvasRepository
+                    .createQueryBuilder('canvas')
+                    .innerJoin('spaces_canvases', 'sc', 'sc.canvas_id = canvas.id')
+                    .innerJoin('spaces', 'space', 'space.id = sc.space_id')
+                    .where('canvas.id = :id', { id: chatflowId })
+                    .andWhere('space.unik_id = :unikId', { unikId })
+                    .getOne()
+            } else {
+                chatflow = await this.canvasRepository.findOne({ where: { id: chatflowId } })
+            }
+
+            if (!chatflow) {
+                throw this.createError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
+            }
+
+            const deleteResult = await this.canvasRepository.delete({ id: chatflowId })
+
+            try {
+                await this.deps.removeFolderFromStorage(chatflowId)
+                await this.deps.updateDocumentStoreUsage(chatflowId, undefined)
+                await this.chatMessageRepository.delete({ chatflowid: chatflowId })
+                await this.chatMessageFeedbackRepository.delete({ chatflowid: chatflowId })
+                await this.upsertHistoryRepository.delete({ chatflowid: chatflowId })
+            } catch (cleanupError) {
+                this.deps.logger.error(`[spaces-srv]: Error deleting file storage for chatflow ${chatflowId}: ${cleanupError}`)
+            }
+
+            return deleteResult
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.deleteChatflow - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async getAllChatflows(type?: ChatflowType, unikId?: string): Promise<Canvas[]> {
+        try {
+            let queryBuilder = this.canvasRepository.createQueryBuilder('canvas')
+
+            if (unikId) {
+                queryBuilder = queryBuilder
+                    .innerJoin('spaces_canvases', 'sc', 'sc.canvas_id = canvas.id')
+                    .innerJoin('spaces', 'space', 'space.id = sc.space_id')
+                    .where('space.unik_id = :unikId', { unikId })
+            }
+
+            if (type === 'MULTIAGENT') {
+                queryBuilder = queryBuilder.andWhere('canvas.type = :type', { type: 'MULTIAGENT' })
+            } else if (type === 'ASSISTANT') {
+                queryBuilder = queryBuilder.andWhere('canvas.type = :type', { type: 'ASSISTANT' })
+            } else if (type === 'CHATFLOW') {
+                queryBuilder = queryBuilder.andWhere('(canvas.type = :type OR canvas.type IS NULL)', { type: 'CHATFLOW' })
+            }
+
+            return await queryBuilder.getMany()
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.getAllChatflows - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async getChatflowByApiKey(apiKeyId: string, keyonly?: string): Promise<Canvas[]> {
+        try {
+            let query = this.canvasRepository
+                .createQueryBuilder('canvas')
+                .where('canvas.apikeyid = :apikeyid', { apikeyid: apiKeyId })
+
+            if (keyonly === undefined) {
+                query = query.orWhere('canvas.apikeyid IS NULL').orWhere("canvas.apikeyid = ''")
+            }
+
+            const results = await query.orderBy('canvas.name', 'ASC').getMany()
+            if (results.length < 1) {
+                throw this.createError(StatusCodes.NOT_FOUND, 'Chatflow not found in the database!')
+            }
+            return results
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.getChatflowByApiKey - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async getChatflowById(chatflowId: string, unikId?: string): Promise<Canvas> {
+        try {
+            let chatflow: Canvas | null
+            if (unikId) {
+                chatflow = await this.canvasRepository
+                    .createQueryBuilder('canvas')
+                    .innerJoin('spaces_canvases', 'sc', 'sc.canvas_id = canvas.id')
+                    .innerJoin('spaces', 'space', 'space.id = sc.space_id')
+                    .where('canvas.id = :id', { id: chatflowId })
+                    .andWhere('space.unik_id = :unikId', { unikId })
+                    .getOne()
+            } else {
+                chatflow = await this.canvasRepository.findOne({ where: { id: chatflowId } })
+            }
+
+            if (!chatflow) {
+                throw this.createError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found in the database!`)
+            }
+
+            return chatflow
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.getChatflowById - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    private async checkAndUpdateDocumentStoreUsage(chatflow: Canvas): Promise<void> {
+        const parsedFlowData = JSON.parse(chatflow.flowData ?? '{}') as { nodes?: any[] }
+        const nodes = Array.isArray(parsedFlowData?.nodes) ? parsedFlowData.nodes : []
+        const documentStoreNode =
+            nodes.length > 0 && nodes.find((node: any) => node?.data?.name === 'documentStore')
+        const selectedStore = documentStoreNode?.data?.inputs?.selectedStore
+
+        if (typeof selectedStore !== 'string' || selectedStore.length === 0) {
+            await this.deps.updateDocumentStoreUsage(chatflow.id, undefined)
+            return
+        }
+
+        await this.deps.updateDocumentStoreUsage(chatflow.id, selectedStore)
+    }
+
+    async saveChatflow(newChatFlow: Partial<Canvas>): Promise<Canvas> {
+        try {
+            this.ensureVersioningFields(newChatFlow)
+
+            let saved: Canvas
+
+            if (newChatFlow.flowData && this.deps.containsBase64File({ flowData: newChatFlow.flowData })) {
+                const incomingFlowData = newChatFlow.flowData
+                newChatFlow.flowData = JSON.stringify({})
+                const entity = this.canvasRepository.create(newChatFlow)
+                const step1Results = await this.canvasRepository.save(entity)
+
+                step1Results.flowData = await this.deps.updateFlowDataWithFilePaths(step1Results.id, incomingFlowData)
+                await this.checkAndUpdateDocumentStoreUsage(step1Results)
+                saved = await this.canvasRepository.save(step1Results)
+            } else {
+                const entity = this.canvasRepository.create(newChatFlow)
+                saved = await this.canvasRepository.save(entity)
+            }
+
+            try {
+                const spaceRepo = this.spaceRepository
+                const scRepo = this.spaceCanvasRepository
+
+                const existingSpace = await spaceRepo.findOne({ where: { id: saved.id } })
+                if (!existingSpace) {
+                    const baseSpacePayload: Record<string, unknown> = {
+                        id: saved.id,
+                        name: newChatFlow.name || 'Space',
+                        visibility: 'private'
+                    }
+                    const unikRelation = (newChatFlow as any)?.unik
+                    if (unikRelation) {
+                        baseSpacePayload.unik = unikRelation
+                    }
+                    const space = spaceRepo.create(baseSpacePayload as any)
+                    await spaceRepo.save(space)
+                }
+
+                const existsJunction =
+                    (await scRepo
+                        .createQueryBuilder('sc')
+                        .where('sc.space_id = :sid AND sc.version_group_id = :vgid', {
+                            sid: saved.id,
+                            vgid: saved.versionGroupId
+                        })
+                        .getCount()) > 0
+
+                if (!existsJunction) {
+                    const spaceCanvas = scRepo.create({
+                        sortOrder: 1,
+                        space: ({ id: saved.id } as Space),
+                        canvas: ({ id: saved.id } as Canvas),
+                        versionGroupId: saved.versionGroupId
+                    })
+                    await scRepo.save(spaceCanvas)
+                } else {
+                    await scRepo
+                        .createQueryBuilder()
+                        .update(SpaceCanvas)
+                        .set({
+                            canvas: ({ id: saved.id } as Canvas),
+                            versionGroupId: saved.versionGroupId
+                        })
+                        .where('space_id = :sid AND version_group_id = :vgid', {
+                            sid: saved.id,
+                            vgid: saved.versionGroupId
+                        })
+                        .execute()
+                }
+            } catch (linkErr) {
+                this.deps.logger.warn(
+                    `[spaces-srv]: Unable to ensure Space/Canvas relation for ${saved.id}: ${linkErr instanceof Error ? linkErr.message : String(linkErr)}`
+                )
+            }
+
+            if (this.deps.telemetry) {
+                await this.deps.telemetry.sendTelemetry('chatflow_created', {
+                    version: await this.deps.getAppVersion(),
+                    chatflowId: saved.id,
+                    flowGraph: this.deps.getTelemetryFlowObj(
+                        JSON.parse(saved.flowData)?.nodes,
+                        JSON.parse(saved.flowData)?.edges
+                    )
+                })
+            }
+
+            this.deps.metricsProvider?.incrementCounter(
+                saved?.type === 'MULTIAGENT'
+                    ? this.deps.metricsConfig.agentflowCreatedCounter
+                    : this.deps.metricsConfig.chatflowCreatedCounter,
+                { status: this.deps.metricsConfig.successStatusLabel }
+            )
+
+            return saved
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.saveChatflow - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async importChatflows(newChatflows: Partial<Canvas>[], queryRunner?: QueryRunner): Promise<any> {
+        try {
+            for (const data of newChatflows) {
+                if (data.id && !validateUuid(data.id)) {
+                    throw this.createError(StatusCodes.PRECONDITION_FAILED, 'Error: importChatflows - invalid id!')
+                }
+            }
+
+            const repository = queryRunner
+                ? queryRunner.manager.getRepository(Canvas)
+                : this.canvasRepository
+
+            if (newChatflows.length === 0) return
+
+            let ids = '('
+            let count = 0
+            const lastCount = newChatflows.length - 1
+            newChatflows.forEach((newChatflow) => {
+                ids += `'${newChatflow.id}'`
+                if (lastCount !== count) ids += ','
+                if (lastCount === count) ids += ')'
+                count += 1
+            })
+
+            const selectResponse = await repository.createQueryBuilder('cf').select('cf.id').where(`cf.id IN ${ids}`).getMany()
+            const foundIds = selectResponse.map((response) => response.id)
+
+            const prepChatflows: Partial<Canvas>[] = newChatflows.map((newChatflow) => {
+                let id = ''
+                if (newChatflow.id) id = newChatflow.id
+                let flowData = ''
+                if (newChatflow.flowData) flowData = newChatflow.flowData
+                if (foundIds.includes(id)) {
+                    newChatflow.id = undefined
+                    newChatflow.name = `${newChatflow.name ?? 'Canvas'} (1)`
+                }
+                newChatflow.flowData = JSON.stringify(JSON.parse(flowData))
+                this.ensureVersioningFields(newChatflow)
+                return newChatflow
+            })
+
+            return await repository.insert(prepChatflows)
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.saveChatflows - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async updateChatflow(chatflow: Canvas, updateChatFlow: Canvas, unikId?: string): Promise<Canvas> {
+        try {
+            if (updateChatFlow.flowData && this.deps.containsBase64File({ flowData: updateChatFlow.flowData })) {
+                updateChatFlow.flowData = await this.deps.updateFlowDataWithFilePaths(chatflow.id, updateChatFlow.flowData)
+            }
+
+            const merged = this.canvasRepository.merge(chatflow, updateChatFlow)
+            await this.checkAndUpdateDocumentStoreUsage(merged)
+            const saved = await this.canvasRepository.save(merged)
+
+            if (unikId) {
+                await this.spaceCanvasRepository
+                    .createQueryBuilder()
+                    .update(SpaceCanvas)
+                    .set({ canvas: ({ id: saved.id } as Canvas) })
+                    .where('canvas_id = :id', { id: saved.id })
+                    .execute()
+            }
+
+            return saved
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.updateChatflow - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+
+    async getSinglePublicChatflow(chatflowId: string): Promise<LegacyChatflowPublicCanvas> {
+        try {
+            const chatflow = await this.canvasRepository
+                .createQueryBuilder('canvas')
+                .leftJoin('spaces_canvases', 'sc', 'sc.canvas_id = canvas.id')
+                .leftJoin('spaces', 'space', 'space.id = sc.space_id')
+                .select([
+                    'canvas.id',
+                    'canvas.name',
+                    'canvas.flowData',
+                    'canvas.isPublic',
+                    'canvas.type',
+                    'canvas.versionGroupId',
+                    'canvas.versionUuid',
+                    'canvas.versionLabel',
+                    'canvas.versionDescription',
+                    'canvas.versionIndex',
+                    'canvas.isActive',
+                    'space.unik_id'
+                ])
+                .where('canvas.id = :id', { id: chatflowId })
+                .getRawOne()
+
+            if (!chatflow) {
+                throw this.createError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
+            }
+
+            return {
+                id: chatflow.canvas_id,
+                name: chatflow.canvas_name,
+                flowData: chatflow.canvas_flowData,
+                isPublic: chatflow.canvas_isPublic,
+                type: chatflow.canvas_type,
+                unikId: chatflow.space_unik_id ?? undefined,
+                versionGroupId: chatflow.canvas_version_group_id,
+                versionUuid: chatflow.canvas_version_uuid,
+                versionLabel: chatflow.canvas_version_label,
+                versionDescription: chatflow.canvas_version_description ?? undefined,
+                versionIndex: chatflow.canvas_version_index,
+                isActive: chatflow.canvas_is_active
+            }
+        } catch (error) {
+            throw this.createError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.getSinglePublicChatflow - ${error instanceof Error ? error.message : String(error)}`
+            )
+        }
+    }
+}

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,10 @@
+## 2025-09-24 — Chatflow alias bridge & service extraction
+
+- Introduced `CanvasId` alias plus helper mappers in `packages/server/src/Interface.ts`, ensuring every chatflow response now carries both `id` and `canvasId` while consumers gradually migrate terminology.
+- Replaced the legacy in-repo chatflows service with `LegacyChatflowsService` under `@universo/spaces-srv`, injecting Flowise dependencies so backend logic executes from the Spaces package while preserving telemetry, metrics, and document store updates.
+- Updated the server adapter to delegate CRUD calls to the Spaces service, keeping `/chatflows` routes functional but emitting Canvas-first payloads for downstream routers/controllers.
+- Embedded the Spaces router inside `createUniksRouter`, forwarding `/unik/:id/spaces` and `/unik/:id/canvases` through `@universo/spaces-srv` with optional rate limiting while preserving legacy chatflows mounts.
+
 ## 2025-09-23 — Localized default canvas handling
 
 - Canvas view keeps the temporary `temp` canvas entirely client-side: rename actions update local state, block PUTs until the space is persisted, and forward the chosen label when creating a space.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -18,6 +18,12 @@
 - Automated Jest suite `pnpm --filter @universo/spaces-srv test` passes across controller, routes, and service specs, validating new DTO paths.
 - Archived the temporary plan document after QA sign-off so future updates rely on the consolidated progress log.
 
+### 2025-09-24 — Spaces router embedded into Uniks
+
+- Mounted `createSpacesRoutes` directly inside the Uniks router so `/unik/:id/spaces` and `/unik/:id/canvases` reuse the Spaces service without an extra express mount layer.
+- Preserved the existing `ensureAuth` guard and wrapped a conditional rate limiter that only fires for `/spaces` and `/canvases` paths to avoid throttling unrelated legacy chatflow routes.
+- Extended Jest route tests to stub the Spaces router, verify bootstrapping, and ensure cleanup helpers continue to be mocked, keeping regression coverage for the new wiring.
+
 ### 2025-09-23 — Localized default canvas flow for new spaces
 
 - Canvas view keeps unsaved "temp" canvases in local state, allowing rename without hitting the API and forwarding the chosen label when the space is persisted.

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -34,6 +34,8 @@ export enum ChatMessageRatingType {
 /**
  * Databases
  */
+export type CanvasId = string
+
 export interface IChatFlow {
     id: string
     name: string
@@ -56,6 +58,21 @@ export interface IChatFlow {
     versionDescription?: string
     versionIndex: number
     isActive: boolean
+}
+
+export interface ICanvasFlow extends IChatFlow {
+    canvasId: CanvasId
+}
+
+export const withCanvasAlias = <T extends IChatFlow>(chatflow: T): T & ICanvasFlow => {
+    return {
+        ...chatflow,
+        canvasId: chatflow.id
+    }
+}
+
+export const withCanvasAliases = <T extends IChatFlow>(chatflows: T[]): Array<T & ICanvasFlow> => {
+    return chatflows.map((chatflow) => withCanvasAlias(chatflow))
 }
 
 export interface IChatMessage {

--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -101,7 +101,8 @@ const getChatflowByApiKey = async (req: Request, res: Response, next: NextFuncti
         if (!apikey) {
             return res.status(401).send('Unauthorized')
         }
-        const apiResponse = await chatflowsService.getChatflowByApiKey(apikey.id, req.query.keyonly)
+        const keyOnly = typeof req.query.keyonly === 'string' ? req.query.keyonly : undefined
+        const apiResponse = await chatflowsService.getChatflowByApiKey(apikey.id, keyOnly)
         return res.json(apiResponse)
     } catch (error) {
         next(error)
@@ -199,7 +200,8 @@ const updateChatflow = async (req: Request, res: Response, next: NextFunction) =
         const updateChatFlow = new ChatFlow()
         Object.assign(updateChatFlow, body)
 
-        updateChatFlow.id = chatflow.id
+        const canvasId = chatflow.canvasId
+        updateChatFlow.id = canvasId
         const rateLimiterManager = RateLimiterManager.getInstance()
         await rateLimiterManager.updateRateLimiter(updateChatFlow)
 

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -1,483 +1,126 @@
-import { ICommonObject, removeFolderFromStorage } from 'flowise-components'
-import { StatusCodes } from 'http-status-codes'
-import { QueryRunner } from 'typeorm'
-import { ChatflowType, IReactFlowObject } from '../../Interface'
+import { removeFolderFromStorage } from 'flowise-components'
+import { ChatflowType, ICanvasFlow, withCanvasAlias, withCanvasAliases } from '../../Interface'
 import { FLOWISE_COUNTER_STATUS, FLOWISE_METRIC_COUNTERS } from '../../Interface.Metrics'
-import { ChatFlow } from '../../database/entities/ChatFlow'
+import { LegacyChatflowsService } from '@universo/spaces-srv'
 import { ChatMessage } from '../../database/entities/ChatMessage'
 import { ChatMessageFeedback } from '../../database/entities/ChatMessageFeedback'
 import { UpsertHistory } from '../../database/entities/UpsertHistory'
-import { InternalFlowiseError } from '../../errors/internalFlowiseError'
-import { getErrorMessage } from '../../errors/utils'
+import { ChatFlow } from '../../database/entities/ChatFlow'
+import type { Canvas } from '@universo/spaces-srv'
 import documentStoreService from '../../services/documentstore'
 import { constructGraphs, getAppVersion, getEndingNodes, getTelemetryFlowObj, isFlowValidForStream } from '../../utils'
 import { containsBase64File, updateFlowDataWithFilePaths } from '../../utils/fileRepository'
 import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
 import { utilGetUploadsConfig } from '../../utils/getUploadsConfig'
+import { InternalFlowiseError } from '../../errors/internalFlowiseError'
+import { getErrorMessage } from '../../errors/utils'
 import logger from '../../utils/logger'
-import { validate } from 'uuid'
-import { Space, SpaceCanvas } from '@universo/spaces-srv'
-import type { Canvas } from '@universo/spaces-srv'
-import type { Unik } from '@universo/uniks-srv'
-import { randomUUID } from 'crypto'
 
-const ensureVersioningFields = (chatflow: Partial<ChatFlow>): void => {
-    if (!chatflow.versionGroupId) {
-        chatflow.versionGroupId = randomUUID()
-    }
-    if (!chatflow.versionUuid) {
-        chatflow.versionUuid = randomUUID()
-    }
-    if (!chatflow.versionLabel) {
-        chatflow.versionLabel = 'v1'
-    }
-    if (typeof chatflow.versionIndex !== 'number' || Number.isNaN(chatflow.versionIndex)) {
-        chatflow.versionIndex = 1
-    }
-    if (typeof chatflow.isActive !== 'boolean') {
-        chatflow.isActive = true
-    }
-}
-
-// Check if chatflow valid for streaming
-const checkIfChatflowIsValidForStreaming = async (chatflowId: string): Promise<any> => {
-    try {
-        const appServer = getRunningExpressApp()
-        //**
-        const chatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOneBy({
-            id: chatflowId
-        })
-        if (!chatflow) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
-        }
-
-        /* Check for post-processing settings, if available isStreamValid is always false */
-        let chatflowConfig: ICommonObject = {}
-        if (chatflow.chatbotConfig) {
-            chatflowConfig = JSON.parse(chatflow.chatbotConfig)
-            if (chatflowConfig?.postProcessing?.enabled === true) {
-                return { isStreaming: false }
-            }
-        }
-
-        /*** Get Ending Node with Directed Graph  ***/
-        const flowData = chatflow.flowData
-        const parsedFlowData: IReactFlowObject = JSON.parse(flowData)
-        const nodes = parsedFlowData.nodes
-        const edges = parsedFlowData.edges
-        const { graph, nodeDependencies } = constructGraphs(nodes, edges)
-
-        const endingNodes = getEndingNodes(nodeDependencies, graph, nodes)
-
-        let isStreaming = false
-        for (const endingNode of endingNodes) {
-            const endingNodeData = endingNode.data
-            const isEndingNode = endingNodeData?.outputs?.output === 'EndingNode'
-            // Once custom function ending node exists, flow is always unavailable to stream
-            if (isEndingNode) {
-                return { isStreaming: false }
-            }
-            isStreaming = isFlowValidForStream(nodes, endingNodeData)
-        }
-
-        // If it is a Multi/Sequential Agents, always enable streaming
-        if (endingNodes.filter((node) => node.data.category === 'Multi Agents' || node.data.category === 'Sequential Agents').length > 0) {
-            return { isStreaming: true }
-        }
-
-        const dbResponse = { isStreaming: isStreaming }
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.checkIfChatflowIsValidForStreaming - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-// Check if chatflow valid for uploads
-const checkIfChatflowIsValidForUploads = async (chatflowId: string): Promise<any> => {
-    try {
-        const dbResponse = await utilGetUploadsConfig(chatflowId)
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.checkIfChatflowIsValidForUploads - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const deleteChatflow = async (chatflowId: string, unikId?: string): Promise<any> => {
-    try {
-        const appServer = getRunningExpressApp()
-        let chatflow: ChatFlow | null
-        if (unikId) {
-            chatflow = await appServer.AppDataSource.getRepository(ChatFlow)
-                .createQueryBuilder('chatflow')
-                .innerJoin('spaces_canvases', 'sc', 'sc.canvas_id = chatflow.id')
-                .innerJoin('spaces', 'space', 'space.id = sc.space_id')
-                .where('chatflow.id = :id', { id: chatflowId })
-                .andWhere('space.unik_id = :unikId', { unikId })
-                .getOne()
-        } else {
-            chatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOneBy({ id: chatflowId })
-        }
-        if (!chatflow) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
-        }
-        const dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).delete({ id: chatflowId })
-        try {
-            // Delete all uploads corresponding to this chatflow
-            await removeFolderFromStorage(chatflowId)
-            await documentStoreService.updateDocumentStoreUsage(chatflowId, undefined)
-
-            // Delete all chat messages
-            await appServer.AppDataSource.getRepository(ChatMessage).delete({ chatflowid: chatflowId })
-
-            // Delete all chat feedback
-            await appServer.AppDataSource.getRepository(ChatMessageFeedback).delete({ chatflowid: chatflowId })
-
-            // Delete all upsert history
-            await appServer.AppDataSource.getRepository(UpsertHistory).delete({ chatflowid: chatflowId })
-        } catch (e) {
-            logger.error(`[server]: Error deleting file storage for chatflow ${chatflowId}: ${e}`)
-        }
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.deleteChatflow - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const getAllChatflows = async (type?: ChatflowType, unikId?: string): Promise<ChatFlow[]> => {
-    try {
-        const appServer = getRunningExpressApp()
-        let queryBuilder = appServer.AppDataSource.getRepository(ChatFlow).createQueryBuilder('chatflow')
-
-        // Apply filter by unikId if provided
-        if (unikId) {
-            queryBuilder = queryBuilder
-                .innerJoin('spaces_canvases', 'sc', 'sc.canvas_id = chatflow.id')
-                .innerJoin('spaces', 'space', 'space.id = sc.space_id')
-                .where('space.unik_id = :unikId', { unikId })
-        }
-
-        // Filter by type at the database level
-        if (type === 'MULTIAGENT') {
-            queryBuilder = queryBuilder.andWhere('chatflow.type = :type', { type: 'MULTIAGENT' })
-        } else if (type === 'ASSISTANT') {
-            queryBuilder = queryBuilder.andWhere('chatflow.type = :type', { type: 'ASSISTANT' })
-        } else if (type === 'CHATFLOW') {
-            queryBuilder = queryBuilder.andWhere('(chatflow.type = :type OR chatflow.type IS NULL)', { type: 'CHATFLOW' })
-        }
-        return await queryBuilder.getMany()
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.getAllChatflows - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const getChatflowByApiKey = async (apiKeyId: string, keyonly?: unknown): Promise<any> => {
-    try {
-        // Here we only get chatflows that are bounded by the apikeyid and chatflows that are not bounded by any apikey
-        const appServer = getRunningExpressApp()
-        let query = appServer.AppDataSource.getRepository(ChatFlow)
-            .createQueryBuilder('cf')
-            .where('cf.apikeyid = :apikeyid', { apikeyid: apiKeyId })
-        if (keyonly === undefined) {
-            query = query.orWhere('cf.apikeyid IS NULL').orWhere('cf.apikeyid = ""')
-        }
-
-        const dbResponse = await query.orderBy('cf.name', 'ASC').getMany()
-        if (dbResponse.length < 1) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow not found in the database!`)
-        }
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.getChatflowByApiKey - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const getChatflowById = async (chatflowId: string, unikId?: string): Promise<any> => {
-    try {
-        const appServer = getRunningExpressApp()
-        let dbResponse: ChatFlow | null
-        if (unikId) {
-            dbResponse = await appServer.AppDataSource.getRepository(ChatFlow)
-                .createQueryBuilder('chatflow')
-                .innerJoin('spaces_canvases', 'sc', 'sc.canvas_id = chatflow.id')
-                .innerJoin('spaces', 'space', 'space.id = sc.space_id')
-                .where('chatflow.id = :id', { id: chatflowId })
-                .andWhere('space.unik_id = :unikId', { unikId })
-                .getOne()
-        } else {
-            dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).findOneBy({ id: chatflowId })
-        }
-        if (!dbResponse) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found in the database!`)
-        }
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.getChatflowById - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const saveChatflow = async (newChatFlow: ChatFlow): Promise<any> => {
-    try {
-        const appServer = getRunningExpressApp()
-
-        ensureVersioningFields(newChatFlow)
-
-        let dbResponse: ChatFlow
-        if (containsBase64File(newChatFlow)) {
-            // we need a 2-step process, as we need to save the chatflow first and then update the file paths
-            // this is because we need the chatflow id to create the file paths
-
-            // step 1 - save with empty flowData
-            const incomingFlowData = newChatFlow.flowData
-            newChatFlow.flowData = JSON.stringify({})
-            const chatflow = appServer.AppDataSource.getRepository(ChatFlow).create(newChatFlow)
-            const step1Results = await appServer.AppDataSource.getRepository(ChatFlow).save(chatflow)
-
-            // step 2 - convert base64 to file paths and update the chatflow
-            step1Results.flowData = await updateFlowDataWithFilePaths(step1Results.id, incomingFlowData)
-            await _checkAndUpdateDocumentStoreUsage(step1Results)
-            dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).save(step1Results)
-        } else {
-            const chatflow = appServer.AppDataSource.getRepository(ChatFlow).create(newChatFlow)
-            dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).save(chatflow)
-        }
-        // Ensure Space and relationship exist (space.id == canvas.id, 1:1 default mapping)
-        try {
-            const spaceRepo = appServer.AppDataSource.getRepository(Space)
-            const scRepo = appServer.AppDataSource.getRepository(SpaceCanvas)
-
-            // upsert Space with the same id as canvas for backward compatibility
-            const existingSpace = await spaceRepo.findOne({ where: { id: dbResponse.id } })
-            if (!existingSpace) {
-                const space = spaceRepo.create({
-                    id: dbResponse.id,
-                    name: newChatFlow.name || 'Space',
-                    visibility: 'private',
-                    // link unik via relation object
-                    unik: ({ id: newChatFlow?.unik?.id } as Unik)
-                })
-                await spaceRepo.save(space)
-            }
-
-            // link Space ↔ Canvas in junction if not exists
-            const existsJunction = (await scRepo
-                .createQueryBuilder('sc')
-                .where('sc.space_id = :sid AND sc.version_group_id = :vgid', {
-                    sid: dbResponse.id,
-                    vgid: dbResponse.versionGroupId
-                })
-                .getCount()) > 0
-            if (!existsJunction) {
-                const spaceCanvas = scRepo.create({
-                    // default first position
-                    sortOrder: 1,
-                    space: ({ id: dbResponse.id } as Space),
-                    canvas: ({ id: dbResponse.id } as unknown as Canvas),
-                    versionGroupId: dbResponse.versionGroupId
-                })
-                await scRepo.save(spaceCanvas)
-            } else {
-                await scRepo
-                    .createQueryBuilder()
-                    .update(SpaceCanvas)
-                    .set({
-                        canvas: ({ id: dbResponse.id } as unknown as Canvas),
-                        versionGroupId: dbResponse.versionGroupId
-                    })
-                    .where('space_id = :sid AND version_group_id = :vgid', {
-                        sid: dbResponse.id,
-                        vgid: dbResponse.versionGroupId
-                    })
-                    .execute()
-            }
-        } catch (linkErr) {
-            logger.warn(`[server]: Unable to ensure Space/Canvas relation for ${dbResponse.id}: ${getErrorMessage(linkErr)}`)
-        }
-
-        await appServer.telemetry.sendTelemetry('chatflow_created', {
-            version: await getAppVersion(),
-            chatflowId: dbResponse.id,
-            flowGraph: getTelemetryFlowObj(JSON.parse(dbResponse.flowData)?.nodes, JSON.parse(dbResponse.flowData)?.edges)
-        })
-        appServer.metricsProvider?.incrementCounter(
-            dbResponse?.type === 'MULTIAGENT' ? FLOWISE_METRIC_COUNTERS.AGENTFLOW_CREATED : FLOWISE_METRIC_COUNTERS.CHATFLOW_CREATED,
-            { status: FLOWISE_COUNTER_STATUS.SUCCESS }
-        )
-
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.saveChatflow - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const importChatflows = async (newChatflows: Partial<ChatFlow>[], queryRunner?: QueryRunner): Promise<any> => {
-    try {
-        for (const data of newChatflows) {
-            if (data.id && !validate(data.id)) {
-                throw new InternalFlowiseError(StatusCodes.PRECONDITION_FAILED, `Error: importChatflows - invalid id!`)
-            }
-        }
-
-        const appServer = getRunningExpressApp()
-        const repository = queryRunner ? queryRunner.manager.getRepository(ChatFlow) : appServer.AppDataSource.getRepository(ChatFlow)
-
-        // step 1 - check whether file chatflows array is zero
-        if (newChatflows.length == 0) return
-
-        // step 2 - check whether ids are duplicate in database
-        let ids = '('
-        let count: number = 0
-        const lastCount = newChatflows.length - 1
-        newChatflows.forEach((newChatflow) => {
-            ids += `'${newChatflow.id}'`
-            if (lastCount != count) ids += ','
-            if (lastCount == count) ids += ')'
-            count += 1
-        })
-
-        const selectResponse = await repository.createQueryBuilder('cf').select('cf.id').where(`cf.id IN ${ids}`).getMany()
-        const foundIds = selectResponse.map((response) => {
-            return response.id
-        })
-
-        // step 3 - remove ids that are only duplicate
-        const prepChatflows: Partial<ChatFlow>[] = newChatflows.map((newChatflow) => {
-            let id: string = ''
-            if (newChatflow.id) id = newChatflow.id
-            let flowData: string = ''
-            if (newChatflow.flowData) flowData = newChatflow.flowData
-            if (foundIds.includes(id)) {
-                newChatflow.id = undefined
-                newChatflow.name += ' (1)'
-            }
-            newChatflow.flowData = JSON.stringify(JSON.parse(flowData))
-            ensureVersioningFields(newChatflow)
-            return newChatflow
-        })
-
-        // step 4 - transactional insert array of entities
-        const insertResponse = await repository.insert(prepChatflows)
-
-        return insertResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.saveChatflows - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-const updateChatflow = async (chatflow: ChatFlow, updateChatFlow: ChatFlow, unikId?: string): Promise<any> => {
-    try {
-        const appServer = getRunningExpressApp()
-        if (updateChatFlow.flowData && containsBase64File(updateChatFlow)) {
-            updateChatFlow.flowData = await updateFlowDataWithFilePaths(chatflow.id, updateChatFlow.flowData)
-        }
-        const newDbChatflow = appServer.AppDataSource.getRepository(ChatFlow).merge(chatflow, updateChatFlow)
-        await _checkAndUpdateDocumentStoreUsage(newDbChatflow)
-        const dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).save(newDbChatflow)
-
-        return dbResponse
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.updateChatflow - ${getErrorMessage(error)}`
-        )
-    }
-}
-
-// Get specific chatflow via id (PUBLIC endpoint, used when sharing chatbot link)
-const getSinglePublicChatflow = async (chatflowId: string): Promise<any> => {
-    try {
-        const appServer = getRunningExpressApp()
-        const dbResponse = await appServer.AppDataSource.getRepository(ChatFlow).findOneBy({
-            id: chatflowId
-        })
-
-        if (!dbResponse) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
-        }
-
-        // Check legacy isPublic flag first
-        if (dbResponse.isPublic) {
-            return dbResponse
-        }
-
-        // Check technology-specific isPublic flags in chatbotConfig
-        if (dbResponse.chatbotConfig) {
-            try {
-                const chatbotConfig = JSON.parse(dbResponse.chatbotConfig)
-                const hasPublicTech = Object.keys(chatbotConfig).some((tech) => chatbotConfig[tech]?.isPublic === true)
-
-                if (hasPublicTech) {
-                    return dbResponse
+const legacyService = new LegacyChatflowsService(
+    () => getRunningExpressApp().AppDataSource,
+    {
+        chatMessage: ChatMessage,
+        chatMessageFeedback: ChatMessageFeedback,
+        upsertHistory: UpsertHistory
+    },
+    {
+        errorFactory: (status, message) => new InternalFlowiseError(status, message),
+        removeFolderFromStorage,
+        updateDocumentStoreUsage: (chatflowId, usage) => documentStoreService.updateDocumentStoreUsage(chatflowId, usage),
+        containsBase64File: ({ flowData }) => containsBase64File({ flowData } as ChatFlow),
+        updateFlowDataWithFilePaths,
+        constructGraphs,
+        getEndingNodes,
+        isFlowValidForStream,
+        getAppVersion,
+        getTelemetryFlowObj,
+        telemetry: {
+            sendTelemetry: async (eventName, payload) => {
+                const telemetry = getRunningExpressApp().telemetry
+                if (telemetry) {
+                    await telemetry.sendTelemetry(eventName, payload)
                 }
-            } catch (parseError) {
-                // If parsing fails, fall back to legacy check already done above
             }
-        }
-
-        throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `Unauthorized`)
-    } catch (error) {
-        if (error instanceof InternalFlowiseError && error.statusCode === StatusCodes.UNAUTHORIZED) {
-            throw error
-        } else {
-            throw new InternalFlowiseError(
-                StatusCodes.INTERNAL_SERVER_ERROR,
-                `Error: chatflowsService.getSinglePublicChatflow - ${getErrorMessage(error)}`
-            )
-        }
+        },
+        metricsProvider: {
+            incrementCounter: (metric, labels) => {
+                const metrics = getRunningExpressApp().metricsProvider
+                metrics?.incrementCounter(metric as FLOWISE_METRIC_COUNTERS, labels)
+            }
+        },
+        metricsConfig: {
+            chatflowCreatedCounter: FLOWISE_METRIC_COUNTERS.CHATFLOW_CREATED,
+            agentflowCreatedCounter: FLOWISE_METRIC_COUNTERS.AGENTFLOW_CREATED,
+            successStatusLabel: FLOWISE_COUNTER_STATUS.SUCCESS
+        },
+        logger,
+        getUploadsConfig: utilGetUploadsConfig
     }
+)
+
+const checkIfChatflowIsValidForStreaming = async (chatflowId: string) => {
+    return legacyService.checkIfChatflowIsValidForStreaming(chatflowId)
 }
 
-// Universo Platformo | Unified bot config service method
+const checkIfChatflowIsValidForUploads = async (chatflowId: string) => {
+    return legacyService.checkIfChatflowIsValidForUploads(chatflowId)
+}
+
+const deleteChatflow = async (chatflowId: string, unikId?: string) => {
+    return legacyService.deleteChatflow(chatflowId, unikId)
+}
+
+const getAllChatflows = async (type?: ChatflowType, unikId?: string): Promise<ICanvasFlow[]> => {
+    const results = await legacyService.getAllChatflows(type, unikId)
+    return withCanvasAliases(results as unknown as ChatFlow[])
+}
+
+const getChatflowByApiKey = async (apiKeyId: string, keyonly?: string): Promise<ICanvasFlow[]> => {
+    const results = await legacyService.getChatflowByApiKey(apiKeyId, keyonly)
+    return withCanvasAliases(results as unknown as ChatFlow[])
+}
+
+const getChatflowById = async (chatflowId: string, unikId?: string): Promise<ICanvasFlow> => {
+    const chatflow = await legacyService.getChatflowById(chatflowId, unikId)
+    return withCanvasAlias(chatflow as unknown as ChatFlow)
+}
+
+const saveChatflow = async (newChatFlow: ChatFlow): Promise<ICanvasFlow> => {
+    const saved = await legacyService.saveChatflow(newChatFlow as unknown as Partial<Canvas>)
+    return withCanvasAlias(saved as unknown as ChatFlow)
+}
+
+const importChatflows = async (newChatflows: Partial<ChatFlow>[], queryRunner?: any) => {
+    return legacyService.importChatflows(newChatflows as Partial<Canvas>[], queryRunner)
+}
+
+const updateChatflow = async (chatflow: ChatFlow, updateChatFlow: ChatFlow, unikId?: string): Promise<ICanvasFlow> => {
+    const updated = await legacyService.updateChatflow(
+        chatflow as unknown as Canvas,
+        updateChatFlow as unknown as Canvas,
+        unikId
+    )
+    return withCanvasAlias(updated as unknown as ChatFlow)
+}
+
+const getSinglePublicChatflow = async (chatflowId: string): Promise<ICanvasFlow & { unikId?: string }> => {
+    const chatflow = await legacyService.getSinglePublicChatflow(chatflowId)
+    return withCanvasAlias({
+        ...chatflow,
+        id: chatflow.id
+    } as unknown as ChatFlow) as ICanvasFlow & { unikId?: string }
+}
+
 const getSinglePublicBotConfig = async (chatflowId: string): Promise<any> => {
     try {
         logger.info(`Getting unified Bot config for chatflow: ${chatflowId}`)
 
-        // Universo Platformo | Use the new bot service factory
         const botServiceFactory = require('../../services/bots').default
-
-        // Universo Platformo | Automatically determine the required service
         const botService = await botServiceFactory.getServiceByChatflowId(chatflowId)
-
-        // Universo Platformo | Delegate work to the specialized service
         return await botService.getBotConfig(chatflowId)
     } catch (error) {
         logger.error(`Error getting unified bot config: ${getErrorMessage(error)}`)
         return { error: getErrorMessage(error) }
-    }
-}
-
-const _checkAndUpdateDocumentStoreUsage = async (chatflow: ChatFlow) => {
-    const parsedFlowData: IReactFlowObject = JSON.parse(chatflow.flowData)
-    const nodes = parsedFlowData.nodes
-    // from the nodes array find if there is a node with name == documentStore)
-    const node = nodes.length > 0 && nodes.find((node) => node.data.name === 'documentStore')
-    if (!node || !node.data || !node.data.inputs || node.data.inputs['selectedStore'] === undefined) {
-        await documentStoreService.updateDocumentStoreUsage(chatflow.id, undefined)
-    } else {
-        await documentStoreService.updateDocumentStoreUsage(chatflow.id, node.data.inputs['selectedStore'])
     }
 }
 


### PR DESCRIPTION
Fixes #454 Consolidate Chatflow naming into Space applications.

# Description

Reconcile the chatflows server adapter with the Spaces legacy service so the refactored Canvas entities type-check and the build completes again.

## Changes Made

- Marked the Canvas `spaceCanvases` relation as optional to align with the legacy `ChatFlow` shape.
- Tightened the `LegacyChatflowsService` dependency types, normalized document store IDs, and accepted string `keyonly` flags.
- Updated the server chatflows adapter and controller to coerce values to the Canvas shape and preserve Flowise metric typing.

## Additional Work

This section includes supplementary work completed as part of this PR:

- None

## Testing

- [ ] Manual testing completed
- [x] Automated tests pass
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #454 Consolidate Chatflow naming into Space applications.

# Описание

Согласовал серверный адаптер chatflows с легаси-сервисом Spaces, чтобы типы Canvas после рефакторинга собирались корректно и сборка снова завершалась успешно.

## Внесенные изменения

- Сделал связь `spaceCanvases` сущности Canvas необязательной, чтобы она соответствовала наследованной форме `ChatFlow`.
- Уточнил типы зависимостей `LegacyChatflowsService`, нормализовал идентификатор хранилища документов и принял строковый флаг `keyonly`.
- Обновил серверный адаптер и контроллер chatflows, приводя значения к форме Canvas и сохраняя типизацию счётчиков Flowise.

## Дополнительная работа

Этот раздел включает дополнительную работу, выполненную в рамках данного PR:

- Нет

## Тестирование

- [ ] Ручное тестирование завершено
- [x] Автоматические тесты проходят
- [x] Не внесено критических изменений
</details>