### PR TITLE
GH675 Metahubs UX improvements: Boolean fixes, Presentation tab, Header checkbox display

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,12 +1,51 @@
 # Active Context
 
-> **Last Updated**: 2026-02-14
+> **Last Updated**: 2026-02-13
 >
 > **Purpose**: Current development focus only. Completed work -> progress.md, planned work -> tasks.md.
 
 ---
 
-## Completed: UI/UX Polish Round 2 — Menu Fix, Create Buttons, Widget Toggle ✅
+## Completed: Metahubs UX Improvements — Boolean Fix, Auto-fill, Presentation Tab, Header Checkbox ✅
+
+**Status**: All 5 improvements + QA fixes (P1, P2) implemented. Build OK, tests OK, lint 0 errors.
+
+### What Was Done
+
+- **Task 1 (Indeterminate checkbox fix)**: Fixed BOOLEAN columns showing indeterminate state when value is NULL. Added `.defaultTo(false)` in SchemaGenerator and SchemaMigrator for nullable BOOLEAN columns; normalized null→false in `resolveRuntimeValue`; changed frontend to `checked={params.value === true} indeterminate={false}`.
+- **Task 2 (Auto-fill publication name)**: PublicationList now auto-fills the create dialog name field with metahub name + " API" suffix across all locales using VLC.
+- **Task 3 (Presentation tab)**: Added "Основное"/"Представление" tabs to both create and edit attribute dialogs. Created `PresentationTabFields` component with display attribute switch and conditional `headerAsCheckbox` switch (BOOLEAN only). Both dialogs (AttributeActions/edit and AttributeList/create) refactored from `extraFields` to `tabs` pattern using `TabConfig[]`.
+- **Task 4 (Boolean header as checkbox)**: Full pipeline from backend to runtime UI. Added `headerAsCheckbox` to `uiConfigSchema` in metahubs-backend; added `ui_config` to SQL SELECT and response in applications-backend; extended Zod schema in apps-template-mui; added `renderHeader` for BOOLEAN columns with `uiConfig.headerAsCheckbox` in RuntimeDashboardApp.
+- **Task 5 (Migration verification)**: Confirmed no new database migrations needed — `ui_config` column already exists, `headerAsCheckbox` stored in existing JSON field, BOOLEAN defaults only apply to future column creation.
+
+### Files Modified (14 files across 6 packages)
+
+**schema-ddl** (2):
+1. `SchemaGenerator.ts` — `.defaultTo(false)` for nullable BOOLEAN
+2. `SchemaMigrator.ts` — `.defaultTo(false)` for ADD_COLUMN BOOLEAN
+
+**applications-backend** (1):
+3. `applicationsRoutes.ts` — null→false in resolveRuntimeValue + ui_config in SQL SELECT + response
+
+**metahubs-backend** (1):
+4. `attributesRoutes.ts` — `headerAsCheckbox: z.boolean().optional()` in uiConfigSchema
+
+**metahubs-frontend** (6):
+5. `metahubs.json` (en) — i18n keys for tabs + presentation
+6. `metahubs.json` (ru) — i18n keys for tabs + presentation
+7. `types.ts` — `uiConfig` added to `AttributeLocalizedPayload`
+8. `AttributeFormFields.tsx` — `PresentationTabFields` component + `hideDisplayAttribute` prop
+9. `AttributeActions.tsx` — refactored to tabs, uiConfig in payload
+10. `AttributeList.tsx` — refactored create dialog to tabs, uiConfig in payload
+11. `PublicationList.tsx` — auto-fill name with metahub name + " API"
+
+**apps-template-mui** (2):
+12. `api.ts` — uiConfig in column Zod schema
+13. `RuntimeDashboardApp.tsx` — renderHeader for checkbox header + indeterminate fix
+
+---
+
+## Previous: UI/UX Polish Round 2 — Menu Fix, Create Buttons, Widget Toggle ✅
 
 **Status**: 3 fixes applied. Full build OK (65/65 packages).
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -14,6 +14,16 @@
 
 ---
 
+## Metahubs UX Improvements — Boolean Fix, Auto-fill, Presentation Tab, Header Checkbox (2026-02-13)
+
+- Implemented 5 improvements across 14 files in 6 packages:
+  - **Indeterminate checkbox fix**: Added `.defaultTo(false)` for nullable BOOLEAN columns in SchemaGenerator/SchemaMigrator; null→false normalization in runtime; `indeterminate={false}` in frontend.
+  - **Auto-fill publication name**: PublicationList auto-fills metahub name + " API" across all locales using VLC.
+  - **Presentation tab**: Added "Основное"/"Представление" tabs to attribute create/edit dialogs with `PresentationTabFields` component (display attribute + headerAsCheckbox switches). Refactored both dialogs from `extraFields` to `tabs` pattern.
+  - **Boolean header as checkbox**: Full pipeline — `headerAsCheckbox` in uiConfigSchema, `ui_config` in SQL SELECT and response, Zod schema, `renderHeader` in RuntimeDashboardApp.
+  - **Migration verification**: No new migrations needed; `ui_config` column pre-exists, BOOLEAN defaults only for future columns.
+- Build: 65/65 packages OK
+
 ## UI/UX Polish Round 2 — Menu Fix, Create Buttons, Widget Toggle (2026-02-14)
 
 - Fixed 3 UI/UX issues found during manual testing:

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -1,6 +1,36 @@
 # Tasks
 > **Note**: Active and planned tasks. Completed work -> progress.md, architectural patterns -> systemPatterns.md.
 
+## Completed: Metahubs UX Improvements — Boolean Fix, Auto-fill, Presentation Tab, Header Checkbox (2026-02-13)
+
+QA fixes applied 2026-02-13:
+- [x] P1 MEDIUM (TYPE-1): Add `uiConfig` to `AttributeFormValues` type in AttributeList.tsx
+- [x] P2 LOW (CONCUR-1): Replace whole-object uiConfig replacement with shallow merge in attributesRoutes.ts update handler
+
+- [x] Task 1: Fix indeterminate checkbox bug for BOOLEAN columns (DDL default, runtime normalizer, frontend fix)
+  - [x] 1.1: SchemaGenerator — add `.defaultTo(false)` for nullable BOOLEAN columns
+  - [x] 1.2: SchemaMigrator — same for ADD_COLUMN case
+  - [x] 1.3: applicationsRoutes — normalize null→false in `resolveRuntimeValue` for BOOLEAN
+  - [x] 1.4: RuntimeDashboardApp — add `indeterminate={false}` and `checked={params.value === true}`
+- [x] Task 2: Auto-fill publication name with metahub name + " API" suffix
+  - [x] 2.1: PublicationList — build VLC from metahub name with " API" suffix in `localizedFormDefaults`
+- [x] Task 3: Add "Presentation" tab to attribute create/edit dialog
+  - [x] 3.1: Add i18n keys for tabs and presentation options (en + ru)
+  - [x] 3.2: Add `uiConfig` to `AttributeLocalizedPayload` type
+  - [x] 3.3: Create PresentationTabFields component in AttributeFormFields.tsx
+  - [x] 3.4: Refactor AttributeActions (edit) and AttributeList (create) from `extraFields` to `tabs` pattern
+  - [x] 3.5: Add `hideDisplayAttribute` prop to AttributeFormFields
+  - [x] 3.6: Update `toPayload` and `handleCreateAttribute` to include uiConfig
+- [x] Task 4: Boolean header as checkbox — full pipeline
+  - [x] 4.1: Extend uiConfigSchema with `headerAsCheckbox` in metahubs-backend
+  - [x] 4.2: Add `ui_config` to SQL SELECT in applications-backend runtime
+  - [x] 4.3: Add uiConfig to runtime response builder
+  - [x] 4.4: Extend Zod schema in apps-template-mui api.ts
+  - [x] 4.5: Add `renderHeader` for checkbox header in RuntimeDashboardApp
+- [x] Task 5: Verify migration system compatibility — no new migrations needed
+- [x] Build validation: full project build (65/65 OK)
+- [x] Update memory-bank
+
 ## Completed: UI/UX Polish Round 2 — Menu Fix, Create Buttons, Widget Toggle (2026-02-14)
 
 - [x] Task 1: Fix "Макеты" menu position in PRODUCTION config (`menuConfigs.ts`) + sync `metahubDashboard.ts`

--- a/packages/applications-frontend/base/src/pages/ApplicationRuntime.tsx
+++ b/packages/applications-frontend/base/src/pages/ApplicationRuntime.tsx
@@ -97,10 +97,7 @@ const ApplicationRuntime = () => {
     // Find active menu from menus array
     const activeMenu = useMemo(() => {
         if (!runtime?.menus?.length) return null
-        return (
-            runtime.menus.find((m) => m.id === runtime.activeMenuId) ??
-            runtime.menus[0]
-        )
+        return runtime.menus.find((m) => m.id === runtime.activeMenuId) ?? runtime.menus[0]
     }, [runtime])
 
     // Build dashboard menu items from active menu
@@ -112,15 +109,17 @@ const ApplicationRuntime = () => {
             if (!item.isActive) return []
 
             if (item.kind === 'catalog') {
-                return [{
-                    id: item.id,
-                    label: item.title,
-                    icon: item.icon ?? null,
-                    kind: 'catalog' as const,
-                    catalogId: item.catalogId ?? null,
-                    href: null,
-                    selected: item.catalogId != null && item.catalogId === activeCatalogId
-                }]
+                return [
+                    {
+                        id: item.id,
+                        label: item.title,
+                        icon: item.icon ?? null,
+                        kind: 'catalog' as const,
+                        catalogId: item.catalogId ?? null,
+                        href: null,
+                        selected: item.catalogId != null && item.catalogId === activeCatalogId
+                    }
+                ]
             }
 
             if (item.kind === 'catalogs_all') {
@@ -135,15 +134,17 @@ const ApplicationRuntime = () => {
                 }))
             }
 
-            return [{
-                id: item.id,
-                label: item.title,
-                icon: item.icon ?? null,
-                kind: 'link' as const,
-                catalogId: null,
-                href: item.href ?? null,
-                selected: false
-            }]
+            return [
+                {
+                    id: item.id,
+                    label: item.title,
+                    icon: item.icon ?? null,
+                    kind: 'link' as const,
+                    catalogId: null,
+                    href: item.href ?? null,
+                    selected: false
+                }
+            ]
         })
     }, [activeMenu, runtime, activeCatalogId])
 
@@ -162,15 +163,17 @@ const ApplicationRuntime = () => {
             const items = runtimeMenu.items.flatMap((item): DashboardMenuItem[] => {
                 if (!item.isActive) return []
                 if (item.kind === 'catalog') {
-                    return [{
-                        id: item.id,
-                        label: item.title,
-                        icon: item.icon ?? null,
-                        kind: 'catalog' as const,
-                        catalogId: item.catalogId ?? null,
-                        href: null,
-                        selected: item.catalogId != null && item.catalogId === activeCatalogId
-                    }]
+                    return [
+                        {
+                            id: item.id,
+                            label: item.title,
+                            icon: item.icon ?? null,
+                            kind: 'catalog' as const,
+                            catalogId: item.catalogId ?? null,
+                            href: null,
+                            selected: item.catalogId != null && item.catalogId === activeCatalogId
+                        }
+                    ]
                 }
                 if (item.kind === 'catalogs_all') {
                     return catalogs.map((catalog) => ({
@@ -183,18 +186,20 @@ const ApplicationRuntime = () => {
                         selected: catalog.id === activeCatalogId
                     }))
                 }
-                return [{
-                    id: item.id,
-                    label: item.title,
-                    icon: item.icon ?? null,
-                    kind: 'link' as const,
-                    catalogId: null,
-                    href: item.href ?? null,
-                    selected: false
-                }]
+                return [
+                    {
+                        id: item.id,
+                        label: item.title,
+                        icon: item.icon ?? null,
+                        kind: 'link' as const,
+                        catalogId: null,
+                        href: item.href ?? null,
+                        selected: false
+                    }
+                ]
             })
             map[runtimeMenu.widgetId] = {
-                title: runtimeMenu.showTitle ? (runtimeMenu.title ?? null) : null,
+                title: runtimeMenu.showTitle ? runtimeMenu.title ?? null : null,
                 showTitle: Boolean(runtimeMenu.showTitle),
                 items,
                 activeCatalogId: activeCatalogId ?? null,
@@ -215,6 +220,10 @@ const ApplicationRuntime = () => {
             type: column.dataType === 'BOOLEAN' ? 'boolean' : column.dataType === 'NUMBER' ? 'number' : 'string',
             headerAlign: 'center',
             align: 'center',
+            renderHeader:
+                column.dataType === 'BOOLEAN' && column.uiConfig?.headerAsCheckbox
+                    ? () => <Checkbox size='small' disabled checked={false} indeterminate={false} sx={{ p: 0 }} title={column.headerName} />
+                    : undefined,
             renderCell:
                 column.dataType === 'BOOLEAN'
                     ? (params) => (
@@ -261,7 +270,7 @@ const ApplicationRuntime = () => {
             menu={
                 dashboardMenuItems.length > 0
                     ? {
-                          title: activeMenu?.showTitle ? (activeMenu.title ?? null) : null,
+                          title: activeMenu?.showTitle ? activeMenu.title ?? null : null,
                           showTitle: Boolean(activeMenu?.showTitle),
                           items: dashboardMenuItems,
                           activeCatalogId: activeCatalogId ?? null,

--- a/packages/applications-frontend/base/src/types.ts
+++ b/packages/applications-frontend/base/src/types.ts
@@ -188,6 +188,7 @@ export interface ApplicationRuntimeColumn {
     field: string
     dataType: 'BOOLEAN' | 'STRING' | 'NUMBER'
     headerName: string
+    uiConfig?: Record<string, unknown>
 }
 
 export interface ApplicationRuntimeCatalog {

--- a/packages/apps-template-mui/src/runtime/RuntimeDashboardApp.tsx
+++ b/packages/apps-template-mui/src/runtime/RuntimeDashboardApp.tsx
@@ -35,9 +35,13 @@ function toGridColumns(response: ApplicationRuntimeResponse): GridColDef[] {
         minWidth: 140,
         sortable: false,
         filterable: true,
+        renderHeader:
+            c.dataType === 'BOOLEAN' && c.uiConfig?.headerAsCheckbox
+                ? () => <Checkbox size='small' disabled checked={false} indeterminate={false} sx={{ p: 0 }} title={c.headerName} />
+                : undefined,
         renderCell: (params) => {
             if (c.dataType === 'BOOLEAN') {
-                return <Checkbox size='small' disabled checked={Boolean(params.value)} />
+                return <Checkbox size='small' disabled checked={params.value === true} indeterminate={false} />
             }
             if (params.value === null || params.value === undefined) return ''
             return String(params.value)
@@ -94,10 +98,7 @@ export default function RuntimeDashboardApp(props: RuntimeDashboardAppProps) {
         if (!runtime || !Array.isArray(runtime.menus) || runtime.menus.length === 0) {
             return null
         }
-        return (
-            runtime.menus.find((menu) => menu.id === runtime.activeMenuId) ??
-            runtime.menus[0]
-        )
+        return runtime.menus.find((menu) => menu.id === runtime.activeMenuId) ?? runtime.menus[0]
     }, [runtime])
 
     const dashboardMenuItems = useMemo(() => {

--- a/packages/apps-template-mui/src/runtime/api.ts
+++ b/packages/apps-template-mui/src/runtime/api.ts
@@ -47,7 +47,8 @@ export const runtimeResponseSchema = z.object({
             codename: z.string(),
             field: z.string(),
             dataType: z.enum(['BOOLEAN', 'STRING', 'NUMBER']),
-            headerName: z.string()
+            headerName: z.string(),
+            uiConfig: z.record(z.unknown()).optional().default({})
         })
     ),
     rows: z.array(z.record(z.unknown()).and(z.object({ id: z.string() }))),

--- a/packages/metahubs-backend/base/src/domains/attributes/routes/attributesRoutes.ts
+++ b/packages/metahubs-backend/base/src/domains/attributes/routes/attributesRoutes.ts
@@ -82,7 +82,8 @@ const uiConfigSchema = z
         placeholder: z.record(z.string()).optional(),
         helpText: z.record(z.string()).optional(),
         hidden: z.boolean().optional(),
-        width: z.number().optional()
+        width: z.number().optional(),
+        headerAsCheckbox: z.boolean().optional()
     })
     .optional()
 
@@ -576,7 +577,10 @@ export function createAttributesRoutes(
             }
 
             if (validationRules) updateData.validationRules = validationRules
-            if (uiConfig) updateData.uiConfig = uiConfig
+            if (uiConfig) {
+                const currentUiConfig = (attribute.uiConfig as Record<string, unknown>) ?? {}
+                updateData.uiConfig = { ...currentUiConfig, ...uiConfig }
+            }
             if (isRequired !== undefined) updateData.isRequired = isRequired
             // isDisplayAttribute is handled separately via setDisplayAttribute for atomicity
             if (sortOrder !== undefined) updateData.sortOrder = sortOrder

--- a/packages/metahubs-backend/base/src/domains/layouts/services/MetahubLayoutsService.ts
+++ b/packages/metahubs-backend/base/src/domains/layouts/services/MetahubLayoutsService.ts
@@ -337,9 +337,7 @@ export class MetahubLayoutsService {
                     template_key: input.templateKey ?? 'dashboard',
                     name: input.name,
                     description: input.description ?? null,
-                    config: input.config ?? buildDashboardLayoutConfig(
-                        DEFAULT_DASHBOARD_ZONE_WIDGETS.filter((w) => w.isActive !== false)
-                    ),
+                    config: input.config ?? buildDashboardLayoutConfig(DEFAULT_DASHBOARD_ZONE_WIDGETS.filter((w) => w.isActive !== false)),
                     is_active: isActive,
                     is_default: isDefault,
                     sort_order: input.sortOrder ?? 0,

--- a/packages/metahubs-backend/base/src/domains/metahubs/services/systemTableDefinitions.ts
+++ b/packages/metahubs-backend/base/src/domains/metahubs/services/systemTableDefinitions.ts
@@ -299,9 +299,7 @@ export const SYSTEM_TABLES_V1: SystemTableDef[] = [
  * When adding a new version, list ALL tables from the previous version plus new ones.
  * The diff engine compares consecutive versions to produce migrations.
  */
-export const SYSTEM_TABLE_VERSIONS: ReadonlyMap<number, readonly SystemTableDef[]> = new Map([
-    [1, SYSTEM_TABLES_V1]
-])
+export const SYSTEM_TABLE_VERSIONS: ReadonlyMap<number, readonly SystemTableDef[]> = new Map([[1, SYSTEM_TABLES_V1]])
 
 export interface SystemStructureSnapshotTable {
     name: string

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeFormFields.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeFormFields.tsx
@@ -63,6 +63,8 @@ export type AttributeFormFieldsProps = {
     dataTypeDisabled?: boolean
     dataTypeHelperText?: string
     disableVlcToggles?: boolean
+    /** When true, hides the display attribute switch (moved to Presentation tab) */
+    hideDisplayAttribute?: boolean
 }
 
 const AttributeFormFields = ({
@@ -97,7 +99,8 @@ const AttributeFormFields = ({
     currentCatalogId,
     dataTypeDisabled = false,
     dataTypeHelperText,
-    disableVlcToggles = false
+    disableVlcToggles = false,
+    hideDisplayAttribute = false
 }: AttributeFormFieldsProps) => {
     const { t } = useTranslation('metahubs')
     const [showTypeSettings, setShowTypeSettings] = useState(false)
@@ -299,7 +302,7 @@ const AttributeFormFields = ({
     const hasTypeSettings = ['STRING', 'NUMBER', 'DATE', 'REF'].includes(dataType)
 
     return (
-        <>
+        <Stack spacing={2}>
             <LocalizedInlineField
                 mode='localized'
                 label={nameLabel}
@@ -364,16 +367,21 @@ const AttributeFormFields = ({
                 label={requiredLabel}
                 disabled={isLoading}
             />
-            <Box>
-                <FormControlLabel
-                    control={
-                        <Switch checked={isDisplayAttribute} onChange={(event) => setValue('isDisplayAttribute', event.target.checked)} />
-                    }
-                    label={displayAttributeLabel}
-                    disabled={isLoading || displayAttributeLocked}
-                />
-                {displayAttributeHelper && <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{displayAttributeHelper}</FormHelperText>}
-            </Box>
+            {!hideDisplayAttribute && (
+                <Box>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={isDisplayAttribute}
+                                onChange={(event) => setValue('isDisplayAttribute', event.target.checked)}
+                            />
+                        }
+                        label={displayAttributeLabel}
+                        disabled={isLoading || displayAttributeLocked}
+                    />
+                    {displayAttributeHelper && <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{displayAttributeHelper}</FormHelperText>}
+                </Box>
+            )}
             <Divider />
             <CodenameField
                 value={codename}
@@ -386,8 +394,75 @@ const AttributeFormFields = ({
                 disabled={isLoading}
                 required
             />
-        </>
+        </Stack>
     )
 }
 
 export default AttributeFormFields
+
+// ============ PRESENTATION TAB FIELDS ============
+
+export type PresentationTabFieldsProps = {
+    values: Record<string, any>
+    setValue: (name: string, value: any) => void
+    isLoading: boolean
+    displayAttributeLabel: string
+    displayAttributeHelper: string
+    displayAttributeLocked: boolean
+    headerAsCheckboxLabel: string
+    headerAsCheckboxHelper: string
+    dataType: string
+}
+
+export const PresentationTabFields = ({
+    values,
+    setValue,
+    isLoading,
+    displayAttributeLabel,
+    displayAttributeHelper,
+    displayAttributeLocked,
+    headerAsCheckboxLabel,
+    headerAsCheckboxHelper,
+    dataType
+}: PresentationTabFieldsProps) => {
+    const isDisplayAttribute = Boolean(values.isDisplayAttribute)
+    const uiConfig = (values.uiConfig ?? {}) as Record<string, unknown>
+
+    return (
+        <Stack spacing={2}>
+            <Box>
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={isDisplayAttribute}
+                            onChange={(_, checked) => setValue('isDisplayAttribute', checked)}
+                            disabled={isLoading || displayAttributeLocked}
+                        />
+                    }
+                    label={displayAttributeLabel}
+                />
+                {displayAttributeHelper && <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{displayAttributeHelper}</FormHelperText>}
+            </Box>
+            {dataType === 'BOOLEAN' && (
+                <>
+                    <Divider />
+                    <Box>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={Boolean(uiConfig.headerAsCheckbox)}
+                                    onChange={(_, checked) => {
+                                        setValue('uiConfig', { ...uiConfig, headerAsCheckbox: checked })
+                                    }}
+                                    disabled={isLoading}
+                                />
+                            }
+                            label={headerAsCheckboxLabel}
+                        />
+                        <FormHelperText sx={{ mt: -0.5, ml: 7 }}>{headerAsCheckboxHelper}</FormHelperText>
+                    </Box>
+                </>
+            )}
+        </Stack>
+    )
+}

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeList.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeList.tsx
@@ -24,7 +24,7 @@ import {
     ConfirmDialog,
     useConfirm
 } from '@universo/template-mui'
-import { EntityFormDialog, ConfirmDeleteDialog, ConflictResolutionDialog } from '@universo/template-mui/components/dialogs'
+import { EntityFormDialog, ConfirmDeleteDialog, ConflictResolutionDialog, type TabConfig } from '@universo/template-mui/components/dialogs'
 import { ViewHeaderMUI as ViewHeader, BaseEntityMenu } from '@universo/template-mui'
 
 import {
@@ -54,7 +54,7 @@ import { isOptimisticLockConflict, extractConflictInfo, type ConflictInfo } from
 import { sanitizeCodename, isValidCodename } from '../../../utils/codename'
 import { extractLocalizedInput, hasPrimaryContent } from '../../../utils/localizedInput'
 import attributeActions from './AttributeActions'
-import AttributeFormFields from './AttributeFormFields'
+import AttributeFormFields, { PresentationTabFields } from './AttributeFormFields'
 
 type AttributeFormValues = {
     nameVlc: VersionedLocalizedContent<string> | null
@@ -66,6 +66,7 @@ type AttributeFormValues = {
     validationRules?: AttributeValidationRules
     targetEntityId?: string | null
     targetEntityKind?: MetaEntityKind | null
+    uiConfig?: Record<string, unknown>
 }
 
 // Get color for data type chip
@@ -222,7 +223,8 @@ const AttributeList = () => {
             isRequired: false,
             isDisplayAttribute: hasNoAttributes,
             targetEntityId: null,
-            targetEntityKind: null
+            targetEntityKind: null,
+            uiConfig: {}
         }
     }, [attributes?.length])
 
@@ -272,7 +274,7 @@ const AttributeList = () => {
         return hasBasicInfo
     }, [])
 
-    const renderLocalizedFields = useCallback(
+    const renderTabs = useCallback(
         ({
             values,
             setValue,
@@ -283,55 +285,86 @@ const AttributeList = () => {
             setValue: (name: string, value: any) => void
             isLoading: boolean
             errors?: Record<string, string>
-        }) => {
+        }): TabConfig[] => {
             const fieldErrors = errors ?? {}
-            return (
-                <AttributeFormFields
-                    values={values}
-                    setValue={setValue}
-                    isLoading={isLoading}
-                    errors={fieldErrors}
-                    uiLocale={i18n.language}
-                    nameLabel={tc('fields.name', 'Name')}
-                    codenameLabel={t('attributes.codename', 'Codename')}
-                    codenameHelper={t('attributes.codenameHelper', 'Unique identifier')}
-                    dataTypeLabel={t('attributes.dataType', 'Data Type')}
-                    requiredLabel={t('attributes.isRequiredLabel', 'Required')}
-                    displayAttributeLabel={t('attributes.isDisplayAttributeLabel', 'Display attribute')}
-                    displayAttributeHelper={t(
-                        'attributes.isDisplayAttributeHelper',
-                        'Use as representation when referencing elements of this catalog'
-                    )}
-                    displayAttributeLocked={(attributes?.length ?? 0) === 0}
-                    dataTypeOptions={[
-                        { value: 'STRING', label: t('attributes.dataTypeOptions.string', 'String') },
-                        { value: 'NUMBER', label: t('attributes.dataTypeOptions.number', 'Number') },
-                        { value: 'BOOLEAN', label: t('attributes.dataTypeOptions.boolean', 'Boolean') },
-                        { value: 'DATE', label: t('attributes.dataTypeOptions.date', 'Date') },
-                        { value: 'REF', label: t('attributes.dataTypeOptions.ref', 'Reference') },
-                        { value: 'JSON', label: t('attributes.dataTypeOptions.json', 'JSON') }
-                    ]}
-                    typeSettingsLabel={t('attributes.typeSettings.title', 'Type Settings')}
-                    stringMaxLengthLabel={t('attributes.typeSettings.string.maxLength', 'Max Length')}
-                    stringMinLengthLabel={t('attributes.typeSettings.string.minLength', 'Min Length')}
-                    stringVersionedLabel={t('attributes.typeSettings.string.versioned', 'Versioned (VLC)')}
-                    stringLocalizedLabel={t('attributes.typeSettings.string.localized', 'Localized (VLC)')}
-                    numberPrecisionLabel={t('attributes.typeSettings.number.precision', 'Precision')}
-                    numberScaleLabel={t('attributes.typeSettings.number.scale', 'Scale')}
-                    numberMinLabel={t('attributes.typeSettings.number.min', 'Min Value')}
-                    numberMaxLabel={t('attributes.typeSettings.number.max', 'Max Value')}
-                    numberNonNegativeLabel={t('attributes.typeSettings.number.nonNegative', 'Non-negative only')}
-                    dateCompositionLabel={t('attributes.typeSettings.date.composition', 'Date Composition')}
-                    dateCompositionOptions={[
-                        { value: 'date', label: t('attributes.typeSettings.date.compositionOptions.date', 'Date only') },
-                        { value: 'time', label: t('attributes.typeSettings.date.compositionOptions.time', 'Time only') },
-                        { value: 'datetime', label: t('attributes.typeSettings.date.compositionOptions.datetime', 'Date and Time') }
-                    ]}
-                    physicalTypeLabel={t('attributes.physicalType.label', 'PostgreSQL type')}
-                    metahubId={metahubId!}
-                    currentCatalogId={catalogId}
-                />
-            )
+            const displayAttributeLocked = (attributes?.length ?? 0) === 0
+            return [
+                {
+                    id: 'general',
+                    label: t('attributes.tabs.general', 'General'),
+                    content: (
+                        <AttributeFormFields
+                            values={values}
+                            setValue={setValue}
+                            isLoading={isLoading}
+                            errors={fieldErrors}
+                            uiLocale={i18n.language}
+                            nameLabel={tc('fields.name', 'Name')}
+                            codenameLabel={t('attributes.codename', 'Codename')}
+                            codenameHelper={t('attributes.codenameHelper', 'Unique identifier')}
+                            dataTypeLabel={t('attributes.dataType', 'Data Type')}
+                            requiredLabel={t('attributes.isRequiredLabel', 'Required')}
+                            displayAttributeLabel={t('attributes.isDisplayAttributeLabel', 'Display attribute')}
+                            displayAttributeHelper={t(
+                                'attributes.isDisplayAttributeHelper',
+                                'Use as representation when referencing elements of this catalog'
+                            )}
+                            displayAttributeLocked={displayAttributeLocked}
+                            dataTypeOptions={[
+                                { value: 'STRING', label: t('attributes.dataTypeOptions.string', 'String') },
+                                { value: 'NUMBER', label: t('attributes.dataTypeOptions.number', 'Number') },
+                                { value: 'BOOLEAN', label: t('attributes.dataTypeOptions.boolean', 'Boolean') },
+                                { value: 'DATE', label: t('attributes.dataTypeOptions.date', 'Date') },
+                                { value: 'REF', label: t('attributes.dataTypeOptions.ref', 'Reference') },
+                                { value: 'JSON', label: t('attributes.dataTypeOptions.json', 'JSON') }
+                            ]}
+                            typeSettingsLabel={t('attributes.typeSettings.title', 'Type Settings')}
+                            stringMaxLengthLabel={t('attributes.typeSettings.string.maxLength', 'Max Length')}
+                            stringMinLengthLabel={t('attributes.typeSettings.string.minLength', 'Min Length')}
+                            stringVersionedLabel={t('attributes.typeSettings.string.versioned', 'Versioned (VLC)')}
+                            stringLocalizedLabel={t('attributes.typeSettings.string.localized', 'Localized (VLC)')}
+                            numberPrecisionLabel={t('attributes.typeSettings.number.precision', 'Precision')}
+                            numberScaleLabel={t('attributes.typeSettings.number.scale', 'Scale')}
+                            numberMinLabel={t('attributes.typeSettings.number.min', 'Min Value')}
+                            numberMaxLabel={t('attributes.typeSettings.number.max', 'Max Value')}
+                            numberNonNegativeLabel={t('attributes.typeSettings.number.nonNegative', 'Non-negative only')}
+                            dateCompositionLabel={t('attributes.typeSettings.date.composition', 'Date Composition')}
+                            dateCompositionOptions={[
+                                { value: 'date', label: t('attributes.typeSettings.date.compositionOptions.date', 'Date only') },
+                                { value: 'time', label: t('attributes.typeSettings.date.compositionOptions.time', 'Time only') },
+                                { value: 'datetime', label: t('attributes.typeSettings.date.compositionOptions.datetime', 'Date and Time') }
+                            ]}
+                            physicalTypeLabel={t('attributes.physicalType.label', 'PostgreSQL type')}
+                            metahubId={metahubId!}
+                            currentCatalogId={catalogId}
+                            hideDisplayAttribute
+                        />
+                    )
+                },
+                {
+                    id: 'presentation',
+                    label: t('attributes.tabs.presentation', 'Presentation'),
+                    content: (
+                        <PresentationTabFields
+                            values={values}
+                            setValue={setValue}
+                            isLoading={isLoading}
+                            displayAttributeLabel={t('attributes.isDisplayAttributeLabel', 'Display attribute')}
+                            displayAttributeHelper={t(
+                                'attributes.isDisplayAttributeHelper',
+                                'Use as representation when referencing elements of this catalog'
+                            )}
+                            displayAttributeLocked={displayAttributeLocked}
+                            headerAsCheckboxLabel={t('attributes.presentation.headerAsCheckbox', 'Display header as checkbox')}
+                            headerAsCheckboxHelper={t(
+                                'attributes.presentation.headerAsCheckboxHelper',
+                                'Show a checkbox in the column header instead of the text label'
+                            )}
+                            dataType={values.dataType ?? 'STRING'}
+                        />
+                    )
+                }
+            ]
         },
         [i18n.language, t, tc, metahubId, catalogId, attributes?.length]
     )
@@ -692,6 +725,7 @@ const AttributeList = () => {
             const isRequired = Boolean(data.isRequired)
             const validationRules = data.validationRules as AttributeValidationRules | undefined
             const isDisplayAttribute = Boolean(data.isDisplayAttribute)
+            const uiConfig = (data.uiConfig as Record<string, unknown>) ?? {}
 
             // REF type: extract target entity info
             const targetEntityId = dataType === 'REF' ? (data.targetEntityId as string | null) : undefined
@@ -710,7 +744,8 @@ const AttributeList = () => {
                     validationRules,
                     isDisplayAttribute,
                     targetEntityId,
-                    targetEntityKind
+                    targetEntityKind,
+                    uiConfig
                 }
             })
 
@@ -884,7 +919,7 @@ const AttributeList = () => {
                 onSave={handleCreateAttribute}
                 hideDefaultFields
                 initialExtraValues={localizedFormDefaults}
-                extraFields={renderLocalizedFields}
+                tabs={renderTabs}
                 validate={validateAttributeForm}
                 canSave={canSaveAttributeForm}
             />

--- a/packages/metahubs-frontend/base/src/domains/layouts/ui/LayoutDetails.tsx
+++ b/packages/metahubs-frontend/base/src/domains/layouts/ui/LayoutDetails.tsx
@@ -108,7 +108,11 @@ function SortableWidgetChip({
             )}
             {onToggleActive && (
                 <Tooltip title={toggleActiveTooltip || ''} arrow>
-                    <IconButton size='small' onClick={() => onToggleActive(!isActive)} sx={!isActive ? { color: 'text.disabled' } : undefined}>
+                    <IconButton
+                        size='small'
+                        onClick={() => onToggleActive(!isActive)}
+                        sx={!isActive ? { color: 'text.disabled' } : undefined}
+                    >
                         {isActive ? <VisibilityRoundedIcon fontSize='small' /> : <VisibilityOffRoundedIcon fontSize='small' />}
                     </IconButton>
                 </Tooltip>

--- a/packages/metahubs-frontend/base/src/i18n/locales/en/metahubs.json
+++ b/packages/metahubs-frontend/base/src/i18n/locales/en/metahubs.json
@@ -507,6 +507,14 @@
       "label": "PostgreSQL type",
       "tooltip": "PostgreSQL: {{type}}"
     },
+    "tabs": {
+      "general": "General",
+      "presentation": "Presentation"
+    },
+    "presentation": {
+      "headerAsCheckbox": "Display header as checkbox",
+      "headerAsCheckboxHelper": "Show a checkbox in the column header instead of the text label (only for Boolean type)"
+    },
     "edit": {
       "typeChangeDisabled": "Data type cannot be changed after creation",
       "settingsReadOnly": "Type settings cannot be modified after creation"

--- a/packages/metahubs-frontend/base/src/i18n/locales/ru/metahubs.json
+++ b/packages/metahubs-frontend/base/src/i18n/locales/ru/metahubs.json
@@ -513,6 +513,14 @@
             "label": "Тип PostgreSQL",
             "tooltip": "PostgreSQL: {{type}}"
         },
+        "tabs": {
+            "general": "Основное",
+            "presentation": "Представление"
+        },
+        "presentation": {
+            "headerAsCheckbox": "Отображать заголовок как чекбокс",
+            "headerAsCheckboxHelper": "Показать чекбокс в заголовке столбца вместо текста (только для типа Булево)"
+        },
         "edit": {
             "typeChangeDisabled": "Тип данных нельзя изменить после создания",
             "settingsReadOnly": "Настройки типа нельзя изменить после создания"

--- a/packages/metahubs-frontend/base/src/menu-items/metahubDashboard.ts
+++ b/packages/metahubs-frontend/base/src/menu-items/metahubDashboard.ts
@@ -21,7 +21,17 @@ export interface MenuItem {
     children?: MenuItem[]
 }
 
-const icons = { IconBuildingStore, IconHierarchy, IconUsersGroup, IconDatabase, IconApps, IconGitBranch, IconLayoutDashboard, IconFiles, IconHistory }
+const icons = {
+    IconBuildingStore,
+    IconHierarchy,
+    IconUsersGroup,
+    IconDatabase,
+    IconApps,
+    IconGitBranch,
+    IconLayoutDashboard,
+    IconFiles,
+    IconHistory
+}
 
 // ==============================|| METAHUB DASHBOARD MENU ITEMS ||============================== //
 

--- a/packages/metahubs-frontend/base/src/types.ts
+++ b/packages/metahubs-frontend/base/src/types.ts
@@ -470,6 +470,10 @@ export interface AttributeLocalizedPayload {
     namePrimaryLocale?: string
     isRequired?: boolean
     isDisplayAttribute?: boolean
+    validationRules?: Record<string, unknown>
+    targetEntityId?: string
+    targetEntityKind?: MetaEntityKind
+    uiConfig?: Record<string, unknown>
 }
 
 // ============ DISPLAY CONVERTERS ============

--- a/packages/schema-ddl/base/src/SchemaGenerator.ts
+++ b/packages/schema-ddl/base/src/SchemaGenerator.ts
@@ -164,7 +164,11 @@ export class SchemaGenerator {
                 if (field.isRequired) {
                     table.specificType(columnName, pgType).notNullable()
                 } else {
-                    table.specificType(columnName, pgType).nullable()
+                    const col = table.specificType(columnName, pgType).nullable()
+                    // BOOLEAN columns default to false to prevent NULL → indeterminate checkbox state
+                    if (field.dataType === AttributeDataType.BOOLEAN) {
+                        col.defaultTo(false)
+                    }
                 }
             }
 

--- a/packages/schema-ddl/base/src/SchemaMigrator.ts
+++ b/packages/schema-ddl/base/src/SchemaMigrator.ts
@@ -236,7 +236,11 @@ export class SchemaMigrator {
                 const columnName = change.columnName ?? generateColumnName(field.id)
 
                 await trx.schema.withSchema(schemaName).alterTable(change.tableName!, (table: Knex.AlterTableBuilder) => {
-                    table.specificType(columnName, pgType).nullable()
+                    const col = table.specificType(columnName, pgType).nullable()
+                    // BOOLEAN columns default to false to prevent NULL → indeterminate checkbox state
+                    if (field.dataType === AttributeDataType.BOOLEAN) {
+                        col.defaultTo(false)
+                    }
                 })
 
                 if (field.isRequired) {


### PR DESCRIPTION
Fixes #675

# Description

This PR implements a comprehensive set of UX improvements for the Metahubs catalog attribute management and runtime application display. The changes span 6 packages and cover Boolean column fixes, a new Presentation tab, header-as-checkbox pipeline, dialog layout improvements, and runtime rendering fixes.

## Changes Made

- **Fix indeterminate checkbox bug for BOOLEAN columns**: Added `.defaultTo(false)` for nullable BOOLEAN columns in `SchemaGenerator` and `SchemaMigrator`, normalized null→false in runtime response (`applicationsRoutes`), fixed frontend `indeterminate` state in `RuntimeDashboardApp`
- **Auto-fill publication name**: When creating a new publication, the name field is auto-filled with metahub name + " API" suffix
- **Add Presentation tab to attribute create/edit dialog**: Refactored attribute dialogs from flat `extraFields` to tabbed layout. General tab contains core fields, Presentation tab contains display options (`isDisplayAttribute`, `headerAsCheckbox` for BOOLEAN type)
- **Boolean header-as-checkbox full pipeline**: Extended `uiConfig` schema with `headerAsCheckbox` option, stored in `_mhb_attributes.ui_config` JSONB, propagated through publication snapshots to `_app_attributes.ui_config`, included in runtime API response, rendered as Checkbox in column header
- **Fix attribute dialog vertical compression**: Wrapped `AttributeFormFields` return in `<Stack spacing={2}>` instead of bare React fragment to restore proper vertical spacing after tab introduction
- **Fix header checkbox not rendering in ApplicationRuntime.tsx**: Added conditional `renderHeader` with Checkbox component — the page was building grid columns independently without `headerAsCheckbox` support
- **Fix prettier formatting errors** in `RuntimeDashboardApp.tsx`

## Additional Work

- Added i18n keys for new tab labels and presentation options (en/ru locales)
- Added `uiConfig` field to `ApplicationRuntimeColumn` type in `applications-frontend`
- Extended Zod schema in `apps-template-mui/api.ts` with `uiConfig` field
- Updated memory-bank documentation (`activeContext.md`, `progress.md`, `tasks.md`)

## Testing

- [x] Manual testing completed (all 7 improvements verified in browser)
- [x] Full project build passes (all packages)
- [x] Lint passes for all modified packages (0 errors)
- [x] No breaking changes introduced
- [x] No new migrations needed (ui_config JSONB column existed since V1)

<details>
<summary>In Russian</summary>

Исправляет #675

# Описание

Этот PR реализует комплексный набор UX-улучшений для управления атрибутами каталогов метахабов и отображения в runtime-приложении. Изменения затрагивают 6 пакетов и охватывают исправления Boolean-столбцов, новую вкладку Представление, pipeline заголовка-чекбокса, улучшения макета диалога и исправления рендеринга в runtime.

## Внесённые изменения

- **Исправлен баг неопределённого чекбокса для BOOLEAN-столбцов**: Добавлен `.defaultTo(false)` для nullable BOOLEAN-столбцов в `SchemaGenerator` и `SchemaMigrator`, нормализован null→false в runtime-ответе (`applicationsRoutes`), исправлено состояние `indeterminate` во фронтенде `RuntimeDashboardApp`
- **Автозаполнение имени публикации**: При создании новой публикации поле имени автоматически заполняется как имя метахаба + суффикс " API"
- **Добавлена вкладка Представление в диалог создания/редактирования атрибута**: Рефакторинг диалогов атрибутов с плоского `extraFields` на табовый макет. Вкладка Общие содержит основные поля, вкладка Представление — опции отображения (`isDisplayAttribute`, `headerAsCheckbox` для типа BOOLEAN)
- **Полный pipeline для Boolean-заголовка как чекбокса**: Расширена схема `uiConfig` опцией `headerAsCheckbox`, хранение в JSONB `_mhb_attributes.ui_config`, пропагация через снимки публикаций в `_app_attributes.ui_config`, включение в runtime API-ответ, рендеринг как Checkbox в заголовке столбца
- **Исправлено вертикальное сжатие диалога атрибутов**: Обёрнут возврат `AttributeFormFields` в `<Stack spacing={2}>` вместо голого React-фрагмента для восстановления вертикальных отступов после добавления вкладок
- **Исправлено отсутствие чекбокса в заголовке ApplicationRuntime.tsx**: Добавлен условный `renderHeader` с компонентом Checkbox — страница строила столбцы сетки самостоятельно без поддержки `headerAsCheckbox`
- **Исправлены ошибки форматирования prettier** в `RuntimeDashboardApp.tsx`

## Дополнительная работа

- Добавлены ключи i18n для новых меток вкладок и опций представления (локали en/ru)
- Добавлено поле `uiConfig` в тип `ApplicationRuntimeColumn` в `applications-frontend`
- Расширена Zod-схема в `apps-template-mui/api.ts` полем `uiConfig`
- Обновлена документация memory-bank (`activeContext.md`, `progress.md`, `tasks.md`)

## Тестирование

- [x] Ручное тестирование завершено (все 7 улучшений проверены в браузере)
- [x] Полная сборка проекта проходит (все пакеты)
- [x] Lint проходит для всех изменённых пакетов (0 ошибок)
- [x] Не внесено критических изменений
- [x] Новые миграции не требуются (столбец JSONB ui_config существовал с V1)

</details>