### PR TITLE
GH703 Implement drag-and-drop reordering for catalog attributes and enumeration values

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,12 +1,147 @@
 # Active Context
 
-> **Last Updated**: 2026-03-03
+> **Last Updated**: 2026-03-04
 >
 > **Purpose**: Current development focus only. Completed work -> progress.md, planned work -> tasks.md.
 
 ---
 
-## Current Focus: Codename Auto-Convert UX Hardening — Completed
+## Current Focus: QA Tech Debt Cleanup — Completed
+
+**Status**: ✅ Completed
+**Date**: 2026-03-04
+
+### What was done
+
+Fixed all tech debt items identified in the comprehensive QA analysis of the attribute DnD feature:
+
+1. **Stale JSDoc comment** — Updated `useReorderAttribute` docstring to reflect that cross-list optimistic updates are now implemented (was "cross-list skipped").
+
+2. **Fragile `movedItem` closure capture** — Replaced side-effect-based closure pattern (`movedItem` set inside `removeUpdater` callback passed to `setQueriesData`) with pre-extraction via `getQueriesData`. The moved item is now found from the cache BEFORE updaters run. The `insertUpdater` uses a `const captured = movedItem` local variable instead of the `movedItem!` non-null assertion.
+
+3. **Over-broad child cache invalidation** — `onSuccess` now invalidates child attribute caches only for cross-list transfers (`newParentAttributeId !== undefined`). Same-list reorder no longer triggers unnecessary refetch of all child lists.
+
+4. **`as any` cleanup** — Replaced `as any` casts in the same-list `reorderUpdater` with typed `Record<string, unknown>` casts, matching the pattern used in cross-list code.
+
+### Files modified
+
+- `mutations.ts` (metahubs-frontend) — all 4 fixes in this single file
+
+### Verified baseline
+
+- Lint: metahubs-frontend 0 errors/153 warnings
+- Tests: metahubs-frontend 97/97
+- Build: metahubs-frontend ✔ success
+
+## Previous Focus: Cross-List DnD Optimistic Update — Completed
+
+1. **Backend auto-set display attr (Fix 1)** — in `reorderAttribute()`, after cross-list move to a child list, counts siblings in target list. If count === 1 (attribute is the only child), auto-sets `is_display_attribute: true` and `is_required: true`. Ensures newly populated child lists always have a display attribute.
+
+2. **Ghost row collision guard (Fix 2)** — in `handleDragOver`, added early return when `over.id === active.id` and `pendingTransfer` exists, preventing render cycle where ghost row mounts/unmounts EmptyDroppableChildArea ↔ DroppableSortableBody. In `handleDragEnd`, saves `pendingTransferRef.current` before clearing state; when dropped on ghost, resolves target container from saved transfer. Sort order uses `savedPendingTransfer.insertIndex + 1` for accurate placement.
+
+3. **Source list display protection (Fix 3)** — changed `_validateCrossListTransfer()` check from `attribute.is_display_attribute && targetParentId !== null` to `attribute.is_display_attribute`. Now blocks ALL display attribute cross-list transfers (not just to-child), aligned with frontend behavior. Prevents source list from losing display attribute via direct API calls.
+
+4. **eslint-disable cleanup (Fix 4)** — extracted inline type annotation to named `EmptyDroppableChildAreaProps` interface. Reduced from 2 eslint-disable comments (one awkwardly inside type annotation) to 1 standard `eslint-disable-next-line` before component declaration.
+
+### Files modified
+
+- `MetahubAttributesService.ts` (metahubs-backend) — auto-set display+required for sole child; block all display attr cross-list transfers
+- `useAttributeDnd.ts` (metahubs-frontend) — ghost collision guard in handleDragOver + handleDragEnd; improved sort order calc
+- `ChildAttributeList.tsx` (metahubs-frontend) — EmptyDroppableChildAreaProps interface, cleaned eslint-disable
+
+### Verified baseline
+
+- Lint: metahubs-backend 0 errors/216 warnings, metahubs-frontend 0 errors/163 warnings
+- Tests: metahubs-backend 128/128, metahubs-frontend 97/97, template-mui 169/169
+- Build: 56/56 successful (5m29s)
+
+## Previous Focus: DnD QA Pass 4 — 4 Issues Fix — Completed
+
+**Status**: ✅ Completed
+**Date**: 2026-03-03
+
+### What was done
+
+1. **Jitter fix (Issue 1)** — added `overflowX: 'hidden'` to FlowListTable's TableContainer sx when `isDropTarget` is active. Prevents horizontal scrollbar cycle when wider ghost rows are injected into narrower child tables during cross-list drag.
+
+2. **Empty child table droppable (Issue 2)** — created `EmptyDroppableChildArea` component using `@dnd-kit/core` `useDroppable` with dashed border styling and drop target highlight. Restructured ChildAttributeList rendering: always computes effectiveData/effectiveIds; when empty shows EmptyDroppableChildArea, when data exists shows FlowListTable.
+
+3. **First-child confirmation dialog (Issue 3)** — extended `onValidateTransfer` signature to include `targetContainerItemCount: number`. In `handleValidateTransfer`, when target is empty child container (targetContainerItemCount === 0), shows confirmation dialog explaining the attribute will become display + required. Added i18n keys in EN and RU.
+
+4. **Display attribute toggle lock (Issue 4)** — in `AttributeActions.tsx` added `|| isDisplayAttributeEntity(ctx)` to `displayAttributeLocked`. In `ChildAttributeList.tsx` edit dialog, passes `displayAttributeLockedOverride: editState.attribute?.isDisplayAttribute ? true : undefined`. The toggle is now ON + disabled when editing the display attribute.
+
+### Files modified
+
+- `FlowListTable.tsx` (universo-template-mui) — `overflowX: 'hidden'` on isDropTarget
+- `ChildAttributeList.tsx` — EmptyDroppableChildArea component, restructured rendering, edit dialog displayAttributeLockedOverride
+- `useAttributeDnd.ts` — extended onValidateTransfer signature with targetContainerItemCount
+- `AttributeDndProvider.tsx` — updated onValidateTransfer prop type
+- `AttributeList.tsx` — first-child confirmation dialog in handleValidateTransfer
+- `AttributeActions.tsx` — displayAttributeLocked includes isDisplayAttributeEntity check
+- `en/metahubs.json` — added firstChildAttributeTitle/firstChildAttributeDescription
+- `ru/metahubs.json` — added Russian translations for same keys
+
+### Verified baseline
+
+- `pnpm --filter metahubs-frontend lint` → 0 errors, 163 warnings
+- `pnpm build` (root) → 56/56 successful, 5m36s
+
+## Previous Focus: DnD QA Critical Debt Closure — Completed
+
+**Status**: ✅ Completed
+**Date**: 2026-03-03
+
+### Finalized in this pass
+
+1. Enforced backend policy settings for cross-list attribute movement in reorder flow (`allowAttributeMoveBetweenRootAndChildren`, `allowAttributeMoveBetweenChildLists`) so transfer restrictions are no longer frontend-only.
+2. Added strict ownership/active-row guards in reorder services for attributes and enumeration values (`id + object_id` scope, deleted flags filtering), plus target-parent ownership validation.
+3. Added and extended route-level tests for reorder endpoints (settings propagation, transfer block mapping, happy-path reorder, validation/not-found paths).
+4. Cleared newly introduced prettier/lint errors in touched DnD/backend files and revalidated build/test baselines.
+
+### Verified baseline
+
+- `pnpm --filter @universo/metahubs-backend test -- src/tests/routes/attributesRoutes.test.ts src/tests/routes/enumerationsRoutes.test.ts` -> pass (`2/2` suites, `21/21` tests)
+- `pnpm --filter @universo/metahubs-backend build` -> pass
+- `pnpm --filter @universo/metahubs-frontend build` -> pass (`Build complete in 6597ms`)
+- `pnpm --filter @universo/template-mui build` -> pass (`Build complete in 1461ms`)
+- `pnpm build` (root) -> pass (`56/56`, `6m33.197s`)
+
+### Active Risk / Follow-up
+
+- No blocker-level QA debt remains in this DnD remediation scope.
+- Legacy warning-only lint debt remains outside this focused closure and is unchanged.
+
+## Previous Focus: DnD for Attributes & Enumeration Values — Completed
+
+**Status**: ✅ Completed (all 11 phases + QA fixes)
+**Date**: 2026-03-03
+
+### Implementation summary
+
+Full drag-and-drop reordering for attributes (root + child lists with cross-list transfer) and enumeration values in metahubs-frontend + metahubs-backend. Uses `@dnd-kit` (same library as spaces-frontend CanvasTabs).
+
+**Backend**: `reorderAttribute()` with cross-list transfer validation (display attr, TABLE nesting, codename uniqueness with auto-rename up to 20 attempts), `reorderValue()` for enumerations. Both use transactional gap-shift + sequential normalization.
+
+**Frontend**: 11 DnD component files (7 for attributes, 4 for enumerations) with Provider/Hook/Component pattern. Integrated in AttributeList, ChildAttributeList, EnumerationValueList. Cross-list DnD via container registry. Two new metahub settings control cross-list permissions.
+
+### QA fixes applied (this pass)
+
+1. **Phase 2.2 settings i18n**: Added missing `catalogs.allowAttributeMoveBetweenRootAndChildren` and `catalogs.allowAttributeMoveBetweenChildLists` keys with descriptions in EN + RU.
+2. **Drag handle accessibility**: Added `dragHandleAriaLabel` prop chain through SortableRow → TableBody → List components using i18n `dnd.dragHandle` key.
+3. **Success snackbars**: Added `enqueueSnackbar(reorderSuccess)` after successful attribute and enumeration value reorder mutations.
+4. **Dead key cleanup**: Removed unused `attributes.dnd.transferBlocked` key (redundant with specific dialog messages).
+
+### Verified baseline
+
+- `pnpm --filter metahubs-frontend build` -> pass (5009ms)
+- All i18n keys verified: no unused DnD keys remain, JSON valid for both locales
+
+### Active Risk / Follow-up
+
+- **template-mui dist stale**: StyledTableCell/StyledTableRow present in source but not in dist type declarations. Full `pnpm build` resolves this.
+- **~9 pre-existing type errors** in EnumerationValueList.tsx unrelated to DnD — existed before and should be addressed in a separate pass.
+
+## Previous Focus: Codename Auto-Convert UX Hardening — Completed
 
 **Status**: ✅ Completed
 **Date**: 2026-03-03
@@ -28,7 +163,7 @@
 
 - No new regressions introduced by this hardening pass.
 
-## Current Focus: QA Debt Eradication — Completed
+## Previous Focus: QA Debt Eradication — Completed
 
 **Status**: ✅ Completed
 **Date**: 2026-03-03

--- a/memory-bank/plan/dnd-attributes-enum-values-plan-2026-03-03.md
+++ b/memory-bank/plan/dnd-attributes-enum-values-plan-2026-03-03.md
@@ -1,0 +1,1736 @@
+# Drag-and-Drop for Attributes & Enumeration Values
+
+> **Date**: 2026-03-03  
+> **Complexity**: Level 4 (Major/Complex)  
+> **Status**: PLAN — awaiting review
+
+---
+
+## Overview
+
+Implement drag-and-drop (DnD) reordering for:
+
+1. **Root attributes** within their list (single-list sortable)
+2. **Child attributes** within a TABLE attribute (single-list sortable)
+3. **Cross-list attribute transfer** — move attributes between root ↔ child and between different child lists (multi-container DnD)
+4. **Enumeration values** within their list (single-list sortable)
+
+DnD must complement the existing move-up/move-down actions (not replace them). Two metahub settings control cross-list permissions (both enabled by default). DnD within a single list is always available — there are no settings to disable it.
+
+**Dialog flow** for cross-list transfer:
+- **Display attribute** → info dialog (OK only) explaining the user must first reassign display attribute
+- **TABLE attribute to child list** → info dialog (OK only) explaining TABLE can only exist at root
+- **Codename conflict** → 409 from backend → ConfirmDialog ("Move" / "Cancel") offering auto-rename → retry with `autoRenameCodename: true`
+- **No conflict** → transfer proceeds immediately (no generic confirmation dialog)
+
+---
+
+## Design Decisions
+
+### DD-1: Why Dedicated DnD Table Components (not modifying FlowListTable)
+
+`FlowListTable` renders `<StyledTableRow>` directly inside its `.map()` loop. `@dnd-kit/sortable`'s `useSortable` hook must be called inside a component that owns the `<tr>` ref. Options:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| A. Modify FlowListTable | Shared reusable | Couples shared component to @dnd-kit; complex API surface; breaks SRP |
+| B. `renderRow` callback in FlowListTable | Minimal change | Can't inject ref/style into already-rendered JSX; useSortable needs a component boundary |
+| **C. Dedicated DnD table components** | Full control; follows CanvasTabs pattern; no shared-component coupling | Some rendering duplication |
+
+**Decision: Option C** — create `SortableAttributeTable` and `SortableEnumerationValueTable` in `metahubs-frontend`. This mirrors how `CanvasTabs.jsx` in `spaces-frontend` builds its own DnD-integrated component rather than adapting a generic one.
+
+### DD-2: Single DndContext for Cross-Container DnD
+
+For moving attributes between root and child lists (or between two child lists), a **single `DndContext`** must wrap the entire attribute area (root table + all expanded child tables). Each list has its own `SortableContext`. Event handlers (`onDragOver`, `onDragEnd`) detect cross-container movement and apply validation.
+
+### DD-3: Backend Reorder API
+
+Current `moveAttribute` API uses `{ direction: 'up' | 'down' }` which only swaps neighbors — unusable for arbitrary DnD reordering. New endpoint:
+
+```
+PATCH /metahub/:m/catalog/:c/attributes/reorder
+Body: { attributeId: string, newSortOrder: number, newParentAttributeId?: string | null, autoRenameCodename?: boolean }
+```
+
+- `newParentAttributeId` absent/unchanged → same-list reorder  
+- `newParentAttributeId` changed → cross-list transfer (includes validation + optional auto-rename)  
+- Backend normalizes all sibling sort_orders after the operation  
+
+### DD-4: Optimistic Updates with Revert-on-Error
+
+Follow the **CanvasTabs pattern**: optimistic local state → API call → revert on error → invalidate on success.
+
+For paginated lists (root attributes): DnD only reorders within the visible page. The `newSortOrder` is computed from the item's new index on the current page.
+
+### DD-5: Pagination Constraint
+
+Root attributes use `usePaginated`. DnD only reorders items **within the visible page**. Cross-page reordering is not supported via DnD; users should use move-up/move-down for that. We'll optionally default to loading all items when the list is small enough (< 100).
+
+---
+
+## Affected Areas
+
+### Packages to Modify
+
+| Package | Scope |
+|---------|-------|
+| `metahubs-frontend` | New DnD components, hooks, API functions; modify AttributeList, ChildAttributeList, EnumerationValueList |
+| `metahubs-backend` | New reorder/transfer endpoints and service methods |
+| `universo-types` | 2 new settings in `METAHUB_SETTINGS_REGISTRY` (cross-list permissions, default `true`) |
+| `universo-template-mui` | (1) Fix FlowListTable `key={index}` → `key={row.id}`; (2) Export `StyledTableCell`/`StyledTableRow` from shared file (QA-F10); (3) Add `hideCancelButton?: boolean` to `ConfirmPayload` interface and handle in `ConfirmDialog` (QA-F4) |
+
+### Key Files
+
+**Frontend (metahubs-frontend)**:
+- `src/domains/attributes/ui/AttributeList.tsx` — wrap with DndContext, replace FlowListTable with DnD table
+- `src/domains/attributes/ui/ChildAttributeList.tsx` — same
+- `src/domains/enumerations/ui/EnumerationValueList.tsx` — same
+- **NEW** `src/domains/attributes/ui/dnd/` — DnD components and hooks
+- **NEW** `src/domains/enumerations/ui/dnd/` — DnD components and hooks
+- `src/domains/attributes/api/attributes.ts` — new `reorderAttribute` API function
+- `src/domains/attributes/hooks/mutations.ts` — new `useReorderAttribute` mutation
+- `src/domains/enumerations/api/` — new `reorderEnumerationValue` API function
+- `src/domains/enumerations/hooks/` — new `useReorderEnumerationValue` mutation
+
+**Backend (metahubs-backend)**:
+- `src/domains/attributes/routes/attributesRoutes.ts` — new PATCH reorder endpoint
+- `src/domains/metahubs/services/MetahubAttributesService.ts` — new `reorderAttribute()` method
+- `src/domains/metahubs/services/MetahubEnumerationValuesService.ts` — new `reorderValue()` method
+
+**Shared types (universo-types)**:
+- `src/common/metahubs.ts` — 2 new settings entries
+
+---
+
+## Plan Steps
+
+### Phase 1: Bug Fix — FlowListTable Key
+
+> Independent prerequisite to prevent React reconciliation issues during DnD.
+
+- [ ] **Step 1.1**: Change `key={index}` → `key={row.id}` in `FlowListTable.tsx` row rendering
+
+```tsx
+// BEFORE (line 339, FlowListTable.tsx)
+{(sortedData || []).filter(activeFilter).map((row, index) => {
+    // ...
+    return (
+        <React.Fragment key={index}>
+
+// AFTER
+{(sortedData || []).filter(activeFilter).map((row, index) => {
+    // ...
+    return (
+        <React.Fragment key={row.id}>
+```
+
+> **QA-F15**: Verify that `FlowListTableData` interface always has `id: string`. Check all usages of `<FlowListTable>` across the project to confirm that `data` items always have `.id` populated. If not, use `row.id ?? index` as fallback.
+
+- [ ] **Step 1.2** (QA-F10): Export `StyledTableCell` and `StyledTableRow` from `@universo/template-mui`
+
+Currently these are defined inside `FlowListTable.tsx`. Export them from a shared file so DnD components can reuse them:
+```typescript
+// packages/universo-template-mui/base/src/components/table/TableStyles.ts
+export { StyledTableCell, StyledTableRow } from './FlowListTable'
+// Also re-export from the package index
+```
+
+- [ ] **Step 1.3** (QA-F4): Add `hideCancelButton` to `ConfirmPayload` and handle in `ConfirmDialog`
+
+```typescript
+// packages/universo-template-mui/base/src/store/actions.ts
+// Add to ConfirmPayload interface:
+export interface ConfirmPayload {
+    title?: string
+    description: string
+    confirmButtonName?: string
+    cancelButtonName?: string
+    customBtnId?: string
+    hideCancelButton?: boolean  // QA-F4: for info-only dialogs (display attribute block, TABLE block)
+}
+```
+
+In `ConfirmDialog.tsx`, conditionally hide the Cancel button:
+```tsx
+{!confirmState?.hideCancelButton && (
+    <StyledButton variant="outlined" onClick={onCancel}>
+        {confirmState?.cancelButtonName || t('common:confirm.cancelButtonText')}
+    </StyledButton>
+)}
+```
+
+---
+
+### Phase 2: New Metahub Settings
+
+- [ ] **Step 2.1**: Add settings to `METAHUB_SETTINGS_REGISTRY` in `universo-types`
+
+```typescript
+// packages/universo-types/base/src/common/metahubs.ts
+// Add after catalogs.allowElementDelete (sortOrder 9):
+
+{
+    key: 'catalogs.allowAttributeMoveBetweenRootAndChildren',
+    tab: 'catalogs',
+    valueType: 'boolean',
+    defaultValue: true,     // QA-F1: ТЗ says "по умолчанию включено"
+    sortOrder: 10
+},
+{
+    key: 'catalogs.allowAttributeMoveBetweenChildLists',
+    tab: 'catalogs',
+    valueType: 'boolean',
+    defaultValue: true,     // QA-F1: ТЗ says "по умолчанию включено"
+    sortOrder: 11
+},
+```
+
+> **QA-F2 Note**: Settings `catalogs.allowAttributeDragReorder` and `enumerations.allowValueDragReorder` were removed — they are NOT in the ТЗ. DnD reordering within a single list is always available; only cross-list transfer has settings.
+
+- [ ] **Step 2.2**: Add i18n keys for new settings (EN + RU) in `metahubs-frontend`
+
+```json
+// EN (only 2 settings per ТЗ)
+{
+    "settings.catalogs.allowAttributeMoveBetweenRootAndChildren": "Allow attributes to move between root and table columns",
+    "settings.catalogs.allowAttributeMoveBetweenRootAndChildren.description": "When enabled, attributes can be dragged between the root list and TABLE attribute child lists",
+    "settings.catalogs.allowAttributeMoveBetweenChildLists": "Allow attributes to move between different table column lists",
+    "settings.catalogs.allowAttributeMoveBetweenChildLists.description": "When enabled, child attributes can be dragged between different TABLE attribute child lists"
+}
+```
+
+```json
+// RU (only 2 settings per ТЗ)
+{
+    "settings.catalogs.allowAttributeMoveBetweenRootAndChildren": "Разрешить перемещение атрибутов между корневым списком и колонками таблиц",
+    "settings.catalogs.allowAttributeMoveBetweenRootAndChildren.description": "Позволяет перетаскивать атрибуты между корневым списком и списками дочерних атрибутов TABLE",
+    "settings.catalogs.allowAttributeMoveBetweenChildLists": "Разрешить перемещение атрибутов между разными списками колонок таблиц",
+    "settings.catalogs.allowAttributeMoveBetweenChildLists.description": "Позволяет перетаскивать дочерние атрибуты между списками разных TABLE-атрибутов"
+}
+```
+
+---
+
+### Phase 3: Backend — Reorder Endpoint for Attributes
+
+- [ ] **Step 3.1**: Add Zod schema and route for reorder
+
+```typescript
+// attributesRoutes.ts — new endpoint
+const reorderAttributeSchema = z.object({
+    attributeId: z.string().uuid(),
+    newSortOrder: z.number().int().min(1),
+    // If provided and differs from current → cross-list transfer
+    newParentAttributeId: z.string().uuid().nullable().optional(),
+    // QA-F3: When true, auto-rename codename on conflict using buildCodenameAttempt()
+    autoRenameCodename: z.boolean().optional()
+})
+
+// PATCH /metahub/:m/catalog/:c/attributes/reorder
+router.patch(
+    '/metahub/:metahubId/catalog/:catalogId/attributes/reorder',
+    authenticateToken,
+    async (req, res) => {
+        const { metahubId, catalogId } = req.params
+        const parsed = reorderAttributeSchema.safeParse(req.body)
+        if (!parsed.success) return res.status(400).json({ message: parsed.error.message })
+
+        const { attributeId, newSortOrder, newParentAttributeId, autoRenameCodename } = parsed.data
+        const userId = req.user?.id
+
+        try {
+            const result = await attributesService.reorderAttribute(
+                metahubId, catalogId, attributeId,
+                newSortOrder, newParentAttributeId, autoRenameCodename, userId
+            )
+            return res.json(result)
+        } catch (err: any) {
+            if (err.message?.includes('CODENAME_CONFLICT')) {
+                // QA-F3: Return 409 with conflict details so frontend can offer auto-rename
+                return res.status(409).json({
+                    message: err.message,
+                    code: 'CODENAME_CONFLICT',
+                    codename: err.codename // the conflicting codename
+                })
+            }
+            if (err.message?.includes('DISPLAY_ATTRIBUTE_TRANSFER_BLOCKED')) {
+                return res.status(422).json({ message: err.message, code: 'DISPLAY_ATTRIBUTE_TRANSFER_BLOCKED' })
+            }
+            if (err.message?.includes('TRANSFER_NOT_ALLOWED')) {
+                return res.status(403).json({ message: err.message, code: 'TRANSFER_NOT_ALLOWED' })
+            }
+            throw err
+        }
+    }
+)
+```
+
+- [ ] **Step 3.2**: Implement `reorderAttribute()` in `MetahubAttributesService`
+
+```typescript
+// MetahubAttributesService.ts
+async reorderAttribute(
+    metahubId: string,
+    objectId: string,
+    attributeId: string,
+    newSortOrder: number,
+    newParentAttributeId?: string | null,
+    autoRenameCodename?: boolean,   // QA-F3: auto-rename on codename conflict
+    userId?: string
+): Promise<Attribute> {
+    const schemaName = await this.schemaService.ensureSchema(metahubId, userId)
+
+    return this.knex.transaction(async (trx) => {
+        // 1. Fetch current attribute
+        const current = await trx.withSchema(schemaName)
+            .from('_mhb_attributes')
+            .where({ id: attributeId })
+            .first()
+        if (!current) throw new Error('Attribute not found')
+
+        const currentParent: string | null = current.parent_attribute_id ?? null
+        const targetParent: string | null =
+            newParentAttributeId !== undefined ? newParentAttributeId : currentParent
+
+        const isCrossList = targetParent !== currentParent
+
+        if (isCrossList) {
+            // ── Cross-list transfer validation ──
+            await this._validateCrossListTransfer(
+                trx, schemaName, metahubId, objectId,
+                current, targetParent, autoRenameCodename, userId
+            )
+
+            // Move: update parent_attribute_id
+            await trx.withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ id: attributeId })
+                .update({ parent_attribute_id: targetParent })
+
+            // Normalize source list (close gap)
+            await this._ensureSequentialSortOrder(
+                metahubId, objectId, trx, userId, currentParent
+            )
+        }
+
+        // 2. Ensure sequential order in target list
+        await this._ensureSequentialSortOrder(
+            metahubId, objectId, trx, userId, targetParent
+        )
+
+        // 3. Re-fetch to get current sort_order after normalization
+        const refreshed = await trx.withSchema(schemaName)
+            .from('_mhb_attributes')
+            .where({ id: attributeId })
+            .first()
+
+        const oldOrder = refreshed.sort_order
+        const clampedNew = Math.max(1, newSortOrder)
+
+        if (oldOrder !== clampedNew) {
+            // Shift siblings to make room
+            if (clampedNew < oldOrder) {
+                // Moving up: shift items [clampedNew, oldOrder) down by 1
+                await trx.withSchema(schemaName)
+                    .from('_mhb_attributes')
+                    .where({ object_id: objectId })
+                    .where(targetParent
+                        ? { parent_attribute_id: targetParent }
+                        : trx.raw('parent_attribute_id IS NULL'))
+                    .where('sort_order', '>=', clampedNew)
+                    .where('sort_order', '<', oldOrder)
+                    .whereNot({ id: attributeId })
+                    .increment('sort_order', 1)
+            } else {
+                // Moving down: shift items (oldOrder, clampedNew] up by 1
+                await trx.withSchema(schemaName)
+                    .from('_mhb_attributes')
+                    .where({ object_id: objectId })
+                    .where(targetParent
+                        ? { parent_attribute_id: targetParent }
+                        : trx.raw('parent_attribute_id IS NULL'))
+                    .where('sort_order', '>', oldOrder)
+                    .where('sort_order', '<=', clampedNew)
+                    .whereNot({ id: attributeId })
+                    .decrement('sort_order', 1)
+            }
+
+            // Set the target sort_order
+            await trx.withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ id: attributeId })
+                .update({ sort_order: clampedNew })
+        }
+
+        // 4. Final normalization pass
+        await this._ensureSequentialSortOrder(
+            metahubId, objectId, trx, userId, targetParent
+        )
+
+        // 5. Return updated attribute
+        const [updated] = await trx.withSchema(schemaName)
+            .from('_mhb_attributes')
+            .where({ id: attributeId })
+            .returning('*')
+        return this.mapRowToAttribute(updated)
+    })
+}
+
+private async _validateCrossListTransfer(
+    trx: any,
+    schemaName: string,
+    metahubId: string,
+    objectId: string,
+    attribute: any,
+    targetParentId: string | null,
+    autoRenameCodename?: boolean,   // QA-F3
+    userId?: string
+): Promise<void> {
+    // 1. Display attribute cannot be moved to child level
+    if (attribute.is_display_attribute && targetParentId !== null) {
+        throw new Error(
+            'DISPLAY_ATTRIBUTE_TRANSFER_BLOCKED: Display attribute cannot be moved. Assign another attribute as the display attribute first.'
+        )
+    }
+
+    // 2. TABLE attributes can only exist at root level (QA-F11)
+    if (attribute.data_type === 'TABLE' && targetParentId !== null) {
+        throw new Error(
+            'TRANSFER_NOT_ALLOWED: TABLE attributes can only exist at the root level'
+        )
+    }
+
+    // 3. If target is a child list, verify parent is TABLE type
+    if (targetParentId !== null) {
+        const parentAttr = await trx.withSchema(schemaName)
+            .from('_mhb_attributes')
+            .where({ id: targetParentId })
+            .first()
+        if (!parentAttr || parentAttr.data_type !== 'TABLE') {
+            throw new Error('TRANSFER_NOT_ALLOWED: Target parent is not a TABLE attribute')
+        }
+        // Check data type is allowed in TABLE children
+        const TABLE_CHILD_DATA_TYPES = ['STRING', 'NUMBER', 'BOOLEAN', 'DATE', 'REF', 'JSON']
+        if (!TABLE_CHILD_DATA_TYPES.includes(attribute.data_type)) {
+            throw new Error(
+                `TRANSFER_NOT_ALLOWED: ${attribute.data_type} attributes are not allowed in TABLE children`
+            )
+        }
+    }
+
+    // 4. Codename uniqueness in target scope
+    // QA-F3: Reuses buildCodenameAttempt() and retry loop from copy endpoint
+    const settings = await this.settingsService.getSettingsMap(metahubId, userId)
+    const codenameScope = settings['catalogs.attributeCodenameScope'] ?? 'per-level'
+
+    const hasConflict = async (codename: string): Promise<boolean> => {
+        let query = trx.withSchema(schemaName)
+            .from('_mhb_attributes')
+            .where({ object_id: objectId, codename })
+            .whereNot({ id: attribute.id })
+
+        if (codenameScope === 'global') {
+            // Global: unique across all attributes in catalog
+        } else {
+            // Per-level: unique among siblings
+            if (targetParentId) {
+                query = query.where({ parent_attribute_id: targetParentId })
+            } else {
+                query = query.whereNull('parent_attribute_id')
+            }
+        }
+        return !!(await query.first())
+    }
+
+    if (await hasConflict(attribute.codename)) {
+        if (!autoRenameCodename) {
+            // No auto-rename — throw conflict so frontend can show dialog
+            const error: any = new Error(
+                `CODENAME_CONFLICT: Codename "${attribute.codename}" already exists in the target scope`
+            )
+            error.codename = attribute.codename
+            throw error
+        }
+
+        // QA-F3: Auto-rename using buildCodenameAttempt() retry loop
+        // (same pattern as copy endpoint in attributesRoutes.ts)
+        const codenameStyle = extractCodenameStyle(attribute.codename)
+        let renamed = false
+        for (let attempt = 2; attempt <= 20 && !renamed; attempt++) {
+            const candidate = buildCodenameAttempt(attribute.codename, attempt, codenameStyle)
+            if (!(await hasConflict(candidate))) {
+                await trx.withSchema(schemaName)
+                    .from('_mhb_attributes')
+                    .where({ id: attribute.id })
+                    .update({ codename: candidate })
+                renamed = true
+            }
+        }
+        if (!renamed) {
+            throw new Error('CODENAME_CONFLICT: Could not generate unique codename after 20 attempts')
+        }
+    }
+}
+```
+
+- [ ] **Step 3.3**: Add hub-scoped route variant
+
+The existing routes support both hub-scoped (`/metahub/:m/hub/:h/catalog/:c/...`) and direct (`/metahub/:m/catalog/:c/...`) paths. The reorder endpoint needs both variants, following the same pattern as `moveAttribute`.
+
+---
+
+### Phase 4: Backend — Reorder Endpoint for Enumeration Values
+
+- [ ] **Step 4.1**: Add route and service method
+
+```typescript
+// enumerationRoutes.ts — new endpoint
+const reorderValueSchema = z.object({
+    valueId: z.string().uuid(),
+    newSortOrder: z.number().int().min(1)
+})
+
+// PATCH /metahub/:m/enumeration/:e/values/reorder
+```
+
+```typescript
+// MetahubEnumerationValuesService.ts
+async reorderValue(
+    metahubId: string,
+    objectId: string,
+    valueId: string,
+    newSortOrder: number,
+    userId?: string
+): Promise<EnumerationValue> {
+    const schemaName = await this.schemaService.ensureSchema(metahubId, userId)
+
+    return this.knex.transaction(async (trx) => {
+        // 1. Ensure sequential order
+        await this._ensureSequentialSortOrder(metahubId, objectId, trx, userId)
+
+        // 2. Fetch current value
+        const current = await trx.withSchema(schemaName)
+            .from('_mhb_values')
+            .where({ id: valueId })
+            .first()
+        if (!current) throw new Error('Enumeration value not found')
+
+        const oldOrder = current.sort_order
+        const clampedNew = Math.max(1, newSortOrder)
+
+        if (oldOrder !== clampedNew) {
+            if (clampedNew < oldOrder) {
+                await trx.withSchema(schemaName)
+                    .from('_mhb_values')
+                    .where({ object_id: objectId })
+                    .where('sort_order', '>=', clampedNew)
+                    .where('sort_order', '<', oldOrder)
+                    .whereNot({ id: valueId })
+                    .increment('sort_order', 1)
+            } else {
+                await trx.withSchema(schemaName)
+                    .from('_mhb_values')
+                    .where({ object_id: objectId })
+                    .where('sort_order', '>', oldOrder)
+                    .where('sort_order', '<=', clampedNew)
+                    .whereNot({ id: valueId })
+                    .decrement('sort_order', 1)
+            }
+
+            await trx.withSchema(schemaName)
+                .from('_mhb_values')
+                .where({ id: valueId })
+                .update({ sort_order: clampedNew })
+        }
+
+        // Final normalization
+        await this._ensureSequentialSortOrder(metahubId, objectId, trx, userId)
+
+        const [updated] = await trx.withSchema(schemaName)
+            .from('_mhb_values')
+            .where({ id: valueId })
+            .returning('*')
+        return this.mapRowToValue(updated)
+    })
+}
+```
+
+---
+
+### Phase 5: Frontend — DnD Dependencies & Shared Utilities
+
+- [ ] **Step 5.1**: Add `@dnd-kit` to `metahubs-frontend/package.json`
+
+```json
+{
+    "dependencies": {
+        "@dnd-kit/core": "catalog:",
+        "@dnd-kit/sortable": "catalog:",
+        "@dnd-kit/utilities": "catalog:"
+    }
+}
+```
+
+Versions are already in `pnpm-workspace.yaml` catalog:
+- `@dnd-kit/core`: ^6.3.1
+- `@dnd-kit/sortable`: ^8.0.0
+- `@dnd-kit/utilities`: ^3.2.2
+
+- [ ] **Step 5.2**: Create `src/domains/attributes/api/attributes.ts` — add API function
+
+```typescript
+// Add to attributes.ts:
+
+/**
+ * Reorder an attribute (with optional cross-list transfer).
+ * @param newParentAttributeId - undefined = same list, null = root, string = child of that parent
+ * @param autoRenameCodename - QA-F3: if true, auto-rename codename on conflict
+ */
+export const reorderAttribute = (
+    metahubId: string,
+    catalogId: string,
+    attributeId: string,
+    newSortOrder: number,
+    newParentAttributeId?: string | null,
+    autoRenameCodename?: boolean
+) =>
+    apiClient.patch<Attribute>(
+        `/metahub/${metahubId}/catalog/${catalogId}/attributes/reorder`,
+        {
+            attributeId,
+            newSortOrder,
+            ...(newParentAttributeId !== undefined && { newParentAttributeId }),
+            ...(autoRenameCodename && { autoRenameCodename })
+        }
+    )
+
+// Hub-scoped variant:
+export const reorderAttributeViaHub = (
+    metahubId: string,
+    hubId: string,
+    catalogId: string,
+    attributeId: string,
+    newSortOrder: number,
+    newParentAttributeId?: string | null,
+    autoRenameCodename?: boolean
+) =>
+    apiClient.patch<Attribute>(
+        `/metahub/${metahubId}/hub/${hubId}/catalog/${catalogId}/attributes/reorder`,
+        {
+            attributeId,
+            newSortOrder,
+            ...(newParentAttributeId !== undefined && { newParentAttributeId }),
+            ...(autoRenameCodename && { autoRenameCodename })
+        }
+    )
+```
+
+- [ ] **Step 5.3**: Create `useReorderAttribute` mutation hook
+
+```typescript
+// mutations.ts — new mutation
+interface ReorderAttributeParams {
+    metahubId: string
+    hubId?: string
+    catalogId: string
+    attributeId: string
+    newSortOrder: number
+    newParentAttributeId?: string | null
+    autoRenameCodename?: boolean   // QA-F3
+}
+
+export function useReorderAttribute() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async ({
+            metahubId, hubId, catalogId,
+            attributeId, newSortOrder, newParentAttributeId,
+            autoRenameCodename
+        }: ReorderAttributeParams) => {
+            if (hubId) {
+                const response = await attributesApi.reorderAttributeViaHub(
+                    metahubId, hubId, catalogId,
+                    attributeId, newSortOrder, newParentAttributeId,
+                    autoRenameCodename
+                )
+                return response.data
+            }
+            const response = await attributesApi.reorderAttribute(
+                metahubId, catalogId,
+                attributeId, newSortOrder, newParentAttributeId,
+                autoRenameCodename
+            )
+            return response.data
+        },
+        onSuccess: (_data, variables) => {
+            // Invalidate all relevant queries
+            if (variables.hubId) {
+                queryClient.invalidateQueries({
+                    queryKey: metahubsQueryKeys.attributes(
+                        variables.metahubId, variables.hubId, variables.catalogId
+                    )
+                })
+            } else {
+                queryClient.invalidateQueries({
+                    queryKey: metahubsQueryKeys.attributesDirect(
+                        variables.metahubId, variables.catalogId
+                    )
+                })
+            }
+            // Also invalidate child queries for cross-list moves
+            queryClient.invalidateQueries({
+                queryKey: ['metahubs', 'childAttributes', variables.metahubId, variables.catalogId]
+            })
+            queryClient.invalidateQueries({
+                queryKey: metahubsQueryKeys.catalogDetail(
+                    variables.metahubId, variables.catalogId
+                )
+            })
+            queryClient.invalidateQueries({
+                queryKey: metahubsQueryKeys.allCatalogs(variables.metahubId)
+            })
+        }
+        // QA-F8: NO onError here — error handling is done in the calling component
+        // so it can distinguish CODENAME_CONFLICT (409) and offer auto-rename dialog
+    })
+}
+```
+
+---
+
+### Phase 6: Frontend — DnD Components for Attributes
+
+Create a `dnd/` sub-folder inside `src/domains/attributes/ui/`.
+
+- [ ] **Step 6.1**: Create `SortableAttributeRow` component
+
+```tsx
+// src/domains/attributes/ui/dnd/SortableAttributeRow.tsx
+import React from 'react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
+// QA-F10: Reuse shared styled components instead of duplicating
+import { StyledTableCell, StyledTableRow } from '@universo/template-mui'
+
+interface SortableAttributeRowProps {
+    id: string
+    disabled?: boolean
+    children: React.ReactNode
+    /** Hide bottom border when expansion content follows */
+    hasExpansion?: boolean
+}
+
+export const SortableAttributeRow: React.FC<SortableAttributeRowProps> = ({
+    id,
+    disabled = false,
+    children,
+    hasExpansion = false
+}) => {
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging
+    } = useSortable({ id, disabled })
+
+    const style: React.CSSProperties = {
+        // QA-F6: Use CSS.Translate (not CSS.Transform) to avoid scale issues on <tr>
+        transform: CSS.Translate.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+        cursor: disabled ? 'default' : 'grab',
+        position: 'relative',
+        zIndex: isDragging ? 1 : 'auto'
+    }
+
+    return (
+        <StyledTableRow
+            ref={setNodeRef}
+            style={style}
+            sx={hasExpansion ? { '& td, & th': { borderBottom: 0 } } : undefined}
+            {...attributes}
+        >
+            {/* Drag handle column */}
+            <StyledTableCell
+                align="center"
+                sx={{ width: 40, px: 0.5, cursor: disabled ? 'default' : 'grab' }}
+                {...listeners}
+            >
+                <DragIndicatorIcon
+                    fontSize="small"
+                    sx={{
+                        color: disabled ? 'action.disabled' : 'action.active',
+                        '&:hover': disabled ? {} : { color: 'primary.main' }
+                    }}
+                />
+            </StyledTableCell>
+            {children}
+        </StyledTableRow>
+    )
+}
+```
+
+- [ ] **Step 6.2**: Create `DragOverlayRow` component
+
+```tsx
+// src/domains/attributes/ui/dnd/DragOverlayRow.tsx
+import React from 'react'
+import { Paper, Typography, Chip, Stack } from '@mui/material'
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
+import type { AttributeDisplay } from '../../../../types'
+
+interface DragOverlayRowProps {
+    attribute: AttributeDisplay
+}
+
+export const DragOverlayRow: React.FC<DragOverlayRowProps> = ({ attribute }) => {
+    return (
+        <Paper
+            elevation={8}
+            sx={{
+                p: 1.5,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                minWidth: 300,
+                maxWidth: 500,
+                borderLeft: '3px solid',
+                borderColor: 'primary.main',
+                opacity: 0.95
+            }}
+        >
+            <DragIndicatorIcon fontSize="small" sx={{ color: 'primary.main' }} />
+            <Typography variant="body2" fontWeight={500} noWrap>
+                {attribute.name || attribute.codename}
+            </Typography>
+            <Chip
+                label={attribute.dataType}
+                size="small"
+                sx={{ ml: 'auto' }}
+            />
+        </Paper>
+    )
+}
+```
+
+- [ ] **Step 6.3**: Create `useAttributeDnd` hook
+
+```tsx
+// src/domains/attributes/ui/dnd/useAttributeDnd.ts
+import { useState, useCallback, useRef } from 'react'
+import type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import type { Attribute, AttributeDisplay } from '../../../../types'
+
+interface ContainerInfo {
+    id: string                    // 'root' | `child-${parentId}`
+    parentAttributeId: string | null
+    items: Attribute[]
+}
+
+interface UseAttributeDndOptions {
+    containers: ContainerInfo[]
+    allowCrossListRootChildren: boolean
+    allowCrossListBetweenChildren: boolean
+    onReorder: (
+        attributeId: string,
+        newSortOrder: number,
+        newParentAttributeId?: string | null
+    ) => Promise<void>
+    onValidateTransfer?: (
+        attribute: Attribute,
+        targetParentId: string | null
+    ) => Promise<boolean>
+}
+
+export function useAttributeDnd({
+    containers,
+    allowCrossListRootChildren,
+    allowCrossListBetweenChildren,
+    onReorder,
+    onValidateTransfer
+}: UseAttributeDndOptions) {
+    const [activeId, setActiveId] = useState<string | null>(null)
+    const [overId, setOverId] = useState<string | null>(null)
+
+    // Track optimistic container state for cross-container moves
+    const [optimisticContainers, setOptimisticContainers] =
+        useState<Map<string, string[]> | null>(null)
+
+    const findContainer = useCallback(
+        (itemId: string): ContainerInfo | undefined => {
+            return containers.find((c) =>
+                c.items.some((item) => item.id === itemId)
+            )
+        },
+        [containers]
+    )
+
+    const findAttribute = useCallback(
+        (itemId: string): Attribute | undefined => {
+            for (const c of containers) {
+                const found = c.items.find((item) => item.id === itemId)
+                if (found) return found
+            }
+            return undefined
+        },
+        [containers]
+    )
+
+    const isCrossListAllowed = useCallback(
+        (sourceContainer: ContainerInfo, targetContainer: ContainerInfo): boolean => {
+            if (sourceContainer.id === targetContainer.id) return true
+
+            const sourceIsRoot = sourceContainer.parentAttributeId === null
+            const targetIsRoot = targetContainer.parentAttributeId === null
+
+            if (sourceIsRoot || targetIsRoot) {
+                return allowCrossListRootChildren
+            }
+            return allowCrossListBetweenChildren
+        },
+        [allowCrossListRootChildren, allowCrossListBetweenChildren]
+    )
+
+    const handleDragStart = useCallback((event: DragStartEvent) => {
+        setActiveId(String(event.active.id))
+    }, [])
+
+    const handleDragOver = useCallback(
+        (event: DragOverEvent) => {
+            // For cross-container visual feedback
+            const { active, over } = event
+            if (!over) return
+
+            const activeContainer = findContainer(String(active.id))
+            const overContainer =
+                findContainer(String(over.id)) ||
+                containers.find((c) => c.id === String(over.id))
+
+            if (!activeContainer || !overContainer) return
+            if (activeContainer.id === overContainer.id) return
+
+            // Check if cross-list is allowed
+            if (!isCrossListAllowed(activeContainer, overContainer)) return
+
+            setOverId(String(over.id))
+        },
+        [containers, findContainer, isCrossListAllowed]
+    )
+
+    const handleDragEnd = useCallback(
+        async (event: DragEndEvent) => {
+            const { active, over } = event
+            setActiveId(null)
+            setOverId(null)
+            setOptimisticContainers(null)
+
+            if (!over) return
+
+            const activeContainer = findContainer(String(active.id))
+            const overContainer =
+                findContainer(String(over.id)) ||
+                containers.find((c) => c.id === String(over.id))
+
+            if (!activeContainer || !overContainer) return
+
+            const attribute = findAttribute(String(active.id))
+            if (!attribute) return
+
+            if (activeContainer.id === overContainer.id) {
+                // Same-list reorder
+                const items = activeContainer.items
+                const oldIndex = items.findIndex((i) => i.id === String(active.id))
+                const overItem = items.findIndex((i) => i.id === String(over.id))
+
+                if (oldIndex === -1 || overItem === -1 || oldIndex === overItem) return
+
+                const newSortOrder = items[overItem].sortOrder ?? (overItem + 1)
+
+                await onReorder(String(active.id), newSortOrder)
+            } else {
+                // Cross-list transfer
+                if (!isCrossListAllowed(activeContainer, overContainer)) return
+
+                // Validate transfer
+                if (onValidateTransfer) {
+                    const allowed = await onValidateTransfer(
+                        attribute,
+                        overContainer.parentAttributeId
+                    )
+                    if (!allowed) return
+                }
+
+                // Calculate new sort_order in target container
+                const targetItems = overContainer.items
+                const overIndex = targetItems.findIndex(
+                    (i) => i.id === String(over.id)
+                )
+                const newSortOrder =
+                    overIndex >= 0
+                        ? (targetItems[overIndex].sortOrder ?? overIndex + 1)
+                        : targetItems.length + 1
+
+                await onReorder(
+                    String(active.id),
+                    newSortOrder,
+                    overContainer.parentAttributeId
+                )
+            }
+        },
+        [
+            containers,
+            findContainer,
+            findAttribute,
+            isCrossListAllowed,
+            onReorder,
+            onValidateTransfer
+        ]
+    )
+
+    const handleDragCancel = useCallback(() => {
+        setActiveId(null)
+        setOverId(null)
+        setOptimisticContainers(null)
+    }, [])
+
+    const activeAttribute = activeId ? findAttribute(activeId) : undefined
+
+    return {
+        activeId,
+        activeAttribute,
+        overId,
+        optimisticContainers,
+        handleDragStart,
+        handleDragOver,
+        handleDragEnd,
+        handleDragCancel
+    }
+}
+```
+
+- [ ] **Step 6.4**: Create `AttributeDndProvider` wrapper
+
+```tsx
+// src/domains/attributes/ui/dnd/AttributeDndProvider.tsx
+import React, { useMemo } from 'react'
+import {
+    DndContext,
+    DragOverlay,
+    PointerSensor,
+    KeyboardSensor,
+    useSensors,
+    useSensor,
+    closestCenter,
+    MeasuringStrategy
+} from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { useAttributeDnd } from './useAttributeDnd'
+import { DragOverlayRow } from './DragOverlayRow'
+import type { Attribute } from '../../../../types'
+// QA-F12: toAttributeDisplay exists at src/types.ts (line 681); import path ../../../../types is correct for src/domains/attributes/ui/dnd/
+import { toAttributeDisplay } from '../../../../types'
+
+interface AttributeDndProviderProps {
+    children: React.ReactNode
+    containers: Array<{
+        id: string
+        parentAttributeId: string | null
+        items: Attribute[]
+    }>
+    allowCrossListRootChildren: boolean
+    allowCrossListBetweenChildren: boolean
+    onReorder: (
+        attributeId: string,
+        newSortOrder: number,
+        newParentAttributeId?: string | null
+    ) => Promise<void>
+    onValidateTransfer?: (
+        attribute: Attribute,
+        targetParentId: string | null
+    ) => Promise<boolean>
+    uiLocale: string
+    // QA-F2: No 'disabled' prop — DnD is always enabled per ТЗ
+}
+
+export const AttributeDndProvider: React.FC<AttributeDndProviderProps> = ({
+    children,
+    containers,
+    allowCrossListRootChildren,
+    allowCrossListBetweenChildren,
+    onReorder,
+    onValidateTransfer,
+    uiLocale
+}) => {
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 8 } // Prevent accidental drags
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates
+        })
+    )
+
+    const {
+        activeAttribute,
+        handleDragStart,
+        handleDragOver,
+        handleDragEnd,
+        handleDragCancel
+    } = useAttributeDnd({
+        containers,
+        allowCrossListRootChildren,
+        allowCrossListBetweenChildren,
+        onReorder,
+        onValidateTransfer
+    })
+
+    return (
+        <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+            // QA-F7: Prevent validateDOMNesting warnings for <div> inside <table>
+            accessibility={{ container: document.body }}
+            measuring={{
+                droppable: { strategy: MeasuringStrategy.Always }
+            }}
+        >
+            {children}
+            <DragOverlay dropAnimation={null}>
+                {activeAttribute ? (
+                    <DragOverlayRow
+                        attribute={toAttributeDisplay(activeAttribute, uiLocale)}
+                    />
+                ) : null}
+            </DragOverlay>
+        </DndContext>
+    )
+}
+```
+
+- [ ] **Step 6.5**: Create `SortableAttributeTableBody` component
+
+This component replaces the direct use of `FlowListTable` in AttributeList when DnD is enabled. It renders the same column structure but each row is wrapped with `SortableAttributeRow`.
+
+```tsx
+// src/domains/attributes/ui/dnd/SortableAttributeTableBody.tsx
+import React from 'react'
+import {
+    SortableContext,
+    verticalListSortingStrategy
+} from '@dnd-kit/sortable'
+import { useDroppable } from '@dnd-kit/core'
+import { Table, TableBody, TableHead, TableRow, TableCell } from '@mui/material'
+import { SortableAttributeRow } from './SortableAttributeRow'
+import type { AttributeDisplay, Attribute } from '../../../../types'
+import type { TableColumn } from '@universo/template-mui'
+
+interface SortableAttributeTableBodyProps {
+    containerId: string
+    items: Attribute[]
+    displayItems: AttributeDisplay[]
+    columns: TableColumn<AttributeDisplay>[]
+    renderActions?: (row: AttributeDisplay) => React.ReactNode
+    renderRowExpansion?: (row: AttributeDisplay, index: number) => React.ReactNode | null
+    disabled?: boolean
+}
+
+export const SortableAttributeTableBody: React.FC<
+    SortableAttributeTableBodyProps
+> = ({
+    containerId,
+    items,
+    displayItems,
+    columns,
+    renderActions,
+    renderRowExpansion,
+    disabled = false
+}) => {
+    const { setNodeRef } = useDroppable({ id: containerId })
+    const itemIds = items.map((item) => item.id)
+
+    return (
+        <SortableContext
+            items={itemIds}
+            strategy={verticalListSortingStrategy}
+        >
+            <TableBody ref={setNodeRef}>
+                {displayItems.map((row, index) => {
+                    const expansionContent = renderRowExpansion
+                        ? renderRowExpansion(row, index)
+                        : null
+
+                    return (
+                        <React.Fragment key={row.id}>
+                            <SortableAttributeRow
+                                id={row.id}
+                                disabled={disabled}
+                                hasExpansion={Boolean(expansionContent)}
+                            >
+                                {columns.map((col) => (
+                                    <TableCell
+                                        key={col.id}
+                                        align={col.align || 'left'}
+                                    >
+                                        {col.render?.(row, index)}
+                                    </TableCell>
+                                ))}
+                                {renderActions && (
+                                    <TableCell align="center">
+                                        {renderActions(row)}
+                                    </TableCell>
+                                )}
+                            </SortableAttributeRow>
+                            {expansionContent && (
+                                <TableRow>
+                                    <TableCell
+                                        colSpan={
+                                            columns.length +
+                                            (renderActions ? 1 : 0) +
+                                            1 /* drag handle column */
+                                        }
+                                        sx={{ py: 0, px: 0 }}
+                                    >
+                                        {expansionContent}
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                        </React.Fragment>
+                    )
+                })}
+            </TableBody>
+        </SortableContext>
+    )
+}
+```
+
+- [ ] **Step 6.6**: Create DnD index barrel file
+
+```typescript
+// src/domains/attributes/ui/dnd/index.ts
+export { SortableAttributeRow } from './SortableAttributeRow'
+export { DragOverlayRow } from './DragOverlayRow'
+export { useAttributeDnd } from './useAttributeDnd'
+export { AttributeDndProvider } from './AttributeDndProvider'
+export { SortableAttributeTableBody } from './SortableAttributeTableBody'
+```
+
+---
+
+### Phase 7: Frontend — Integrate DnD in AttributeList
+
+- [ ] **Step 7.1**: Wrap AttributeList with `AttributeDndProvider`
+
+In `AttributeList.tsx`:
+
+1. Read new settings:
+```typescript
+// QA-F2: Only 2 settings per ТЗ (no allowDragReorder — DnD is always on)
+const allowCrossListRootChildren = useSettingValue<boolean>('catalogs.allowAttributeMoveBetweenRootAndChildren') ?? true
+const allowCrossListBetweenChildren = useSettingValue<boolean>('catalogs.allowAttributeMoveBetweenChildLists') ?? true
+```
+
+2. Build container list from root attributes + expanded child attributes:
+```typescript
+const dndContainers = useMemo(() => {
+    const containers = [{
+        id: 'root',
+        parentAttributeId: null,
+        items: attributes
+    }]
+    // Child containers added by ChildAttributeList via context
+    return containers
+}, [attributes])
+```
+
+3. Wrap the table area with `AttributeDndProvider`:
+```tsx
+{/* QA-F2: DnD is always enabled (no disabled prop) */}
+<AttributeDndProvider
+    containers={dndContainers}
+    allowCrossListRootChildren={allowCrossListRootChildren}
+    allowCrossListBetweenChildren={allowCrossListBetweenChildren}
+    onReorder={handleReorder}
+    onValidateTransfer={handleValidateTransfer}
+    uiLocale={i18n.language}
+>
+    {/* Root attribute table using SortableAttributeTableBody */}
+    {/* ... */}
+</AttributeDndProvider>
+```
+
+4. Replace `<FlowListTable>` with MUI Table + `<SortableAttributeTableBody>` (DnD is always on, no fallback needed):
+
+```tsx
+{/* QA-F2: No conditional fallback to FlowListTable — DnD table is always used */}
+<Table>
+    <TableHead>{/* same columns as before + drag handle column */}</TableHead>
+    <SortableAttributeTableBody
+        containerId="root"
+        items={attributes}
+        displayItems={attributes.map(getAttributeTableData)}
+        columns={attributeColumns}
+        renderActions={renderActions}
+        renderRowExpansion={renderRowExpansion}
+    />
+</Table>
+```
+
+- [ ] **Step 7.2**: Implement optimistic reorder handler
+
+```typescript
+const reorderMutation = useReorderAttribute()
+const { confirm } = useConfirm()   // QA-F3: for codename conflict dialog
+
+const handleReorder = useCallback(
+    async (
+        attributeId: string,
+        newSortOrder: number,
+        newParentAttributeId?: string | null
+    ) => {
+        if (!metahubId || !catalogId) return
+
+        try {
+            await reorderMutation.mutateAsync({
+                metahubId,
+                hubId: effectiveHubId,
+                catalogId,
+                attributeId,
+                newSortOrder,
+                newParentAttributeId
+            })
+        } catch (error: unknown) {
+            // QA-F3: Handle CODENAME_CONFLICT (409) — offer auto-rename
+            if (error instanceof Error && (error as any).response?.status === 409) {
+                const conflictCodename = (error as any).response?.data?.codename
+                const shouldAutoRename = await confirm({
+                    title: t('attributes.dnd.codenameConflictTitle', 'Codename conflict'),
+                    description: t(
+                        'attributes.dnd.codenameConflictDescription',
+                        'An attribute with codename "{{codename}}" already exists in the target list. Move with automatic codename rename?',
+                        { codename: conflictCodename }
+                    ),
+                    confirmButtonName: t('attributes.dnd.confirmMove', 'Move'),
+                    cancelButtonName: t('common:confirm.cancelButtonText', 'Cancel')
+                })
+                if (shouldAutoRename) {
+                    try {
+                        await reorderMutation.mutateAsync({
+                            metahubId,
+                            hubId: effectiveHubId,
+                            catalogId,
+                            attributeId,
+                            newSortOrder,
+                            newParentAttributeId,
+                            autoRenameCodename: true
+                        })
+                    } catch (retryError: unknown) {
+                        const msg = retryError instanceof Error ? retryError.message
+                            : t('attributes.reorderError', 'Failed to reorder attribute')
+                        enqueueSnackbar(msg, { variant: 'error' })
+                    }
+                }
+                return
+            }
+            // Other errors — show generic snackbar
+            const message = error instanceof Error ? error.message
+                : t('attributes.reorderError', 'Failed to reorder attribute')
+            enqueueSnackbar(message, { variant: 'error' })
+        }
+    },
+    [metahubId, catalogId, effectiveHubId, reorderMutation, confirm, enqueueSnackbar, t]
+)
+```
+
+- [ ] **Step 7.3**: Implement cross-list transfer validation (pre-drag checks)
+
+```typescript
+// QA-F4+F5: Only two specialized dialogs, no generic confirmation for cross-list moves
+const handleValidateTransfer = useCallback(
+    async (attribute: Attribute, targetParentId: string | null): Promise<boolean> => {
+        // 1. QA-F4: Display attribute → show info dialog with OK button only
+        if (attribute.isDisplayAttribute && targetParentId !== null) {
+            await confirm({
+                title: t('attributes.dnd.displayAttributeBlockedTitle', 'Cannot move display attribute'),
+                description: t(
+                    'attributes.dnd.displayAttributeBlockedDescription',
+                    'This attribute is the display attribute for its list. Assign another attribute as the display attribute first, then try again.'
+                ),
+                confirmButtonName: t('common:ok', 'OK'),
+                hideCancelButton: true   // QA-F4: only OK, no Cancel
+            })
+            return false
+        }
+
+        // 2. TABLE attributes can only exist at root level
+        if (attribute.dataType === 'TABLE' && targetParentId !== null) {
+            await confirm({
+                title: t('attributes.dnd.tableCannotMoveTitle', 'Cannot move TABLE attribute'),
+                description: t(
+                    'attributes.dnd.tableCannotMoveDescription',
+                    'TABLE attributes can only exist at the root level.'
+                ),
+                confirmButtonName: t('common:ok', 'OK'),
+                hideCancelButton: true
+            })
+            return false
+        }
+
+        // QA-F5: No generic confirmation dialog — cross-list moves proceed immediately.
+        // Codename conflicts are handled after the API call in handleReorder (F3).
+        return true
+    },
+    [confirm, t]
+)
+```
+
+---
+
+### Phase 8: Frontend — Integrate DnD in ChildAttributeList
+
+- [ ] **Step 8.1**: Similar pattern to AttributeList
+
+ChildAttributeList registers itself as a DnD container via the parent's `AttributeDndProvider` context. Each child list gets its own `SortableContext` with `containerId = child-{parentAttributeId}`.
+
+The `ChildAttributeList` component will:
+1. Render its own `SortableAttributeTableBody` with `containerId={`child-${parentAttributeId}`}`
+2. Report its items to the parent DnD context (for cross-container awareness)
+
+Implementation detail: Use a shared React context (`AttributeDndContainerRegistry`) where child lists register/unregister their items. The parent `AttributeDndProvider` reads from this registry.
+
+```tsx
+// src/domains/attributes/ui/dnd/AttributeDndContainerRegistry.tsx
+// QA-F9: Simplified — plain React Context + useState instead of useSyncExternalStore overhead
+import React, { createContext, useContext, useCallback, useState } from 'react'
+import type { Attribute } from '../../../../types'
+
+interface ContainerEntry {
+    id: string
+    parentAttributeId: string | null
+    items: Attribute[]
+}
+
+interface ContainerRegistryValue {
+    containers: ContainerEntry[]
+    register: (entry: ContainerEntry) => void
+    unregister: (id: string) => void
+}
+
+const AttributeDndContainerRegistryContext = createContext<ContainerRegistryValue | null>(null)
+
+export const AttributeDndContainerRegistryProvider: React.FC<{
+    children: React.ReactNode
+}> = ({ children }) => {
+    const [containers, setContainers] = useState<ContainerEntry[]>([])
+
+    const register = useCallback((entry: ContainerEntry) => {
+        setContainers((prev) => {
+            const filtered = prev.filter((c) => c.id !== entry.id)
+            return [...filtered, entry]
+        })
+    }, [])
+
+    const unregister = useCallback((id: string) => {
+        setContainers((prev) => prev.filter((c) => c.id !== id))
+    }, [])
+
+    return (
+        <AttributeDndContainerRegistryContext.Provider
+            value={{ containers, register, unregister }}
+        >
+            {children}
+        </AttributeDndContainerRegistryContext.Provider>
+    )
+}
+
+export function useContainerRegistry() {
+    const ctx = useContext(AttributeDndContainerRegistryContext)
+    if (!ctx) throw new Error('useContainerRegistry must be inside AttributeDndContainerRegistryProvider')
+    return ctx
+}
+
+export function useRegisteredContainers(): ContainerEntry[] {
+    const { containers } = useContainerRegistry()
+    return containers
+}
+```
+
+---
+
+### Phase 9: Frontend — DnD for Enumeration Values
+
+- [ ] **Step 9.1**: Create simpler DnD components for enumeration values
+
+Since enumeration values are a simple flat list with no cross-container logic, the implementation is straightforward:
+
+```tsx
+// src/domains/enumerations/ui/dnd/SortableValueRow.tsx
+// Same pattern as SortableAttributeRow — wraps <StyledTableRow> with useSortable
+// Uses CSS.Translate.toString(transform) for <tr> safety (QA-F6)
+// Imports StyledTableCell, StyledTableRow from @universo/template-mui (QA-F10)
+// Includes DragIndicatorIcon handle column
+```
+
+```tsx
+// src/domains/enumerations/ui/dnd/DragOverlayValueRow.tsx
+// Lightweight Paper overlay showing value name + codename during drag
+// Similar minimal style as DragOverlayRow for attributes
+```
+
+```tsx
+// src/domains/enumerations/ui/dnd/SortableEnumerationValueTable.tsx
+// Wraps the values table body with SortableContext + DndContext
+// Single-container only (no cross-container for enum values)
+// Contains DndContext with accessibility={{ container: document.body }} (QA-F7)
+// Contains DragOverlay with DragOverlayValueRow
+// Sensors: PointerSensor { distance: 8 } + KeyboardSensor
+```
+
+- [ ] **Step 9.2**: Add API function and mutation
+
+```typescript
+// src/domains/enumerations/api/enumerationValues.ts — add:
+export const reorderEnumerationValue = (
+    metahubId: string,
+    enumerationId: string,
+    valueId: string,
+    newSortOrder: number
+) =>
+    apiClient.patch<EnumerationValue>(
+        `/metahub/${metahubId}/enumeration/${enumerationId}/values/reorder`,
+        { valueId, newSortOrder }
+    )
+```
+
+```typescript
+// src/domains/enumerations/hooks/mutations.ts — add:
+interface ReorderEnumerationValueParams {
+    metahubId: string
+    hubId?: string
+    enumerationId: string
+    valueId: string
+    newSortOrder: number
+}
+
+export function useReorderEnumerationValue() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async ({ metahubId, enumerationId, valueId, newSortOrder }: ReorderEnumerationValueParams) => {
+            const response = await enumerationValuesApi.reorderEnumerationValue(
+                metahubId, enumerationId, valueId, newSortOrder
+            )
+            return response.data
+        },
+        onSuccess: (_data, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: metahubsQueryKeys.enumerationValues(variables.metahubId, variables.enumerationId)
+            })
+        }
+    })
+}
+```
+
+- [ ] **Step 9.3**: Integrate in `EnumerationValueList.tsx`
+
+DnD is always enabled for enumeration values (no setting to disable it):
+
+```tsx
+// In EnumerationValueList.tsx:
+const reorderMutation = useReorderEnumerationValue()
+
+const handleReorder = useCallback(async (valueId: string, newSortOrder: number) => {
+    if (!metahubId || !enumerationId) return
+    try {
+        await reorderMutation.mutateAsync({
+            metahubId, enumerationId, valueId, newSortOrder
+        })
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : t('enumerationValues.reorderError')
+        enqueueSnackbar(message, { variant: 'error' })
+    }
+}, [metahubId, enumerationId, reorderMutation, enqueueSnackbar, t])
+
+// Replace FlowListTable with SortableEnumerationValueTable
+// Always on, no conditional rendering
+```
+
+---
+
+### Phase 10: i18n Keys
+
+- [ ] **Step 10.1**: Add all DnD-related i18n keys
+
+```json
+// EN additions
+{
+    "attributes.reorderSuccess": "Attribute order updated",
+    "attributes.reorderError": "Failed to reorder attribute",
+    "attributes.dnd.dragHandle": "Drag to reorder",
+
+    "attributes.dnd.codenameConflictTitle": "Codename conflict",
+    "attributes.dnd.codenameConflictDescription": "An attribute with codename \"{{codename}}\" already exists in the target list. Move with automatic codename rename?",
+    "attributes.dnd.confirmMove": "Move",
+
+    "attributes.dnd.displayAttributeBlockedTitle": "Cannot move display attribute",
+    "attributes.dnd.displayAttributeBlockedDescription": "This attribute is the display attribute for its list. Assign another attribute as the display attribute first, then try again.",
+    "attributes.dnd.tableCannotMoveTitle": "Cannot move TABLE attribute",
+    "attributes.dnd.tableCannotMoveDescription": "TABLE attributes can only exist at the root level.",
+
+    "attributes.dnd.transferBlocked": "This attribute cannot be moved to the selected list",
+
+    "enumerationValues.reorderSuccess": "Value order updated",
+    "enumerationValues.reorderError": "Failed to reorder value",
+    "enumerationValues.dnd.dragHandle": "Drag to reorder"
+}
+```
+
+```json
+// RU additions
+{
+    "attributes.reorderSuccess": "Порядок атрибутов обновлён",
+    "attributes.reorderError": "Не удалось изменить порядок атрибута",
+    "attributes.dnd.dragHandle": "Перетащите для изменения порядка",
+
+    "attributes.dnd.codenameConflictTitle": "Конфликт кодового имени",
+    "attributes.dnd.codenameConflictDescription": "Атрибут с кодовым именем «{{codename}}» уже существует в целевом списке. Переместить с автоматическим переименованием?",
+    "attributes.dnd.confirmMove": "Переместить",
+
+    "attributes.dnd.displayAttributeBlockedTitle": "Нельзя переместить атрибут отображения",
+    "attributes.dnd.displayAttributeBlockedDescription": "Этот атрибут является атрибутом отображения для своего списка. Сначала назначьте другой атрибут в качестве атрибута отображения, затем повторите попытку.",
+    "attributes.dnd.tableCannotMoveTitle": "Нельзя переместить TABLE-атрибут",
+    "attributes.dnd.tableCannotMoveDescription": "TABLE-атрибуты могут существовать только на корневом уровне.",
+
+    "attributes.dnd.transferBlocked": "Этот атрибут нельзя переместить в выбранный список",
+
+    "enumerationValues.reorderSuccess": "Порядок значений обновлён",
+    "enumerationValues.reorderError": "Не удалось изменить порядок значения",
+    "enumerationValues.dnd.dragHandle": "Перетащите для изменения порядка"
+}
+```
+
+> **Note**: Keys `confirmTransferTitle`, `confirmTransferDescription`, `displayAttributeCannotMove`, `tableCannotNest` removed — replaced by the more specific dialog keys above (QA-F4/F5).
+
+---
+
+### Phase 11: Tests
+
+- [ ] **Step 11.1**: Backend tests for reorder endpoints
+  - Same-list reorder (move attribute from position 3 to position 1)
+  - Cross-list transfer (root → child, child → root, child → child)
+  - Codename conflict validation (per-level and global scope)
+  - Display attribute transfer block
+  - TABLE nesting block
+  - Concurrent reorder safety (sequential sort_order normalization)
+
+- [ ] **Step 11.2**: Frontend tests for DnD hooks
+  - `useAttributeDnd` — same-list reorder events
+  - `useAttributeDnd` — cross-list events with validation
+  - Container registry — register/unregister lifecycle
+
+- [ ] **Step 11.3**: Lint verification
+  - `pnpm --filter @universo/metahubs-frontend lint`
+  - `pnpm --filter @universo/metahubs-backend lint`
+
+- [ ] **Step 11.4**: Full workspace build
+  - `pnpm build`
+
+---
+
+## Potential Challenges
+
+### C-1: FlowListTable Replacement Scope
+
+Replacing `FlowListTable` with a DnD-aware table might regress features like sorting, loading skeletons, and row expansion. **Mitigation**: DnD is always enabled (no fallback to FlowListTable per QA-F2). Replicate only the column rendering in the DnD table — sorting/filtering is not used in attribute lists (they're sorted by `sortOrder` server-side). Loading skeletons and empty states should be handled before the DnD table renders.
+
+### C-2: Pagination + DnD
+
+Root attributes use `usePaginated`. DnD within a page works, but the `newSortOrder` must be computed correctly relative to the page offset. **Mitigation**: Compute `newSortOrder` as `pageOffset + dropIndex + 1` or use the `sortOrder` value of the item at the drop position. Backend handles the rest.
+
+### C-3: Cross-Container DnD Complexity
+
+@dnd-kit's multi-container requires `onDragOver` to detect cross-container movement and update state accordingly. If two containers are far apart on screen, visual feedback during drag can be confusing. **Mitigation**: Use `DragOverlay` for a floating preview, highlight valid drop targets, and show a warning indicator when hovering over disallowed containers.
+
+### C-4: Codename Uniqueness on Cross-List Transfer
+
+When moving an attribute to a new scope, its codename may conflict with existing attributes. **Mitigation**: Backend validates codename uniqueness and returns 409 CODENAME_CONFLICT with the conflicting codename. Frontend catches the 409, shows a ConfirmDialog offering auto-rename. On confirmation, retries with `autoRenameCodename: true`, and the backend uses `buildCodenameAttempt()` (up to 20 attempts) to generate a unique codename. No client-side pre-check needed.
+
+### C-5: Child List Registration Lifecycle
+
+ChildAttributeList mounts only when the TABLE row is expanded. When collapsed, it unmounts and unregisters from the DnD context. If a drag starts targeting a collapsed child list, it won't be available. **Mitigation**: Cross-container DnD only works with expanded (visible) child lists. Non-expanded lists are not valid drop targets.
+
+### C-6: `useSortable` on `<tr>` Elements
+
+Applying CSS transforms to `<tr>` elements can cause visual glitches in some browsers (table layout constraints). **Mitigation**: Use `CSS.Translate.toString()` (not `CSS.Transform.toString()`) from @dnd-kit/utilities — this avoids the `scale(1, 1)` that breaks table row width. Also add `accessibility={{ container: document.body }}` to DndContext to prevent validateDOMNesting warnings from the overlay `<div>` inside `<table>`.
+
+---
+
+## Implementation Order (Recommended)
+
+```
+Phase 1 → Phase 2 → Phase 3 → Phase 5 → Phase 6 → Phase 7 → Phase 11a (attribute tests)
+                     Phase 4 → Phase 9 → Phase 11b (enum tests)
+Phase 8 (cross-container) depends on Phase 7 completion  
+Phase 10 (i18n) can be done in parallel throughout
+Phase 11.3–11.4 (lint + build) at the end
+```
+
+**Milestone 1** (MVP): Single-list DnD for root attributes (Phases 1–3, 5–7 basics, 10 partial, 11 partial)
+**Milestone 2**: Single-list DnD for child attributes + enumeration values (Phases 4, 8 partial, 9)
+**Milestone 3**: Cross-container DnD for attributes (Phase 8 full, container registry)
+**Milestone 4**: Final QA, full tests, lint, build (Phase 11)
+
+---
+
+## Dependencies
+
+| Dependency | Type | Notes |
+|-----------|------|-------|
+| `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` | npm (workspace catalog) | Already in workspace for spaces-frontend |
+| `universo-types` settings update | Cross-package | Must be built before metahubs-frontend |
+| `universo-template-mui` updates | Cross-package | `hideCancelButton` in ConfirmPayload + StyledTable exports; must be built before metahubs-frontend |
+| Backend reorder endpoints | Backend deployment | Must be deployed before frontend can use new APIs |
+| `FlowListTable` key fix | Shared component | Should be done first as independent improvement |
+
+---
+
+## Appendix: Reference Implementations
+
+### CanvasTabs.jsx (@dnd-kit in this project)
+
+Location: `packages/spaces-frontend/base/src/components/CanvasTabs.jsx`
+
+Key patterns to follow:
+- `PointerSensor` with `distance: 8` activation constraint
+- `KeyboardSensor` for accessibility
+- Optimistic state (`optimisticCanvases` / `pendingReorder`)
+- `DragOverlay` with `dropAnimation={null}` for instant visual
+- Revert-on-error with `enqueueSnackbar`
+
+### Current moveAttribute API
+
+Location: `packages/metahubs-backend/base/src/domains/metahubs/services/MetahubAttributesService.ts`
+
+Key patterns:
+- `_ensureSequentialSortOrder()` — normalizes gaps before any reorder
+- Transaction wrapping for atomic operations
+- Parent scope filtering (`parent_attribute_id IS NULL` vs specific parent)
+
+### ConfirmDialog / useConfirm
+
+Location: `packages/universo-template-mui/base/src/components/dialogs/ConfirmDialog.tsx`
+
+Usage pattern:
+```typescript
+const { confirm } = useConfirm()
+const result = await confirm({ title, description, confirmButtonName })
+if (result) { /* proceed */ }
+```

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -44,6 +44,194 @@
 
 ---
 
+## QA Tech Debt Cleanup (2026-03-04)
+
+Fixed all tech debt items identified in the comprehensive QA analysis.
+
+### What was fixed
+
+- **Stale JSDoc comment (MEDIUM)**: Updated `useReorderAttribute` docstring — said "cross-list skipped" but cross-list optimistic updates were already implemented.
+- **Fragile `movedItem` closure (LOW)**: Replaced side-effect capture inside `setQueriesData` callback with pre-extraction via `getQueriesData`. The moved item is found from cache before updaters run, eliminating reliance on closure mutation order.
+- **Over-broad child invalidation (LOW)**: `onSuccess` now conditionally invalidates child caches only for cross-list transfers (`newParentAttributeId !== undefined`). Same-list reorder no longer triggers unnecessary refetch of all child attribute lists.
+- **`as any` cleanup**: Replaced `as any` casts in same-list `reorderUpdater` with typed `Record<string, unknown>` casts, matching cross-list code style. Reduced lint warnings from 166 to 153.
+
+### Verification
+
+- Lint: metahubs-frontend 0 errors/153 warnings
+- Tests: metahubs-frontend 97/97
+- Build: metahubs-frontend ✔ success
+
+---
+
+## Cross-List DnD Optimistic Update (2026-03-03)
+
+Added instant visual feedback for cross-list attribute DnD transfers (root↔child, child↔child).
+
+### What was fixed
+
+- **Cross-list snap-back eliminated**: Previously, `onMutate` skipped optimistic updates for cross-list transfers (`newParentAttributeId !== undefined`), causing attributes to snap back to original position for 2-3s until server response arrived. Now items instantly move between caches.
+- **Implementation**: Added `currentParentAttributeId` parameter through the callback chain (`useAttributeDnd` → `AttributeDndProvider` → `AttributeList` → `mutations.ts`). In `onMutate`, source cache item is removed via `removeUpdater`, target cache receives it via `insertUpdater`, both lists get sort orders re-indexed.
+- **Unified rollback**: Both root and child caches are snapshotted before any modification, ensuring clean rollback on error.
+
+### Verification
+
+- Lint: metahubs-frontend 0 errors/166 warnings
+- Tests: metahubs-frontend 97/97, metahubs-backend 128/128
+- Build: 56/56 successful
+
+---
+
+## DnD QA Pass 5 — Post-Analysis Fixes (2026-03-03)
+
+Fixed 4 issues identified by comprehensive QA analysis of the DnD implementation.
+
+### What was fixed
+
+- **Backend auto-set display attribute (Fix 1, MEDIUM)**: In `reorderAttribute()`, after cross-list move to child list, counts siblings in target. If count === 1, auto-sets `is_display_attribute: true` + `is_required: true`. Ensures newly populated child lists always have a display attribute.
+- **Ghost row collision guard (Fix 2, MEDIUM)**: In `handleDragOver`, early return when hovering over ghost of dragged item prevents render cycle (EmptyDroppableChildArea ↔ DroppableSortableBody). In `handleDragEnd`, saves pending transfer before clearing state; resolves target container from saved transfer when dropped on ghost; uses `insertIndex + 1` for sort order.
+- **Source list display protection (Fix 3, LOW)**: Changed `_validateCrossListTransfer()` to block ALL display attribute cross-list transfers (removed `&& targetParentId !== null`). Aligned backend with frontend behavior. Prevents source list losing display attribute via direct API.
+- **eslint-disable cleanup (Fix 4, LOW)**: Extracted inline type to `EmptyDroppableChildAreaProps` interface. Reduced from 2 awkward eslint-disable comments to 1 standard `eslint-disable-next-line`.
+
+### Verification
+
+- Lint: metahubs-backend 0 errors/216 warnings, metahubs-frontend 0 errors/163 warnings
+- Tests: metahubs-backend 128/128, metahubs-frontend 97/97, template-mui 169/169
+- Build: 56/56 successful (5m29s)
+
+---
+
+## DnD QA Pass 4 — 4 Issues Fix (2026-03-03)
+
+Fixed 4 QA issues from manual testing of DnD cross-list transfers and attribute editing.
+
+### What was fixed
+
+- **Cross-list drag jitter (Issue 1)**: Added `overflowX: 'hidden'` to FlowListTable TableContainer when `isDropTarget` active. Prevents horizontal scrollbar cycle caused by wider ghost rows injected into narrower child tables.
+- **Empty child table drop target (Issue 2)**: Created `EmptyDroppableChildArea` component with `@dnd-kit/core` `useDroppable`. Restructured ChildAttributeList rendering to always compute effectiveData — shows EmptyDroppableChildArea when empty, FlowListTable when data exists.
+- **First-child confirmation dialog (Issue 3)**: Extended `onValidateTransfer` signature with `targetContainerItemCount`. When dropping to empty child container, shows confirmation dialog explaining attribute will become display + required. Added EN/RU i18n keys.
+- **Display attribute toggle lock (Issue 4)**: `displayAttributeLocked` now also true when editing the current display attribute (AttributeActions.tsx + ChildAttributeList edit dialog). Switch shows ON + disabled state.
+
+### Verification
+
+- `pnpm --filter metahubs-frontend lint` → 0 errors, 163 warnings
+- `pnpm build` (root) → 56/56 successful, 5m36s
+
+## DnD QA Pass 3 — 4 Issues Fix (2026-03-03)
+
+Fixed 4 QA issues from manual testing of DnD attributes/enumeration values.
+
+### What was fixed
+
+- **Enum value row height**: Removed `compact` from EnumerationValueList FlowListTable (standard 64px rows).
+- **Drag handle centering**: Added `verticalAlign: 'middle'` to drag handle cell in SortableTableRow — works for both 64px and 40px rows.
+- **Cross-list DnD ghost row**: New `PendingTransfer` state in `useAttributeDnd` tracks virtual cross-list item movement. Source container hides the dragged item; target container injects a ghost row at the insertion point (computed from cursor position relative to over item center). @dnd-kit `isDragging` opacity (0.4) makes the ghost semi-transparent automatically.
+- **Codename VLC auto-rename**: Verified correct for both VLC ON and OFF — `codename_localized: null` ensures display falls back to renamed codename.
+
+### Verification
+
+- `pnpm --filter @universo/metahubs-frontend lint` → 0 errors, 164 warnings
+- `pnpm --filter @universo/metahubs-frontend test` → 97/97 passed
+- `pnpm --filter @universo/metahubs-backend test` → 17/17 suites, 128 passed, 3 skipped
+- `pnpm --filter @universo/template-mui test` → 10/10 suites, 169/169 passed
+- `pnpm build` (root) → 56/56 successful, 4m54s
+
+## DnD QA Pass 2 — 6 Issues Fix (2026-03-04)
+
+Fixed 6 QA issues found during manual testing of the DnD attributes/enumeration values feature.
+
+### What was fixed
+
+- **Row height**: Removed `compact` from root AttributeList FlowListTable (64px standard rows), child lists remain compact (40px).
+- **Cross-list DnD visual feedback**: New `AttributeDndStateContext` + `useAttributeDndState()` hook + `DndDropTarget` render-prop + `isDropTarget` prop in FlowListTable. Shows dashed primary border + 4% alpha background on target container during cross-list drag.
+- **Display attr validation**: Blocks display attribute from ANY cross-list transfer (previously only blocked root→child).
+- **ConfirmDialog styling**: Widened from `maxWidth='xs'` to `'sm'`, added DialogActions padding to match ConfirmDeleteDialog.
+- **Codename suffix format**: `buildCodenameAttempt` no longer uses separator (`Name2` not `Name_2`).
+- **Codename rename bug**: Auto-rename now also sets `codename_localized: null` so display shows updated codename.
+- **Optimistic updates**: Added `onMutate`/`onError` to `useReorderAttribute` (same-list) and `useReorderEnumerationValue` with cache snapshot and rollback.
+
+### Verification
+
+- `pnpm --filter @universo/metahubs-frontend lint` → 0 errors, 164 warnings
+- `pnpm --filter @universo/metahubs-frontend test` → 97/97 passed
+- `pnpm --filter @universo/metahubs-backend test` → 17/17 suites, 128 passed, 3 skipped
+- `pnpm --filter @universo/template-mui test` → 10/10 suites, 169/169 passed
+- `pnpm build` (root) → 56/56 successful, 5m32s
+
+## DnD Table Design Restoration & Tech Debt Elimination (2026-03-03)
+
+Restored standard table design across all DnD-enabled lists by extending FlowListTable with built-in DnD support, fixed all pre-existing TS errors, and cleaned up redundant components.
+
+### What was implemented
+
+- **FlowListTable DnD extension** (`universo-template-mui`): Created `FlowListTableDnd.tsx` with internal building blocks (SortableTableRow, SortableTableBody, InternalDndWrapper). Added 12 DnD props to FlowListTable: `sortableRows`, `sortableItemIds`, `droppableContainerId`, `externalDndContext`, `onSortableDragEnd/Start/Over/Cancel`, `renderDragOverlay`, `dragHandleAriaLabel`, `dragDisabled`. Added `@dnd-kit` deps.
+- **EntityFormDialog fixes**: Added `'copy'` to mode union, `deleteButtonDisabledReason?: string` with Tooltip wrapper.
+- **EnumerationValueList TS error fixes**: Fixed `appendCopySuffix` locales cast, `onSearchChange` type, `t()` overloads (2×), `deleting`→`loading` prop. Explicitly typed all implicit `any` params: 11 `ctx: ValueActionCtx`, deriveCodename, onChange (3×), onTouchedChange, onLocalizedChange, onSearchChange, extraFields (2×).
+- **Consumer migrations**: AttributeList and ChildAttributeList migrated from bare `<Table>` to `<FlowListTable>` with `sortableRows` + `externalDndContext`. EnumerationValueList migrated to `<FlowListTable>` with internal DnD (onSortableDragEnd, renderDragOverlay).
+- **Cleanup**: Deleted 4 redundant DnD components (SortableAttributeRow, SortableAttributeTableBody, SortableValueRow, SortableEnumerationValueTable). Updated barrel exports in `attributes/ui/dnd/index.ts` and `enumerations/ui/dnd/index.ts`.
+
+### Verification
+
+- `pnpm --filter @universo/metahubs-frontend lint` → pass (0 errors, 149 warnings)
+- `pnpm --filter @universo/metahubs-backend lint` → pass (0 errors, 216 warnings)
+- `pnpm --filter @universo/metahubs-backend test` → pass (2/2 suites, 21/21 tests)
+- `pnpm --filter @universo/metahubs-frontend build` → pass (5494ms)
+- `pnpm build` (root) → pass (56/56, 5m32s)
+
+### Outcome
+
+- All DnD-enabled tables now use standard FlowListTable with consistent TableContainer/Paper/border design.
+- Pre-existing TS errors in EnumerationValueList eliminated (0 real code errors).
+- 4 redundant DnD components removed; remaining 5 domain-specific components (DragOverlayRow, AttributeDndProvider, useAttributeDnd, AttributeDndContainerRegistry, DragOverlayValueRow) preserved.
+- FlowListTable DnD API is reusable for future DnD additions across the platform.
+
+## DnD QA Critical Debt Closure (2026-03-03)
+
+Completed a focused remediation pass to eliminate remaining QA blockers in DnD reorder flows for attributes and enumeration values.
+
+### What was fixed
+
+- Backend reorder policy enforcement now uses metahub settings for cross-list transfers (`allowAttributeMoveBetweenRootAndChildren`, `allowAttributeMoveBetweenChildLists`) so restricted moves are rejected server-side.
+- Reorder services now enforce strict ownership and active-row constraints when loading/updating entities (`id + object_id`, deleted-flag guards), including target-parent ownership checks.
+- Route-level regression coverage was expanded for reorder contracts in attributes/enumerations APIs (settings propagation, blocked transfer mapping, validation/not-found/happy paths).
+- Newly introduced formatting/lint issues in touched DnD/backend files were resolved.
+
+### Verification
+
+- `pnpm --filter @universo/metahubs-backend test -- src/tests/routes/attributesRoutes.test.ts src/tests/routes/enumerationsRoutes.test.ts` -> pass (`2/2` suites, `21/21` tests)
+- `pnpm --filter @universo/metahubs-backend build` -> pass
+- `pnpm --filter @universo/metahubs-frontend build` -> pass (`Build complete in 6597ms`)
+- `pnpm --filter @universo/template-mui build` -> pass (`Build complete in 1461ms`)
+- `pnpm build` (root) -> pass (`56 successful, 56 total`, `6m33.197s`)
+
+### Outcome
+
+- The DnD QA debt in this scope is closed with backend-enforced policy/ownership safety and green verification gates.
+
+## Drag-and-Drop for Attributes & Enumeration Values (2026-03-03)
+
+Implemented full drag-and-drop reordering for attributes (root + child lists with cross-list transfer) and enumeration values in metahubs. Uses `@dnd-kit` library (same as spaces-frontend).
+
+### What was implemented
+
+- **Backend**: `reorderAttribute()` with transactional gap-shift + sequential normalization, cross-list transfer validation (display attr, TABLE nesting, codename uniqueness with auto-rename up to 20 attempts), `reorderValue()` for enumerations. PATCH routes with Zod validation and proper HTTP error codes (409/422/403).
+- **Frontend**: 11 DnD component files (7 for attributes in Provider/Hook/Component pattern, 4 for enumerations). Integrated in AttributeList, ChildAttributeList, EnumerationValueList. Cross-list DnD via `AttributeDndContainerRegistry` context.
+- **Settings**: 2 new metahub settings (`catalogs.allowAttributeMoveBetweenRootAndChildren`, `catalogs.allowAttributeMoveBetweenChildLists`) with EN+RU i18n.
+- **i18n**: Full EN+RU coverage for DnD dialogs, success/error snackbars, drag handle accessibility labels, codename conflict resolution UI.
+- **Accessibility**: `aria-label` on all drag handle cells via prop chain.
+
+### QA fixes applied
+
+- Added missing Phase 2.2 settings i18n keys (4 keys × 2 locales)
+- Wired `dragHandleAriaLabel` prop through SortableRow → TableBody → List components
+- Added success snackbars after reorder mutations
+- Removed dead `transferBlocked` i18n key
+
+### Verification
+
+- `pnpm --filter metahubs-frontend build` -> pass
+- `pnpm --filter metahubs-backend build` -> pass
+- All i18n keys verified: no unused DnD keys, JSON valid
+
 ## Codename Auto-Convert UX Hardening (2026-03-03)
 
 Completed a focused UX/logic hardening pass to make mixed-alphabet codename conversion consistent between manual codename editing and codename auto-generation from Name.

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -4,6 +4,223 @@
 
 ---
 
+## Completed: QA Tech Debt Cleanup — 2026-03-04 ✅
+
+> **Goal**: Fix all issues found in the comprehensive QA analysis: stale JSDoc, fragile closure capture, over-broad cache invalidation, `as any` cleanup.
+
+### Implementation
+- [x] Fixed stale JSDoc comment on `useReorderAttribute` — "cross-list skipped" → "both same-list and cross-list"
+- [x] Replaced fragile `movedItem` closure capture with pre-extraction from cache via `getQueriesData` before applying updaters
+- [x] Optimized `onSuccess` — child attribute caches invalidated only for cross-list transfers (`newParentAttributeId !== undefined`), not for same-list reorder
+- [x] Cleaned up `as any` casts in same-list `reorderUpdater` to use typed `Record<string, unknown>` casts matching cross-list code
+
+### Verification
+- [x] Lint: metahubs-frontend 0 errors/153 warnings (13 fewer than before — `as any` removals)
+- [x] Tests: metahubs-frontend 97/97
+- [x] Build: metahubs-frontend ✔ success
+
+---
+
+## Completed: Cross-List DnD Optimistic Update — 2026-03-03 ✅
+
+> **Goal**: Add optimistic cache updates for cross-list attribute DnD transfers so items instantly appear in the target list instead of snapping back and re-appearing after 2-3s server response.
+
+### Implementation
+- [x] Added `currentParentAttributeId` parameter to `onReorder` callback chain (`useAttributeDnd` → `AttributeDndProvider` → `AttributeList` → `mutations.ts`)
+- [x] In `handleDragEnd`: pass `activeContainer.parentAttributeId` as 4th argument to `onReorder` for cross-list transfers
+- [x] In `onMutate`: implemented cross-list optimistic update — removes item from source cache, inserts into target cache at correct position, re-indexes sort orders in both
+- [x] Unified rollback: snapshots both root and child caches before modification, restores all on error
+- [x] Same-list reorder optimistic update preserved (refactored to use extracted `reorderUpdater`)
+
+### Verification
+- [x] Lint: metahubs-frontend 0 errors/166 warnings
+- [x] Tests: metahubs-frontend 97/97, metahubs-backend 128/128
+- [x] Build: 56/56 successful
+- [x] Memory Bank updated
+
+---
+
+## Completed: DnD QA Pass 5 — Post-Analysis Fixes — 2026-03-03 ✅
+
+> **Goal**: Fix 4 issues from comprehensive QA analysis: backend auto-set display attr, ghost row collision cycle, source list display protection, eslint-disable cleanup.
+
+### Fix 1: Backend auto-set display attribute for first child (MEDIUM)
+- [x] In `reorderAttribute()`: after cross-list move to child list, count siblings; if count === 1, auto-set `is_display_attribute: true` + `is_required: true`
+
+### Fix 2: Ghost row collision guard (MEDIUM)
+- [x] In `handleDragOver`: early return when `over.id === active.id && pendingTransfer` exists — prevents render cycle where ghost unmounts/remounts
+- [x] In `handleDragEnd`: save `pendingTransferRef.current` before clearing state; when `over.id === active.id`, resolve target container from saved pending transfer instead of re-resolving via findContainer
+- [x] Sort order calculation: use `savedPendingTransfer.insertIndex + 1` when dropped on ghost row (overIndex not found in target items)
+
+### Fix 3: Source list display attribute protection (LOW)
+- [x] In `_validateCrossListTransfer()`: changed condition from `attribute.is_display_attribute && targetParentId !== null` to `attribute.is_display_attribute` — blocks ALL display attribute cross-list transfers, aligned with frontend behavior
+
+### Fix 4: eslint-disable cleanup (LOW)
+- [x] Extracted inline type annotation to named `EmptyDroppableChildAreaProps` interface
+- [x] Reduced from 2 eslint-disable comments (one inside type annotation) to 1 standard eslint-disable-next-line before component declaration
+
+### Verification
+- [x] Lint: metahubs-backend 0 errors/216 warnings, metahubs-frontend 0 errors/163 warnings
+- [x] Tests: metahubs-backend 128/128, metahubs-frontend 97/97, template-mui 169/169
+- [x] Build: 56/56 successful (5m29s)
+- [x] Memory Bank updated
+
+---
+
+## Completed: DnD QA Pass 4 — 4 Issues Fix — 2026-03-03 ✅
+
+> **Goal**: Fix 4 new QA issues: jitter on cross-list drag, empty child table drop target, first-attr confirmation dialog, lock display attribute toggle.
+
+### Issue 1: Jitter on cross-list drag (width mismatch)
+- [x] Add `overflowX: 'hidden'` to FlowListTable `TableContainer` when `isDropTarget` is active, prevent horizontal scrollbar jitter
+
+### Issue 2: Empty child table needs droppable area
+- [x] In ChildAttributeList: render `EmptyDroppableChildArea` component with `useDroppable` when no children + no ghost row
+- [x] Container detected as drop target via @dnd-kit useDroppable — registered with containerId
+- [x] Show drop target visual feedback (dashed border highlight) on empty placeholder
+- [x] Restructured rendering: always compute effectiveData, show EmptyDroppableChildArea or FlowListTable
+
+### Issue 3: First attribute in empty table → confirmation dialog
+- [x] Extended `onValidateTransfer` signature with `targetContainerItemCount` parameter
+- [x] Show confirmation dialog when dropping to empty child container (targetContainerItemCount === 0)
+- [x] Added i18n keys for EN (firstChildAttributeTitle/firstChildAttributeDescription) and RU translations
+
+### Issue 4: Lock display attribute toggle when editing display attribute
+- [x] In `AttributeActions.tsx`: added `|| isDisplayAttributeEntity(ctx)` to `displayAttributeLocked` computation
+- [x] In `ChildAttributeList.tsx`: pass `displayAttributeLockedOverride: editState.attribute?.isDisplayAttribute ? true : undefined` in edit dialog tabs
+- [x] Verified childActionDescriptors context menu actions are correctly gated (clear-display-attribute requires displayAttributesCount > 1)
+
+### Verification
+- [x] Lint: 0 errors, 163 warnings (metahubs-frontend)
+- [x] Build: 56/56 successful (5m36s)
+- [x] Memory Bank updated
+
+---
+
+## Completed: DnD Table Design Restoration & Tech Debt Elimination — 2026-03-03 ✅
+
+> **Goal**: Restore standard table design (FlowListTable) wherever DnD was introduced, extend FlowListTable with built-in DnD support, fix all pre-existing TS errors in EnumerationValueList, clean up redundant DnD components.
+
+### Phase 1: Extend FlowListTable with DnD support
+- [x] Add `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` to `universo-template-mui` deps
+- [x] Create `FlowListTableDnd.tsx` with internal DnD building blocks (SortableTableRow, SortableTableBody, InternalDndWrapper)
+- [x] Add DnD props to `FlowListTableProps` (sortableRows, sortableItemIds, droppableContainerId, externalDndContext, onSortableDragEnd, renderDragOverlay, etc.)
+- [x] Integrate DnD rendering path in FlowListTable (drag handle column, sortable rows, disabled internal sort)
+- [x] Export new types from template-mui index
+
+### Phase 2: Fix dialog component types
+- [x] Add `'copy'` to `EntityFormDialogProps.mode` union
+- [x] Add `deleteButtonDisabledReason?: string` to `EntityFormDialogProps` with Tooltip support
+
+### Phase 3: Fix pre-existing TS errors in EnumerationValueList (9 errors)
+- [x] Fix `appendCopySuffix` locales type mismatch (line 104)
+- [x] Fix `onSearchChange={setSearch}` type mismatch (line 723)
+- [x] Fix `t()` overload issues (lines 827, 929)
+- [x] Fix `deleting` → `loading` prop on ConfirmDeleteDialog (line 970)
+- [x] Type all implicit `any` params (11 `ctx: ValueActionCtx`, `deriveCodename`, `onChange`, `onTouchedChange`, `onLocalizedChange`, `onSearchChange`, `extraFields` destructured params)
+  - Note: readonly `descriptors` and `createValueActionContext` errors were cascading from VS Code TS server module resolution cache, not real code bugs
+
+### Phase 4: Migrate consumers to FlowListTable DnD
+- [x] Migrate AttributeList to use FlowListTable with `sortableRows` + `externalDndContext`
+- [x] Migrate ChildAttributeList to use FlowListTable with `sortableRows` + `externalDndContext`
+- [x] Migrate EnumerationValueList to use FlowListTable with `sortableRows` (internal DndContext)
+
+### Phase 5: Clean up & verify
+- [x] Remove redundant DnD components (SortableAttributeRow, SortableAttributeTableBody, SortableValueRow, SortableEnumerationValueTable)
+- [x] Update dnd/index.ts barrel exports
+- [x] Lint verification (`metahubs-frontend`: 0 errors/149 warnings, `metahubs-backend`: 0 errors/216 warnings)
+- [x] Build verification (`pnpm build` — 56 successful, 56 total, 5m32s)
+- [x] Backend tests (21/21 passed)
+
+---
+
+## Completed: DnD QA Critical Debt Closure — 2026-03-03 ✅
+
+> **Goal**: Eliminate all remaining QA blockers for DnD attributes/enumeration values with safe backend enforcement, clean lint status in touched areas, and verified builds/tests.
+
+### Final implementation plan (execution pass)
+
+- [x] Enforce cross-list move settings on backend reorder endpoint/service (not frontend-only)
+- [x] Add strict ownership checks in reorder services (`attribute.object_id === catalogId`, `value.object_id === enumerationId`)
+- [x] Add/adjust backend tests for settings enforcement and ownership guardrails in reorder APIs
+- [x] Fix all new lint/prettier errors introduced by DnD files and route/service edits
+- [x] Re-run targeted verification (`metahubs-frontend lint/test`, `metahubs-backend lint/test`, touched builds)
+- [x] Update Memory Bank closure (`activeContext.md`, `progress.md`, `tasks.md`) with outcomes
+
+### Verification evidence (this completion)
+
+- [x] `pnpm --filter @universo/metahubs-backend test -- src/tests/routes/attributesRoutes.test.ts src/tests/routes/enumerationsRoutes.test.ts` -> pass (`2/2` suites, `21/21` tests)
+- [x] `pnpm --filter @universo/metahubs-backend build` -> pass
+- [x] `pnpm --filter @universo/metahubs-frontend build` -> pass (`Build complete in 6597ms`)
+- [x] `pnpm --filter @universo/template-mui build` -> pass (`Build complete in 1461ms`)
+- [x] `pnpm build` (root) -> pass (`56 successful, 56 total`, `6m33.197s`)
+
+---
+
+## Completed: Drag-and-Drop for Attributes & Enumeration Values — 2026-03-03 ✅
+
+> **Goal**: Implement drag-and-drop reordering for root/child attributes and enumeration values. Add cross-list attribute transfer (root ↔ child, child ↔ child) with codename uniqueness and display-attribute validation. New metahub settings control permissions.
+
+> **Plan**: See [memory-bank/plan/dnd-attributes-enum-values-plan-2026-03-03.md](plan/dnd-attributes-enum-values-plan-2026-03-03.md) for detailed implementation plan with code examples.
+
+> **Complexity**: Level 4 (Major/Complex)
+
+### Phase 1: FlowListTable Key Fix
+- [x] Fix `key={index}` → `key={row.id}` in `FlowListTable.tsx`
+
+### Phase 2: New Metahub Settings
+- [x] Add 2 new settings to `METAHUB_SETTINGS_REGISTRY` in `universo-types`
+- [x] Add i18n keys for new settings (EN + RU) — added in QA fix pass
+
+### Phase 3: Backend — Attribute Reorder Endpoint
+- [x] Add Zod schema and PATCH `/attributes/reorder` route (hub-scoped + direct)
+- [x] Implement `reorderAttribute()` in `MetahubAttributesService` (same-list + cross-list)
+- [x] Implement `_validateCrossListTransfer()` (display attr, TABLE nesting, codename uniqueness)
+
+### Phase 4: Backend — Enum Value Reorder Endpoint
+- [x] Add PATCH `/values/reorder` route for enumeration values
+- [x] Implement `reorderValue()` in `MetahubEnumerationValuesService`
+
+### Phase 5: Frontend — DnD Dependencies & API
+- [x] Add `@dnd-kit` deps to `metahubs-frontend` (catalog versions)
+- [x] Add `reorderAttribute` and `reorderEnumerationValue` API functions
+- [x] Add `useReorderAttribute` and `useReorderEnumerationValue` mutation hooks
+
+### Phase 6: Frontend — DnD Components for Attributes
+- [x] Create `SortableAttributeRow` (useSortable + drag handle)
+- [x] Create `DragOverlayRow` (floating drag preview)
+- [x] Create `useAttributeDnd` hook (DnD event handlers)
+- [x] Create `AttributeDndProvider` (DndContext + sensors + overlay)
+- [x] Create `SortableAttributeTableBody` (SortableContext + droppable body)
+
+### Phase 7: Frontend — Integrate DnD in AttributeList
+- [x] Wrap AttributeList with AttributeDndProvider
+- [x] Replace FlowListTable with SortableAttributeTableBody when DnD enabled
+- [x] Implement optimistic reorder handler
+- [x] Implement cross-list transfer validation (display attr, TABLE nesting, codename, confirm dialog)
+
+### Phase 8: Frontend — Integrate DnD in ChildAttributeList
+- [x] Register child lists as DnD containers via context
+- [x] Render SortableAttributeTableBody per child list
+- [x] Create `AttributeDndContainerRegistry` for cross-container awareness
+
+### Phase 9: Frontend — DnD for Enumeration Values
+- [x] Create DnD components for enumeration values
+- [x] Integrate in EnumerationValueList with setting toggle
+
+### Phase 10: i18n
+- [x] Add all DnD-related i18n keys (EN + RU)
+
+### Phase 11: QA Fixes & Verification
+- [x] QA analysis (comprehensive review of all phases)
+- [x] Fix Phase 2.2: add missing settings i18n keys (EN + RU)
+- [x] Fix unused `dragHandle` keys: add `aria-label` to drag handles via prop chain
+- [x] Fix unused `reorderSuccess` keys: add success snackbars after reorder
+- [x] Remove unused `transferBlocked` key (redundant with specific messages)
+- [x] `pnpm --filter metahubs-frontend build` -> pass
+
+---
+
 ## Completed: Codename Auto-Convert UX Hardening — 2026-03-03 ✅
 
 > **Goal**: Ensure mixed-alphabet auto-conversion works both for manual codename blur and for codename auto-generation from name across all codename-enabled forms; align settings wording in admin + metahub UI.
@@ -23,7 +240,7 @@
 - [x] `pnpm build` (root) -> pass (`56 successful, 56 total`, `5m23.968s`)
 - [x] Memory Bank closure synchronized in `activeContext.md` and `progress.md`
 
-## Active: QA Debt Eradication — 2026-03-03
+## Completed: QA Debt Eradication — 2026-03-03 ✅
 
 > **Goal**: Resolve all issues found in the latest QA pass with safe, minimal, lint-clean changes and no regressions.
 
@@ -42,6 +259,67 @@
 - [x] `pnpm --filter @universo/metahubs-backend test` -> pass (`17/17` suites, `123` passed, `3` skipped)
 - [x] `pnpm --filter @universo/template-mui test` -> pass (`10/10` suites, `169/169` tests)
 - [x] `pnpm build` (root) -> pass (`56 successful, 56 total`, `5m20.626s`)
+
+---
+
+## Completed: DnD QA Pass 3 — 4 Issues Fix — 2026-03-03 ✅
+
+> **Goal**: Fix 4 new QA issues found during testing of DnD attributes/enum values feature.
+
+### Issue 1: Enum value row height too short
+- [x] Remove `compact` from `FlowListTable` in `EnumerationValueList.tsx`
+
+### Issue 2: Drag handle not vertically centered
+- [x] Add `verticalAlign: 'middle'` to drag handle StyledTableCell in `SortableTableRow` (FlowListTableDnd.tsx)
+
+### Issue 3: Cross-list DnD ghost placeholder missing
+- [x] Add `pendingTransfer` state to `useAttributeDnd` (itemId, from/to container, insertIndex)
+- [x] Expose `pendingTransfer` + `activeAttribute` through `AttributeDndStateContext`
+- [x] In `AttributeList.tsx`: modify `data` and `sortableItemIds` based on pendingTransfer (remove from source, inject ghost in target)
+- [x] In `ChildAttributeList.tsx`: same ghost injection logic
+- [x] Result: cross-list drag shows semi-transparent row at insertion point (using @dnd-kit isDragging opacity)
+
+### Issue 4: Verify codename_localized auto-rename logic
+- [x] Trace flow for VLC on + VLC off scenarios — both correct
+- [x] Confirm `codename_localized: null` is correct for both cases — fallback to plain codename works
+
+### Verification
+- [x] Build: 56/56, lint: 0 errors/164 warnings, tests: 128+97+169 passed
+- [x] Memory Bank updated
+
+## Completed: DnD QA Pass 2 — 6 Issues Fix — 2026-03-04 ✅
+
+> **Goal**: Fix 6 issues found during QA testing of DnD attributes/enum values feature.
+
+### Issue 1: Root attribute row height too short
+- [x] Remove `compact` from root `FlowListTable` in `AttributeList.tsx` (keep compact in `ChildAttributeList.tsx`)
+
+### Issue 2: Cross-list DnD has no visual feedback
+- [x] Add visual drop indicator when dragging between root ↔ child containers
+  - Created `AttributeDndStateContext` in `AttributeDndProvider.tsx` exposing `activeId`, `activeContainerId`, `overContainerId`
+  - Added `useAttributeDndState()` hook
+  - Created `DndDropTarget` render-prop component in `AttributeList.tsx`
+  - Added `isDropTarget` prop to `FlowListTable` with dashed primary border + 4% alpha background
+
+### Issue 3: Display attribute cross-list validation order
+- [x] Block display attribute from ANY cross-list transfer (not just root → child)
+  - Removed `&& targetParentId !== null` condition in `handleValidateTransfer`
+
+### Issue 4: Codename conflict dialog too narrow
+- [x] Widen `ConfirmDialog` from `maxWidth='xs'` to `'sm'` and add padding to `DialogActions`
+
+### Issue 5: Codename rename bug + suffix format
+- [x] Fix `buildCodenameAttempt` to not use separator before number (e.g., `Name2` not `Name_2`)
+- [x] Fix auto-rename to also set `codename_localized: null` so display shows new codename
+
+### Issue 6: No optimistic updates for DnD reorder
+- [x] Add optimistic updates to `useReorderAttribute` (same-list only) and `useReorderEnumerationValue`
+  - `onMutate`: cancel queries, snapshot cache, reorder items optimistically
+  - `onError`: rollback from snapshot
+
+### Verification
+- [x] Build verification — 56/56 packages, 0 lint errors, all tests pass
+- [x] Memory Bank updated
 
 ## Completed: QA Remediation — Root Attribute Codename Flow Hardening — 2026-03-03 ✅
 

--- a/packages/metahubs-backend/base/src/domains/attributes/routes/attributesRoutes.ts
+++ b/packages/metahubs-backend/base/src/domains/attributes/routes/attributesRoutes.ts
@@ -25,7 +25,9 @@ import {
     extractAllowedAttributeTypes,
     getAllowAttributeCopy,
     getAllowAttributeDelete,
-    getAllowDeleteLastDisplayAttribute
+    getAllowDeleteLastDisplayAttribute,
+    getAllowAttributeMoveBetweenRootAndChildren,
+    getAllowAttributeMoveBetweenChildLists
 } from '../../shared/codenameStyleHelper'
 import { syncMetahubSchema } from '../../metahubs/services/schemaSync'
 import { KnexClient, uuidToLockKey, acquireAdvisoryLock, releaseAdvisoryLock } from '../../ddl'
@@ -1277,6 +1279,79 @@ export function createAttributesRoutes(
                 const updated = await attributesService.moveAttribute(metahubId, catalogId, attributeId, direction, userId)
                 res.json(updated)
             } catch (error: any) {
+                if (error.message === 'Attribute not found') {
+                    return res.status(404).json({ error: 'Attribute not found' })
+                }
+                throw error
+            }
+        })
+    )
+
+    /**
+     * PATCH /metahub/:metahubId/hub/:hubId/catalog/:catalogId/attributes/reorder
+     * PATCH /metahub/:metahubId/catalog/:catalogId/attributes/reorder
+     * Reorder an attribute within its list, or transfer to a different parent list (cross-list DnD)
+     */
+    const reorderAttributeSchema = z.object({
+        attributeId: z.string().uuid(),
+        newSortOrder: z.number().int().min(1),
+        newParentAttributeId: z.string().uuid().nullable().optional(),
+        autoRenameCodename: z.boolean().optional()
+    })
+
+    router.patch(
+        [
+            '/metahub/:metahubId/hub/:hubId/catalog/:catalogId/attributes/reorder',
+            '/metahub/:metahubId/catalog/:catalogId/attributes/reorder'
+        ],
+        writeLimiter,
+        asyncHandler(async (req: Request, res: Response) => {
+            const { metahubId, catalogId } = req.params
+            const { attributesService, settingsService } = services(req)
+            const userId = resolveUserId(req)
+
+            const parsed = reorderAttributeSchema.safeParse(req.body)
+            if (!parsed.success) {
+                return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues })
+            }
+
+            const { attributeId, newSortOrder, newParentAttributeId, autoRenameCodename } = parsed.data
+
+            // Load codename settings from the route layer (service doesn't own settingsService)
+            const codenameScope = await getAttributeCodenameScope(settingsService, metahubId, userId)
+            const { style: codenameStyle } = await getCodenameSettings(settingsService, metahubId, userId)
+            const allowCrossListRootChildren = await getAllowAttributeMoveBetweenRootAndChildren(settingsService, metahubId, userId)
+            const allowCrossListBetweenChildren = await getAllowAttributeMoveBetweenChildLists(settingsService, metahubId, userId)
+
+            try {
+                const updated = await attributesService.reorderAttribute(
+                    metahubId,
+                    catalogId,
+                    attributeId,
+                    newSortOrder,
+                    newParentAttributeId,
+                    codenameScope as 'per-level' | 'global',
+                    codenameStyle as 'kebab-case' | 'pascal-case',
+                    allowCrossListRootChildren,
+                    allowCrossListBetweenChildren,
+                    autoRenameCodename,
+                    userId
+                )
+                res.json(updated)
+            } catch (error: any) {
+                if (error.message?.startsWith('CODENAME_CONFLICT')) {
+                    return res.status(409).json({
+                        message: error.message,
+                        code: 'CODENAME_CONFLICT',
+                        codename: error.codename
+                    })
+                }
+                if (error.message?.startsWith('DISPLAY_ATTRIBUTE_TRANSFER_BLOCKED')) {
+                    return res.status(422).json({ message: error.message, code: 'DISPLAY_ATTRIBUTE_TRANSFER_BLOCKED' })
+                }
+                if (error.message?.startsWith('TRANSFER_NOT_ALLOWED')) {
+                    return res.status(403).json({ message: error.message, code: 'TRANSFER_NOT_ALLOWED' })
+                }
                 if (error.message === 'Attribute not found') {
                     return res.status(404).json({ error: 'Attribute not found' })
                 }

--- a/packages/metahubs-backend/base/src/domains/enumerations/routes/enumerationsRoutes.ts
+++ b/packages/metahubs-backend/base/src/domains/enumerations/routes/enumerationsRoutes.ts
@@ -2004,6 +2004,51 @@ export function createEnumerationsRoutes(
         })
     )
 
+    /**
+     * PATCH /metahub/:metahubId/enumeration/:enumerationId/values/reorder
+     * Reorder a single enumeration value to a new sort_order position (DnD)
+     */
+    const reorderValueSchema = z.object({
+        valueId: z.string().uuid(),
+        newSortOrder: z.number().int().min(1)
+    })
+
+    router.patch(
+        '/metahub/:metahubId/enumeration/:enumerationId/values/reorder',
+        writeLimiter,
+        asyncHandler(async (req, res) => {
+            const { metahubId, enumerationId } = req.params
+            const { objectsService, valuesService } = services(req)
+            const userId = resolveUserId(req)
+
+            const enumeration = await objectsService.findById(metahubId, enumerationId, userId)
+            if (!enumeration || enumeration.kind !== MetaEntityKind.ENUMERATION) {
+                return res.status(404).json({ error: 'Enumeration not found' })
+            }
+
+            const parsed = reorderValueSchema.safeParse(req.body)
+            if (!parsed.success) {
+                return res.status(400).json({ error: 'Validation failed', details: parsed.error.issues })
+            }
+
+            try {
+                const updated = await valuesService.reorderValue(
+                    metahubId,
+                    enumerationId,
+                    parsed.data.valueId,
+                    parsed.data.newSortOrder,
+                    userId
+                )
+                return res.json(updated)
+            } catch (error) {
+                if (error instanceof Error && error.message === 'Enumeration value not found') {
+                    return res.status(404).json({ error: 'Enumeration value not found' })
+                }
+                throw error
+            }
+        })
+    )
+
     router.post(
         '/metahub/:metahubId/enumeration/:enumerationId/value/:valueId/copy',
         writeLimiter,

--- a/packages/metahubs-backend/base/src/domains/metahubs/services/MetahubAttributesService.ts
+++ b/packages/metahubs-backend/base/src/domains/metahubs/services/MetahubAttributesService.ts
@@ -1,8 +1,9 @@
 import { KnexClient } from '../../ddl'
 import { MetahubSchemaService } from './MetahubSchemaService'
 import { updateWithVersionCheck, incrementVersion } from '../../../utils/optimisticLock'
-import { AttributeDataType } from '@universo/types'
+import { AttributeDataType, TABLE_CHILD_DATA_TYPES } from '@universo/types'
 import { generateUuidV7 } from '@universo/utils'
+import { buildCodenameAttempt } from '../../shared/codenameStyleHelper'
 import type { Knex } from 'knex'
 
 /**
@@ -583,6 +584,262 @@ export class MetahubAttributesService {
             const [updated] = await trx.withSchema(schemaName).from('_mhb_attributes').where({ id: attributeId }).returning('*')
             return this.mapRowToAttribute(updated)
         })
+    }
+
+    /**
+     * Reorder an attribute to a new sort_order (and optionally transfer to a different parent list).
+     * @param codenameScope - 'per-level' or 'global' codename uniqueness scope
+     * @param codenameStyle - 'kebab-case' or 'pascal-case' for auto-rename suffix
+     * @param autoRenameCodename - if true, auto-rename codename on conflict
+     */
+    async reorderAttribute(
+        metahubId: string,
+        objectId: string,
+        attributeId: string,
+        newSortOrder: number,
+        newParentAttributeId: string | null | undefined,
+        codenameScope: 'per-level' | 'global',
+        codenameStyle: 'kebab-case' | 'pascal-case',
+        allowCrossListRootChildren: boolean,
+        allowCrossListBetweenChildren: boolean,
+        autoRenameCodename?: boolean,
+        userId?: string
+    ) {
+        const schemaName = await this.schemaService.ensureSchema(metahubId, userId)
+
+        return this.knex.transaction(async (trx) => {
+            // 1. Fetch current attribute
+            const current = await trx
+                .withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ id: attributeId, object_id: objectId })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+                .first()
+            if (!current) throw new Error('Attribute not found')
+
+            const currentParent: string | null = current.parent_attribute_id ?? null
+            const targetParent: string | null = newParentAttributeId !== undefined ? newParentAttributeId : currentParent
+            const isCrossList = targetParent !== currentParent
+
+            if (isCrossList) {
+                // ── Cross-list transfer validation ──
+                await this._validateCrossListTransfer(
+                    trx,
+                    schemaName,
+                    objectId,
+                    current,
+                    currentParent,
+                    targetParent,
+                    allowCrossListRootChildren,
+                    allowCrossListBetweenChildren,
+                    codenameScope,
+                    codenameStyle,
+                    autoRenameCodename
+                )
+
+                // Move: update parent_attribute_id
+                await trx
+                    .withSchema(schemaName)
+                    .from('_mhb_attributes')
+                    .where({ id: attributeId })
+                    .update({ parent_attribute_id: targetParent })
+
+                // Normalize source list (close gap left by the moved attribute)
+                await this._ensureSequentialSortOrder(metahubId, objectId, trx, userId, currentParent)
+
+                // Auto-set display attribute + required when attribute becomes the only child in target list
+                if (targetParent !== null) {
+                    const siblingCount = await trx
+                        .withSchema(schemaName)
+                        .from('_mhb_attributes')
+                        .where({ object_id: objectId, parent_attribute_id: targetParent })
+                        .andWhere('_upl_deleted', false)
+                        .andWhere('_mhb_deleted', false)
+                        .count('id as count')
+                        .first()
+                    if (siblingCount && Number(siblingCount.count) === 1) {
+                        await trx
+                            .withSchema(schemaName)
+                            .from('_mhb_attributes')
+                            .where({ id: attributeId })
+                            .update({ is_display_attribute: true, is_required: true })
+                    }
+                }
+            }
+
+            // 2. Ensure sequential order in target list
+            await this._ensureSequentialSortOrder(metahubId, objectId, trx, userId, targetParent)
+
+            // 3. Re-fetch to get current sort_order after normalization
+            const refreshed = await trx
+                .withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ id: attributeId, object_id: objectId })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+                .first()
+            if (!refreshed) throw new Error('Attribute not found')
+            const oldOrder = refreshed.sort_order
+            const clampedNew = Math.max(1, newSortOrder)
+
+            if (oldOrder !== clampedNew) {
+                // Build parent scope condition
+                const parentCondition = (q: Knex.QueryBuilder) => {
+                    if (targetParent) {
+                        q.where({ parent_attribute_id: targetParent })
+                    } else {
+                        q.whereNull('parent_attribute_id')
+                    }
+                }
+
+                if (clampedNew < oldOrder) {
+                    // Moving up: shift items [clampedNew, oldOrder) down by 1
+                    await trx
+                        .withSchema(schemaName)
+                        .from('_mhb_attributes')
+                        .where({ object_id: objectId })
+                        .modify(parentCondition)
+                        .where('sort_order', '>=', clampedNew)
+                        .where('sort_order', '<', oldOrder)
+                        .whereNot({ id: attributeId })
+                        .increment('sort_order', 1)
+                } else {
+                    // Moving down: shift items (oldOrder, clampedNew] up by 1
+                    await trx
+                        .withSchema(schemaName)
+                        .from('_mhb_attributes')
+                        .where({ object_id: objectId })
+                        .modify(parentCondition)
+                        .where('sort_order', '>', oldOrder)
+                        .where('sort_order', '<=', clampedNew)
+                        .whereNot({ id: attributeId })
+                        .decrement('sort_order', 1)
+                }
+
+                // Set the target sort_order
+                await trx.withSchema(schemaName).from('_mhb_attributes').where({ id: attributeId }).update({ sort_order: clampedNew })
+            }
+
+            // 4. Final normalization pass
+            await this._ensureSequentialSortOrder(metahubId, objectId, trx, userId, targetParent)
+
+            // 5. Return updated attribute
+            const updated = await trx
+                .withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ id: attributeId, object_id: objectId })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+                .first()
+            if (!updated) throw new Error('Attribute not found')
+            return this.mapRowToAttribute(updated)
+        })
+    }
+
+    /**
+     * Validate a cross-list attribute transfer (change of parent_attribute_id).
+     * Throws typed errors that the route handler maps to HTTP status codes.
+     */
+    private async _validateCrossListTransfer(
+        trx: Knex.Transaction,
+        schemaName: string,
+        objectId: string,
+        attribute: any,
+        currentParentId: string | null,
+        targetParentId: string | null,
+        allowCrossListRootChildren: boolean,
+        allowCrossListBetweenChildren: boolean,
+        codenameScope: 'per-level' | 'global',
+        codenameStyle: 'kebab-case' | 'pascal-case',
+        autoRenameCodename?: boolean
+    ): Promise<void> {
+        const sourceIsRoot = currentParentId === null
+        const targetIsRoot = targetParentId === null
+
+        if ((sourceIsRoot || targetIsRoot) && !allowCrossListRootChildren) {
+            throw new Error('TRANSFER_NOT_ALLOWED: Moving attributes between root and child lists is disabled by settings')
+        }
+
+        if (!sourceIsRoot && !targetIsRoot && !allowCrossListBetweenChildren) {
+            throw new Error('TRANSFER_NOT_ALLOWED: Moving attributes between child lists is disabled by settings')
+        }
+
+        // 1. Display attribute cannot be moved across lists
+        if (attribute.is_display_attribute) {
+            throw new Error(
+                'DISPLAY_ATTRIBUTE_TRANSFER_BLOCKED: Display attribute cannot be moved. Assign another attribute as the display attribute first.'
+            )
+        }
+
+        // 2. TABLE attributes can only exist at root level
+        if (attribute.data_type === AttributeDataType.TABLE && targetParentId !== null) {
+            throw new Error('TRANSFER_NOT_ALLOWED: TABLE attributes can only exist at the root level')
+        }
+
+        // 3. If target is a child list, verify parent is TABLE type and data type is allowed
+        if (targetParentId !== null) {
+            const parentAttr = await trx
+                .withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ id: targetParentId, object_id: objectId })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+                .first()
+            if (!parentAttr || parentAttr.data_type !== AttributeDataType.TABLE) {
+                throw new Error('TRANSFER_NOT_ALLOWED: Target parent is not a TABLE attribute')
+            }
+            if (!TABLE_CHILD_DATA_TYPES.includes(attribute.data_type)) {
+                throw new Error(`TRANSFER_NOT_ALLOWED: ${attribute.data_type} attributes are not allowed in TABLE children`)
+            }
+        }
+
+        // 4. Codename uniqueness check in target scope
+        const hasConflict = async (codename: string): Promise<boolean> => {
+            let query = trx
+                .withSchema(schemaName)
+                .from('_mhb_attributes')
+                .where({ object_id: objectId, codename })
+                .whereNot({ id: attribute.id })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+
+            if (codenameScope !== 'global') {
+                // Per-level: unique among siblings at target level
+                if (targetParentId) {
+                    query = query.where({ parent_attribute_id: targetParentId })
+                } else {
+                    query = query.whereNull('parent_attribute_id')
+                }
+            }
+            return !!(await query.first())
+        }
+
+        if (await hasConflict(attribute.codename)) {
+            if (!autoRenameCodename) {
+                // No auto-rename — throw conflict so frontend can show dialog
+                const error: any = new Error(`CODENAME_CONFLICT: Codename "${attribute.codename}" already exists in the target scope`)
+                error.codename = attribute.codename
+                throw error
+            }
+
+            // Auto-rename using buildCodenameAttempt() retry loop
+            let renamed = false
+            for (let attempt = 2; attempt <= 20 && !renamed; attempt++) {
+                const candidate = buildCodenameAttempt(attribute.codename, attempt, codenameStyle)
+                if (!(await hasConflict(candidate))) {
+                    await trx
+                        .withSchema(schemaName)
+                        .from('_mhb_attributes')
+                        .where({ id: attribute.id })
+                        .update({ codename: candidate, codename_localized: null })
+                    renamed = true
+                }
+            }
+            if (!renamed) {
+                throw new Error('CODENAME_CONFLICT: Could not generate unique codename after 20 attempts')
+            }
+        }
     }
 
     /**

--- a/packages/metahubs-backend/base/src/domains/metahubs/services/MetahubEnumerationValuesService.ts
+++ b/packages/metahubs-backend/base/src/domains/metahubs/services/MetahubEnumerationValuesService.ts
@@ -285,6 +285,84 @@ export class MetahubEnumerationValuesService {
         })
     }
 
+    /**
+     * Reorder a single enumeration value to a new sort_order position.
+     * Uses gap-shift approach: shift neighbouring values up/down, then place the moved value.
+     */
+    async reorderValue(metahubId: string, enumerationId: string, valueId: string, newSortOrder: number, userId?: string) {
+        const schemaName = await this.schemaService.ensureSchema(metahubId, userId)
+
+        return this.knex.transaction(async (trx) => {
+            // 1. Normalize sort_order first
+            await this.ensureSequentialSortOrderInTransaction(schemaName, enumerationId, trx)
+
+            // 2. Fetch the current value
+            const current = await trx
+                .withSchema(schemaName)
+                .from('_mhb_values')
+                .where({ id: valueId, object_id: enumerationId })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+                .first()
+            if (!current) throw new Error('Enumeration value not found')
+
+            const oldOrder = current.sort_order
+            const clampedNew = Math.max(1, newSortOrder)
+
+            if (oldOrder !== clampedNew) {
+                const now = new Date()
+
+                if (clampedNew < oldOrder) {
+                    // Moving up: shift items [clampedNew, oldOrder) down by 1
+                    await trx
+                        .withSchema(schemaName)
+                        .from('_mhb_values')
+                        .where({ object_id: enumerationId })
+                        .andWhere('_upl_deleted', false)
+                        .andWhere('_mhb_deleted', false)
+                        .where('sort_order', '>=', clampedNew)
+                        .where('sort_order', '<', oldOrder)
+                        .whereNot({ id: valueId })
+                        .update({ _upl_updated_at: now, _upl_updated_by: userId ?? null })
+                        .increment('sort_order', 1)
+                } else {
+                    // Moving down: shift items (oldOrder, clampedNew] up by 1
+                    await trx
+                        .withSchema(schemaName)
+                        .from('_mhb_values')
+                        .where({ object_id: enumerationId })
+                        .andWhere('_upl_deleted', false)
+                        .andWhere('_mhb_deleted', false)
+                        .where('sort_order', '>', oldOrder)
+                        .where('sort_order', '<=', clampedNew)
+                        .whereNot({ id: valueId })
+                        .update({ _upl_updated_at: now, _upl_updated_by: userId ?? null })
+                        .decrement('sort_order', 1)
+                }
+
+                // Place the value at its new position
+                await trx
+                    .withSchema(schemaName)
+                    .from('_mhb_values')
+                    .where({ id: valueId })
+                    .update({ sort_order: clampedNew, _upl_updated_at: now, _upl_updated_by: userId ?? null })
+            }
+
+            // 3. Final normalization
+            await this.ensureSequentialSortOrderInTransaction(schemaName, enumerationId, trx)
+
+            const updated = await trx
+                .withSchema(schemaName)
+                .from('_mhb_values')
+                .where({ id: valueId, object_id: enumerationId })
+                .andWhere('_upl_deleted', false)
+                .andWhere('_mhb_deleted', false)
+                .first()
+            if (!updated) throw new Error('Enumeration value not found')
+            return this.mapRow(updated)
+        })
+    }
+
     async getDefaultValue(metahubId: string, enumerationId: string, userId?: string) {
         const schemaName = await this.schemaService.ensureSchema(metahubId, userId)
         const row = await this.knex

--- a/packages/metahubs-backend/base/src/domains/shared/codenameStyleHelper.ts
+++ b/packages/metahubs-backend/base/src/domains/shared/codenameStyleHelper.ts
@@ -199,6 +199,42 @@ export async function getAllowDeleteLastDisplayAttribute(
     }
 }
 
+/**
+ * Read allow-move-between-root-and-children setting.
+ * Returns true if not set.
+ */
+export async function getAllowAttributeMoveBetweenRootAndChildren(
+    settingsService: MetahubSettingsService,
+    metahubId: string,
+    userId?: string
+): Promise<boolean> {
+    try {
+        const row = await settingsService.findByKey(metahubId, 'catalogs.allowAttributeMoveBetweenRootAndChildren', userId)
+        const value = row?.value?._value
+        return value !== false
+    } catch {
+        return true
+    }
+}
+
+/**
+ * Read allow-move-between-child-lists setting.
+ * Returns true if not set.
+ */
+export async function getAllowAttributeMoveBetweenChildLists(
+    settingsService: MetahubSettingsService,
+    metahubId: string,
+    userId?: string
+): Promise<boolean> {
+    try {
+        const row = await settingsService.findByKey(metahubId, 'catalogs.allowAttributeMoveBetweenChildLists', userId)
+        const value = row?.value?._value
+        return value !== false
+    } catch {
+        return true
+    }
+}
+
 // ─── Codename attempt builder ────────────────────────────────────────────────
 
 /**
@@ -209,8 +245,7 @@ export async function getAllowDeleteLastDisplayAttribute(
 export function buildCodenameAttempt(baseCodename: string, attempt: number, style: CodenameStyle = 'kebab-case'): string {
     if (attempt <= 1) return baseCodename
 
-    const sep = style === 'pascal-case' ? '_' : '-'
-    const attemptSuffix = `${sep}${attempt}`
+    const attemptSuffix = `${attempt}`
     const limit = style === 'pascal-case' ? 80 : 100
     const maxLength = Math.max(1, limit - attemptSuffix.length)
     return `${baseCodename.slice(0, maxLength)}${attemptSuffix}`

--- a/packages/metahubs-backend/base/src/tests/routes/attributesRoutes.test.ts
+++ b/packages/metahubs-backend/base/src/tests/routes/attributesRoutes.test.ts
@@ -63,7 +63,8 @@ const mockAttributesService = {
     update: jest.fn(),
     findByCodename: jest.fn(),
     create: jest.fn(),
-    findChildAttributes: jest.fn()
+    findChildAttributes: jest.fn(),
+    reorderAttribute: jest.fn()
 }
 
 const mockObjectsService = {}
@@ -155,7 +156,71 @@ describe('Attributes Routes', () => {
         mockAttributesService.findByCodename.mockResolvedValue(null)
         mockAttributesService.create.mockResolvedValue({})
         mockAttributesService.findChildAttributes.mockResolvedValue([])
+        mockAttributesService.reorderAttribute.mockResolvedValue({
+            id: '11111111-1111-1111-1111-111111111111',
+            objectId: '22222222-2222-2222-2222-222222222222',
+            sortOrder: 1,
+            parentAttributeId: null
+        })
         mockEnumerationValuesService.findById.mockResolvedValue(null)
+    })
+
+    describe('PATCH /metahub/:metahubId/catalog/:catalogId/attributes/reorder', () => {
+        it('passes cross-list move settings to reorder service', async () => {
+            mockSettingsService.findByKey.mockImplementation(async (_metahubId: string, key: string) => {
+                const values: Record<string, unknown> = {
+                    'catalogs.attributeCodenameScope': 'per-level',
+                    'general.codenameStyle': 'pascal-case',
+                    'catalogs.allowAttributeMoveBetweenRootAndChildren': false,
+                    'catalogs.allowAttributeMoveBetweenChildLists': false
+                }
+
+                return key in values ? { key, value: { _value: values[key] } } : null
+            })
+
+            const app = buildApp()
+            await request(app)
+                .patch('/metahub/metahub-1/catalog/catalog-1/attributes/reorder')
+                .send({
+                    attributeId: '11111111-1111-1111-1111-111111111111',
+                    newSortOrder: 2,
+                    newParentAttributeId: '33333333-3333-3333-3333-333333333333'
+                })
+                .expect(200)
+
+            expect(mockAttributesService.reorderAttribute).toHaveBeenCalledWith(
+                'metahub-1',
+                'catalog-1',
+                '11111111-1111-1111-1111-111111111111',
+                2,
+                '33333333-3333-3333-3333-333333333333',
+                'per-level',
+                'pascal-case',
+                false,
+                false,
+                undefined,
+                'test-user-id'
+            )
+        })
+
+        it('returns 403 when service rejects cross-list transfer by settings', async () => {
+            mockAttributesService.reorderAttribute.mockRejectedValueOnce(
+                new Error('TRANSFER_NOT_ALLOWED: Moving attributes between root and child lists is disabled by settings')
+            )
+
+            const app = buildApp()
+            const response = await request(app)
+                .patch('/metahub/metahub-1/catalog/catalog-1/attributes/reorder')
+                .send({
+                    attributeId: '11111111-1111-1111-1111-111111111111',
+                    newSortOrder: 2,
+                    newParentAttributeId: '33333333-3333-3333-3333-333333333333'
+                })
+                .expect(403)
+
+            expect(response.body.code).toBe('TRANSFER_NOT_ALLOWED')
+            expect(response.body.message).toContain('TRANSFER_NOT_ALLOWED')
+        })
     })
 
     describe('PATCH /metahub/:metahubId/catalog/:catalogId/attribute/:attributeId/toggle-required', () => {

--- a/packages/metahubs-backend/base/src/tests/routes/enumerationsRoutes.test.ts
+++ b/packages/metahubs-backend/base/src/tests/routes/enumerationsRoutes.test.ts
@@ -90,7 +90,9 @@ const mockAttributesService = {
     findReferenceBlockersByTarget: jest.fn()
 }
 
-const mockValuesService = {}
+const mockValuesService = {
+    reorderValue: jest.fn()
+}
 const mockHubsService = {
     findByIds: jest.fn()
 }
@@ -290,6 +292,11 @@ describe('Enumerations Routes', () => {
         )
         mockObjectsService.restore.mockResolvedValue(undefined)
         mockObjectsService.permanentDelete.mockResolvedValue(undefined)
+        mockValuesService.reorderValue.mockResolvedValue({
+            id: '44444444-4444-4444-4444-444444444444',
+            objectId: 'enum-1',
+            sortOrder: 2
+        })
         mockAttributesService.findReferenceBlockersByTarget.mockResolvedValue([])
         mockHubsService.findByIds.mockResolvedValue([
             {
@@ -301,6 +308,54 @@ describe('Enumerations Routes', () => {
         mockMetahubRepo.findOne.mockResolvedValue({ id: 'metahub-1' })
         mockEnsureMetahubAccess.mockResolvedValue({ metahubId: 'metahub-1' })
         mockEnsureSchema.mockResolvedValue('mhb_test_schema')
+    })
+
+    describe('PATCH /metahub/:metahubId/enumeration/:enumerationId/values/reorder', () => {
+        it('reorders enumeration value and returns updated value', async () => {
+            const app = buildApp()
+            const response = await request(app)
+                .patch('/metahub/metahub-1/enumeration/enum-1/values/reorder')
+                .send({
+                    valueId: '44444444-4444-4444-4444-444444444444',
+                    newSortOrder: 2
+                })
+                .expect(200)
+
+            expect(response.body.id).toBe('44444444-4444-4444-4444-444444444444')
+            expect(mockValuesService.reorderValue).toHaveBeenCalledWith(
+                'metahub-1',
+                'enum-1',
+                '44444444-4444-4444-4444-444444444444',
+                2,
+                'test-user-id'
+            )
+        })
+
+        it('returns 404 when reordered value is not found in target enumeration', async () => {
+            mockValuesService.reorderValue.mockRejectedValueOnce(new Error('Enumeration value not found'))
+
+            const app = buildApp()
+            const response = await request(app)
+                .patch('/metahub/metahub-1/enumeration/enum-1/values/reorder')
+                .send({
+                    valueId: '44444444-4444-4444-4444-444444444444',
+                    newSortOrder: 2
+                })
+                .expect(404)
+
+            expect(response.body.error).toBe('Enumeration value not found')
+        })
+
+        it('returns 400 when payload is invalid', async () => {
+            const app = buildApp()
+            const response = await request(app)
+                .patch('/metahub/metahub-1/enumeration/enum-1/values/reorder')
+                .send({ valueId: 'not-a-uuid', newSortOrder: 0 })
+                .expect(400)
+
+            expect(response.body.error).toBe('Validation failed')
+            expect(mockValuesService.reorderValue).not.toHaveBeenCalled()
+        })
     })
 
     describe('DELETE /metahub/:metahubId/enumeration/:enumerationId/permanent', () => {

--- a/packages/metahubs-frontend/base/src/domains/attributes/api/attributes.ts
+++ b/packages/metahubs-frontend/base/src/domains/attributes/api/attributes.ts
@@ -198,6 +198,45 @@ export const deleteAttributeDirect = (metahubId: string, catalogId: string, attr
 export const moveAttributeDirect = (metahubId: string, catalogId: string, attributeId: string, direction: 'up' | 'down') =>
     apiClient.patch<Attribute>(`/metahub/${metahubId}/catalog/${catalogId}/attribute/${attributeId}/move`, { direction })
 
+/**
+ * Reorder an attribute via DnD (with hubId).
+ * Supports same-list reorder and cross-list transfer.
+ */
+export const reorderAttribute = (
+    metahubId: string,
+    hubId: string,
+    catalogId: string,
+    attributeId: string,
+    newSortOrder: number,
+    newParentAttributeId?: string | null,
+    autoRenameCodename?: boolean
+) =>
+    apiClient.patch<Attribute>(`/metahub/${metahubId}/hub/${hubId}/catalog/${catalogId}/attributes/reorder`, {
+        attributeId,
+        newSortOrder,
+        ...(newParentAttributeId !== undefined && { newParentAttributeId }),
+        ...(autoRenameCodename && { autoRenameCodename })
+    })
+
+/**
+ * Reorder an attribute via DnD (without hubId).
+ * Supports same-list reorder and cross-list transfer.
+ */
+export const reorderAttributeDirect = (
+    metahubId: string,
+    catalogId: string,
+    attributeId: string,
+    newSortOrder: number,
+    newParentAttributeId?: string | null,
+    autoRenameCodename?: boolean
+) =>
+    apiClient.patch<Attribute>(`/metahub/${metahubId}/catalog/${catalogId}/attributes/reorder`, {
+        attributeId,
+        newSortOrder,
+        ...(newParentAttributeId !== undefined && { newParentAttributeId }),
+        ...(autoRenameCodename && { autoRenameCodename })
+    })
+
 export const copyAttributeDirect = (metahubId: string, catalogId: string, attributeId: string, data: AttributeCopyInput) =>
     apiClient.post<Attribute>(`/metahub/${metahubId}/catalog/${catalogId}/attribute/${attributeId}/copy`, data)
 

--- a/packages/metahubs-frontend/base/src/domains/attributes/hooks/mutations.ts
+++ b/packages/metahubs-frontend/base/src/domains/attributes/hooks/mutations.ts
@@ -56,6 +56,17 @@ interface CopyAttributeParams {
     data: AttributeCopyInput
 }
 
+interface ReorderAttributeParams {
+    metahubId: string
+    hubId?: string
+    catalogId: string
+    attributeId: string
+    newSortOrder: number
+    newParentAttributeId?: string | null
+    currentParentAttributeId?: string | null
+    autoRenameCodename?: boolean
+}
+
 export function useCreateAttribute() {
     const queryClient = useQueryClient()
     const { enqueueSnackbar } = useSnackbar()
@@ -203,6 +214,171 @@ export function useMoveAttribute() {
         },
         onError: (error: Error) => {
             enqueueSnackbar(error.message || t('attributes.moveError', 'Failed to update attribute order'), { variant: 'error' })
+        }
+    })
+}
+
+/**
+ * Reorder an attribute via DnD (same-list reorder + cross-list transfer).
+ * No onError here — error handling is done in the calling component
+ * to distinguish CODENAME_CONFLICT (409) and offer auto-rename dialog.
+ * Optimistic updates for both same-list reorder and cross-list transfer.
+ */
+export function useReorderAttribute() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async ({
+            metahubId,
+            hubId,
+            catalogId,
+            attributeId,
+            newSortOrder,
+            newParentAttributeId,
+            autoRenameCodename
+        }: ReorderAttributeParams) => {
+            if (hubId) {
+                const response = await attributesApi.reorderAttribute(
+                    metahubId,
+                    hubId,
+                    catalogId,
+                    attributeId,
+                    newSortOrder,
+                    newParentAttributeId,
+                    autoRenameCodename
+                )
+                return response.data
+            }
+            const response = await attributesApi.reorderAttributeDirect(
+                metahubId,
+                catalogId,
+                attributeId,
+                newSortOrder,
+                newParentAttributeId,
+                autoRenameCodename
+            )
+            return response.data
+        },
+        onMutate: async (variables) => {
+            const baseKey = variables.hubId
+                ? metahubsQueryKeys.attributes(variables.metahubId, variables.hubId, variables.catalogId)
+                : metahubsQueryKeys.attributesDirect(variables.metahubId, variables.catalogId)
+            const childKeyPrefix = ['metahubs', 'childAttributes', variables.metahubId, variables.catalogId]
+
+            // Cancel in-flight queries to prevent overwriting our optimistic update
+            await queryClient.cancelQueries({ queryKey: baseKey })
+            await queryClient.cancelQueries({ queryKey: childKeyPrefix })
+
+            // Snapshot ALL relevant caches for rollback (covers both same-list and cross-list)
+            const previousRootQueries = queryClient.getQueriesData<Record<string, unknown>>({ queryKey: baseKey })
+            const previousChildQueries = queryClient.getQueriesData<Record<string, unknown>>({ queryKey: childKeyPrefix })
+
+            const isCrossList = variables.newParentAttributeId !== undefined
+
+            if (isCrossList) {
+                // ── Cross-list transfer optimistic update ──
+                const currentParent = variables.currentParentAttributeId ?? null
+                const targetParent = variables.newParentAttributeId!
+                const sourceIsRoot = currentParent === null
+                const targetIsRoot = targetParent === null
+
+                // Extract the moved item from source cache BEFORE applying updaters.
+                // This avoids relying on a closure side-effect inside setQueriesData callbacks.
+                const sourceKey = sourceIsRoot ? baseKey : [...childKeyPrefix, currentParent]
+                let movedItem: Record<string, unknown> | null = null
+                const sourceQueries = queryClient.getQueriesData<Record<string, unknown>>({ queryKey: sourceKey })
+                for (const [, data] of sourceQueries) {
+                    if (data && Array.isArray((data as Record<string, unknown> & { items?: unknown[] }).items)) {
+                        const items = (data as Record<string, unknown> & { items: Record<string, unknown>[] }).items
+                        const found = items.find((i) => (i as Record<string, unknown>).id === variables.attributeId)
+                        if (found) {
+                            movedItem = { ...found }
+                            break
+                        }
+                    }
+                }
+
+                // Updater: remove the dragged attribute from source cache, re-index sort orders
+                const removeUpdater = (old: Record<string, unknown> | undefined) => {
+                    if (!old || !Array.isArray((old as Record<string, unknown> & { items?: unknown[] }).items)) return old
+                    const items: Record<string, unknown>[] = (old as Record<string, unknown> & { items: Record<string, unknown>[] }).items
+                    const idx = items.findIndex((i) => (i as Record<string, unknown>).id === variables.attributeId)
+                    if (idx === -1) return old
+                    const remaining = items.filter((_, i) => i !== idx)
+                    const reindexed = remaining.map((item, i) => ({ ...item, sortOrder: i + 1 }))
+                    return { ...old, items: reindexed }
+                }
+
+                // Remove from source cache
+                queryClient.setQueriesData<Record<string, unknown>>({ queryKey: sourceKey }, removeUpdater)
+
+                // Insert into target cache
+                if (movedItem) {
+                    const captured = movedItem
+                    const insertUpdater = (old: Record<string, unknown> | undefined) => {
+                        if (!old || !Array.isArray((old as Record<string, unknown> & { items?: unknown[] }).items)) return old
+                        const items = [...(old as Record<string, unknown> & { items: Record<string, unknown>[] }).items]
+                        const insertIdx = Math.min(Math.max(0, variables.newSortOrder - 1), items.length)
+                        items.splice(insertIdx, 0, { ...captured, sortOrder: variables.newSortOrder })
+                        const reindexed = items.map((item, i) => ({ ...item, sortOrder: i + 1 }))
+                        return { ...old, items: reindexed }
+                    }
+
+                    const targetKey = targetIsRoot ? baseKey : [...childKeyPrefix, targetParent]
+                    queryClient.setQueriesData<Record<string, unknown>>({ queryKey: targetKey }, insertUpdater)
+                }
+            } else {
+                // ── Same-list reorder optimistic update ──
+                const reorderUpdater = (old: Record<string, unknown> | undefined) => {
+                    if (!old || !Array.isArray((old as Record<string, unknown> & { items?: unknown[] }).items)) return old
+                    const items = [...(old as Record<string, unknown> & { items: Record<string, unknown>[] }).items]
+                    const fromIndex = items.findIndex((i) => (i as Record<string, unknown>).id === variables.attributeId)
+                    if (fromIndex === -1) return old
+                    let toIndex = items.findIndex((i) => ((i as Record<string, unknown>).sortOrder ?? 0) === variables.newSortOrder)
+                    if (toIndex === -1) toIndex = items.length - 1
+                    const [moved] = items.splice(fromIndex, 1)
+                    items.splice(toIndex, 0, moved)
+                    const updated = items.map((item, idx) => ({ ...item, sortOrder: idx + 1 }))
+                    return { ...old, items: updated }
+                }
+
+                queryClient.setQueriesData<Record<string, unknown>>({ queryKey: baseKey }, reorderUpdater)
+                queryClient.setQueriesData<Record<string, unknown>>({ queryKey: childKeyPrefix }, reorderUpdater)
+            }
+
+            return { previousRootQueries, previousChildQueries }
+        },
+        onError: (_error, _variables, context) => {
+            // Rollback optimistic update on error
+            if (context?.previousRootQueries) {
+                for (const [key, data] of context.previousRootQueries) {
+                    queryClient.setQueryData(key, data)
+                }
+            }
+            if (context?.previousChildQueries) {
+                for (const [key, data] of context.previousChildQueries) {
+                    queryClient.setQueryData(key, data)
+                }
+            }
+        },
+        onSuccess: (_data, variables) => {
+            if (variables.hubId) {
+                queryClient.invalidateQueries({
+                    queryKey: metahubsQueryKeys.attributes(variables.metahubId, variables.hubId, variables.catalogId)
+                })
+                queryClient.invalidateQueries({ queryKey: metahubsQueryKeys.catalogs(variables.metahubId, variables.hubId) })
+            } else {
+                queryClient.invalidateQueries({ queryKey: metahubsQueryKeys.attributesDirect(variables.metahubId, variables.catalogId) })
+            }
+            // Invalidate child attribute queries only for cross-list transfers
+            // (backend may auto-rename codename, auto-set display/required, etc.)
+            if (variables.newParentAttributeId !== undefined) {
+                queryClient.invalidateQueries({
+                    queryKey: ['metahubs', 'childAttributes', variables.metahubId, variables.catalogId]
+                })
+            }
+            queryClient.invalidateQueries({ queryKey: metahubsQueryKeys.catalogDetail(variables.metahubId, variables.catalogId) })
+            queryClient.invalidateQueries({ queryKey: metahubsQueryKeys.allCatalogs(variables.metahubId) })
         }
     })
 }

--- a/packages/metahubs-frontend/base/src/domains/attributes/hooks/mutations.ts
+++ b/packages/metahubs-frontend/base/src/domains/attributes/hooks/mutations.ts
@@ -319,7 +319,11 @@ export function useReorderAttribute() {
                         if (!old || !Array.isArray((old as Record<string, unknown> & { items?: unknown[] }).items)) return old
                         const items = [...(old as Record<string, unknown> & { items: Record<string, unknown>[] }).items]
                         const insertIdx = Math.min(Math.max(0, variables.newSortOrder - 1), items.length)
-                        items.splice(insertIdx, 0, { ...captured, sortOrder: variables.newSortOrder })
+                        items.splice(insertIdx, 0, {
+                            ...captured,
+                            sortOrder: variables.newSortOrder,
+                            parentAttributeId: variables.newParentAttributeId ?? null
+                        })
                         const reindexed = items.map((item, i) => ({ ...item, sortOrder: i + 1 }))
                         return { ...old, items: reindexed }
                     }

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeActions.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeActions.tsx
@@ -303,7 +303,10 @@ const attributeActions: readonly ActionDescriptor<AttributeDisplay, AttributeLoc
                     initialExtraValues: initial,
                     tabs: ({ values, setValue, isLoading, errors }: AttributeTabArgs): TabConfig[] => {
                         const attributeMap = ctx.attributeMap as Map<string, Attribute> | undefined
-                        const displayAttributeLocked = (attributeMap?.size ?? 0) <= 1
+                        // Lock the display attribute toggle when:
+                        // 1. there's only one attribute (can't unset the only one), or
+                        // 2. the current attribute IS the display attribute (must assign to another first)
+                        const displayAttributeLocked = (attributeMap?.size ?? 0) <= 1 || isDisplayAttributeEntity(ctx)
                         return [
                             {
                                 id: 'general',

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeList.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/AttributeList.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react'
+import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { Box, Skeleton, Stack, Typography, Chip, Alert, Tooltip, Tabs, Tab, IconButton } from '@mui/material'
 import AddRoundedIcon from '@mui/icons-material/AddRounded'
@@ -34,6 +34,7 @@ import {
     useUpdateAttribute,
     useDeleteAttribute,
     useMoveAttribute,
+    useReorderAttribute,
     useToggleAttributeRequired,
     useSetDisplayAttribute,
     useClearDisplayAttribute
@@ -59,6 +60,7 @@ import { extractLocalizedInput, hasPrimaryContent } from '../../../utils/localiz
 import attributeActions from './AttributeActions'
 import AttributeFormFields, { PresentationTabFields } from './AttributeFormFields'
 import ChildAttributeList from './ChildAttributeList'
+import { AttributeDndProvider, AttributeDndContainerRegistryProvider, useAttributeDndState } from './dnd'
 import { useCodenameConfig } from '../../settings/hooks/useCodenameConfig'
 import { useSettingValue } from '../../settings/hooks/useSettings'
 import { ExistingCodenamesProvider } from '../../../components'
@@ -178,6 +180,23 @@ const getDataTypeColor = (dataType: AttributeDataType): 'default' | 'primary' | 
         default:
             return 'default'
     }
+}
+
+/**
+ * Render-prop component that reads DnD state and provides `isDropTarget` + ghost row data for a container.
+ * Must be used inside <AttributeDndProvider>.
+ */
+const DndDropTarget: React.FC<{
+    containerId: string
+    children: (props: {
+        isDropTarget: boolean
+        pendingTransfer: import('./dnd').PendingTransfer | null
+        activeAttribute: Attribute | undefined
+    }) => React.ReactNode
+}> = ({ containerId, children }) => {
+    const { activeContainerId, overContainerId, pendingTransfer, activeAttribute } = useAttributeDndState()
+    const isDropTarget = overContainerId === containerId && activeContainerId !== null && activeContainerId !== containerId
+    return <>{children({ isDropTarget, pendingTransfer, activeAttribute })}</>
 }
 
 const AttributeList = () => {
@@ -322,27 +341,139 @@ const AttributeList = () => {
     const updateAttributeMutation = useUpdateAttribute()
     const deleteAttributeMutation = useDeleteAttribute()
     const moveAttributeMutation = useMoveAttribute()
+    const reorderMutation = useReorderAttribute()
     const toggleRequiredMutation = useToggleAttributeRequired()
     const setDisplayAttributeMutation = useSetDisplayAttribute()
     const clearDisplayAttributeMutation = useClearDisplayAttribute()
 
-    // Memoize images object
-    const images = useMemo(() => {
-        const imagesMap: Record<string, unknown[]> = {}
-        if (Array.isArray(attributes)) {
-            attributes.forEach((attr) => {
-                if (attr?.id) {
-                    imagesMap[attr.id] = []
-                }
-            })
-        }
-        return imagesMap
-    }, [attributes])
+    // DnD cross-list permission settings
+    const allowCrossListRootChildren = useSettingValue<boolean>('catalogs.allowAttributeMoveBetweenRootAndChildren') ?? true
+    const allowCrossListBetweenChildren = useSettingValue<boolean>('catalogs.allowAttributeMoveBetweenChildLists') ?? true
 
     const attributeMap = useMemo(() => {
         if (!Array.isArray(attributes)) return new Map<string, Attribute>()
         return new Map(attributes.map((attr) => [attr.id, attr]))
     }, [attributes])
+
+    // DnD: Handle reorder (same-list + cross-list transfer)
+    const handleReorder = useCallback(
+        async (
+            attributeId: string,
+            newSortOrder: number,
+            newParentAttributeId?: string | null,
+            currentParentAttributeId?: string | null
+        ) => {
+            if (!metahubId || !catalogId) return
+
+            try {
+                await reorderMutation.mutateAsync({
+                    metahubId,
+                    hubId: effectiveHubId,
+                    catalogId,
+                    attributeId,
+                    newSortOrder,
+                    newParentAttributeId,
+                    currentParentAttributeId
+                })
+                enqueueSnackbar(t('attributes.reorderSuccess', 'Attribute order updated'), { variant: 'success' })
+            } catch (error: unknown) {
+                // Handle CODENAME_CONFLICT (409) — offer auto-rename
+                const responseData = extractResponseData(error)
+                const responseStatus =
+                    error && typeof error === 'object' && 'response' in error
+                        ? (error as { response?: { status?: number } }).response?.status ?? 0
+                        : 0
+
+                if (responseStatus === 409 && responseData?.code === 'CODENAME_CONFLICT') {
+                    const conflictCodename = typeof responseData?.codename === 'string' ? responseData.codename : ''
+                    const shouldAutoRename = await confirm({
+                        title: t('attributes.dnd.codenameConflictTitle', 'Codename conflict'),
+                        description: t(
+                            'attributes.dnd.codenameConflictDescription',
+                            'An attribute with codename "{{codename}}" already exists in the target list. Move with automatic codename rename?',
+                            { codename: conflictCodename }
+                        ),
+                        confirmButtonName: t('attributes.dnd.confirmMove', 'Move'),
+                        cancelButtonName: tc('actions.cancel', 'Cancel')
+                    })
+                    if (shouldAutoRename) {
+                        try {
+                            await reorderMutation.mutateAsync({
+                                metahubId,
+                                hubId: effectiveHubId,
+                                catalogId,
+                                attributeId,
+                                newSortOrder,
+                                newParentAttributeId,
+                                autoRenameCodename: true,
+                                currentParentAttributeId
+                            })
+                            enqueueSnackbar(t('attributes.reorderSuccess', 'Attribute order updated'), { variant: 'success' })
+                        } catch (retryError: unknown) {
+                            const msg =
+                                retryError instanceof Error
+                                    ? retryError.message
+                                    : t('attributes.reorderError', 'Failed to reorder attribute')
+                            enqueueSnackbar(msg, { variant: 'error' })
+                        }
+                    }
+                    return
+                }
+
+                // Other errors — show generic snackbar
+                const message = error instanceof Error ? error.message : t('attributes.reorderError', 'Failed to reorder attribute')
+                enqueueSnackbar(message, { variant: 'error' })
+            }
+        },
+        [metahubId, catalogId, effectiveHubId, reorderMutation, confirm, enqueueSnackbar, t, tc]
+    )
+
+    // DnD: Validate cross-list transfer before applying
+    const handleValidateTransfer = useCallback(
+        async (attribute: Attribute, targetParentId: string | null, targetContainerItemCount: number): Promise<boolean> => {
+            // Display attribute cannot be moved between lists (root ↔ child)
+            if (attribute.isDisplayAttribute) {
+                await confirm({
+                    title: t('attributes.dnd.displayAttributeBlockedTitle', 'Cannot move display attribute'),
+                    description: t(
+                        'attributes.dnd.displayAttributeBlockedDescription',
+                        'This attribute is the display attribute for its list. Assign another attribute as the display attribute first, then try again.'
+                    ),
+                    confirmButtonName: tc('ok', 'OK'),
+                    hideCancelButton: true
+                })
+                return false
+            }
+
+            // TABLE attributes can only exist at root level
+            if (attribute.dataType === 'TABLE' && targetParentId !== null) {
+                await confirm({
+                    title: t('attributes.dnd.tableCannotMoveTitle', 'Cannot move TABLE attribute'),
+                    description: t('attributes.dnd.tableCannotMoveDescription', 'TABLE attributes can only exist at the root level.'),
+                    confirmButtonName: tc('ok', 'OK'),
+                    hideCancelButton: true
+                })
+                return false
+            }
+
+            // Moving to an empty child table — attribute will become display + required
+            if (targetParentId !== null && targetContainerItemCount === 0) {
+                const shouldMove = await confirm({
+                    title: t('attributes.dnd.firstChildAttributeTitle', 'First child attribute'),
+                    description: t(
+                        'attributes.dnd.firstChildAttributeDescription',
+                        'This will be the first attribute in the table. It will automatically become the display attribute and required. After that, it cannot be moved out until another attribute is set as the display attribute.'
+                    ),
+                    confirmButtonName: t('attributes.dnd.confirmMove', 'Move'),
+                    cancelButtonName: tc('actions.cancel', 'Cancel')
+                })
+                if (!shouldMove) return false
+            }
+
+            return true
+        },
+        [confirm, t, tc]
+    )
 
     const localizedFormDefaults = useMemo<AttributeFormValues>(() => {
         const hasNoAttributes = (attributes?.length ?? 0) === 0
@@ -961,301 +1092,363 @@ const AttributeList = () => {
         }
     }
 
-    // Transform Attribute data for FlowListTable (which expects string name)
+    // Transform Attribute data for table display
     const getAttributeTableData = (attr: Attribute): AttributeDisplay => toAttributeDisplay(attr, i18n.language)
 
     return (
-        <ExistingCodenamesProvider entities={codenameEntities}>
-            <MainCard
-                sx={{ maxWidth: '100%', width: '100%' }}
-                contentSX={{ px: 0, py: 0 }}
-                disableContentPadding
-                disableHeader
-                border={false}
-                shadow={false}
-            >
-                {error ? (
-                    <EmptyListState
-                        image={APIEmptySVG}
-                        imageAlt='Connection error'
-                        title={t('errors.connectionFailed')}
-                        description={!hasResponseStatus(error) ? t('errors.checkConnection') : t('errors.pleaseTryLater')}
-                        action={{
-                            label: t('actions.retry'),
-                            onClick: () => paginationResult.actions.goToPage(1)
+        <AttributeDndContainerRegistryProvider>
+            <ExistingCodenamesProvider entities={codenameEntities}>
+                <MainCard
+                    sx={{ maxWidth: '100%', width: '100%' }}
+                    contentSX={{ px: 0, py: 0 }}
+                    disableContentPadding
+                    disableHeader
+                    border={false}
+                    shadow={false}
+                >
+                    {error ? (
+                        <EmptyListState
+                            image={APIEmptySVG}
+                            imageAlt='Connection error'
+                            title={t('errors.connectionFailed')}
+                            description={!hasResponseStatus(error) ? t('errors.checkConnection') : t('errors.pleaseTryLater')}
+                            action={{
+                                label: t('actions.retry'),
+                                onClick: () => paginationResult.actions.goToPage(1)
+                            }}
+                        />
+                    ) : (
+                        <Stack flexDirection='column' sx={{ gap: 1 }}>
+                            <ViewHeader
+                                search={true}
+                                searchPlaceholder={t('attributes.searchPlaceholder')}
+                                onSearchChange={handleSearchChange}
+                                title={t('attributes.title')}
+                            >
+                                <ToolbarControls
+                                    primaryAction={{
+                                        label: tc('create'),
+                                        onClick: handleAddNew,
+                                        startIcon: <AddRoundedIcon />,
+                                        disabled: limitReached
+                                    }}
+                                />
+                            </ViewHeader>
+
+                            <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}>
+                                <Tabs
+                                    value='attributes'
+                                    onChange={handleCatalogTabChange}
+                                    aria-label={t('catalogs.title', 'Catalogs')}
+                                    textColor='primary'
+                                    indicatorColor='primary'
+                                    sx={{
+                                        minHeight: 40,
+                                        '& .MuiTab-root': {
+                                            minHeight: 40,
+                                            textTransform: 'none'
+                                        }
+                                    }}
+                                >
+                                    <Tab value='attributes' label={t('attributes.title')} />
+                                    <Tab value='elements' label={t('elements.title')} />
+                                </Tabs>
+                            </Box>
+
+                            {limitReached && (
+                                <Alert
+                                    severity='info'
+                                    icon={<InfoIcon />}
+                                    sx={{
+                                        mx: { xs: -1.5, md: -2 },
+                                        mt: 0,
+                                        mb: 2
+                                    }}
+                                >
+                                    {t('attributes.limitReached', { limit: limitValue })}
+                                </Alert>
+                            )}
+
+                            {isLoading && attributes.length === 0 ? (
+                                <Skeleton variant='rectangular' height={120} />
+                            ) : !isLoading && attributes.length === 0 ? (
+                                <EmptyListState
+                                    image={APIEmptySVG}
+                                    imageAlt='No attributes'
+                                    title={t('attributes.empty')}
+                                    description={t('attributes.emptyDescription')}
+                                />
+                            ) : (
+                                <Box sx={{ mx: { xs: -1.5, md: -2 } }}>
+                                    <AttributeDndProvider
+                                        rootItems={attributes}
+                                        allowCrossListRootChildren={allowCrossListRootChildren}
+                                        allowCrossListBetweenChildren={allowCrossListBetweenChildren}
+                                        onReorder={handleReorder}
+                                        onValidateTransfer={handleValidateTransfer}
+                                        uiLocale={i18n.language}
+                                    >
+                                        <DndDropTarget containerId='root'>
+                                            {({ isDropTarget, pendingTransfer: pt, activeAttribute: activeAttr }) => {
+                                                // Compute effective data/IDs for ghost row rendering
+                                                const baseData = attributes.map(getAttributeTableData)
+                                                const baseIds = attributes.map((a) => a.id)
+                                                let effectiveData = baseData
+                                                let effectiveIds = baseIds
+
+                                                if (pt) {
+                                                    if (pt.fromContainerId === 'root') {
+                                                        // Source container: hide the dragged item
+                                                        effectiveData = baseData.filter((d) => d.id !== pt.itemId)
+                                                        effectiveIds = baseIds.filter((id) => id !== pt.itemId)
+                                                    } else if (pt.toContainerId === 'root' && activeAttr) {
+                                                        // Target container: inject ghost at insertion point
+                                                        const ghost = toAttributeDisplay(activeAttr, i18n.language)
+                                                        const insertAt = Math.min(pt.insertIndex, baseData.length)
+                                                        effectiveData = [...baseData.slice(0, insertAt), ghost, ...baseData.slice(insertAt)]
+                                                        effectiveIds = [
+                                                            ...baseIds.slice(0, insertAt),
+                                                            pt.itemId,
+                                                            ...baseIds.slice(insertAt)
+                                                        ]
+                                                    }
+                                                }
+
+                                                return (
+                                                    <FlowListTable<AttributeDisplay>
+                                                        data={effectiveData}
+                                                        customColumns={attributeColumns}
+                                                        sortableRows
+                                                        externalDndContext
+                                                        droppableContainerId='root'
+                                                        sortableItemIds={effectiveIds}
+                                                        dragHandleAriaLabel={t('attributes.dnd.dragHandle', 'Drag to reorder')}
+                                                        isDropTarget={isDropTarget}
+                                                        renderActions={(row: AttributeDisplay) => {
+                                                            const originalAttribute = attributes.find((a) => a.id === row.id)
+                                                            if (!originalAttribute) return null
+
+                                                            const descriptors: ActionDescriptor<
+                                                                AttributeDisplay,
+                                                                AttributeLocalizedPayload
+                                                            >[] = [...attributeActions]
+
+                                                            return (
+                                                                <Stack direction='row' spacing={0} alignItems='center'>
+                                                                    {row.dataType === 'TABLE' && (
+                                                                        <IconButton
+                                                                            size='small'
+                                                                            onClick={(e) => {
+                                                                                e.stopPropagation()
+                                                                                setExpandedTableIds((prev) => {
+                                                                                    const next = new Set(prev)
+                                                                                    if (next.has(row.id)) {
+                                                                                        next.delete(row.id)
+                                                                                    } else {
+                                                                                        next.add(row.id)
+                                                                                    }
+                                                                                    return next
+                                                                                })
+                                                                            }}
+                                                                            sx={{ width: 28, height: 28, p: 0.5 }}
+                                                                        >
+                                                                            {expandedTableIds.has(row.id) ? (
+                                                                                <KeyboardArrowUpIcon fontSize='small' />
+                                                                            ) : (
+                                                                                <KeyboardArrowDownIcon fontSize='small' />
+                                                                            )}
+                                                                        </IconButton>
+                                                                    )}
+                                                                    {descriptors.length > 0 && (
+                                                                        <BaseEntityMenu<AttributeDisplay, AttributeLocalizedPayload>
+                                                                            entity={toAttributeDisplay(originalAttribute, i18n.language)}
+                                                                            entityKind='attribute'
+                                                                            descriptors={descriptors}
+                                                                            namespace='metahubs'
+                                                                            menuButtonLabelKey='flowList:menu.button'
+                                                                            i18nInstance={i18n}
+                                                                            createContext={createAttributeContext}
+                                                                        />
+                                                                    )}
+                                                                </Stack>
+                                                            )
+                                                        }}
+                                                        renderRowExpansion={(row: AttributeDisplay) => {
+                                                            if (row.dataType !== 'TABLE') return null
+                                                            if (!expandedTableIds.has(row.id)) return null
+                                                            return (
+                                                                <Box sx={{ pl: 1, pr: 1, pb: 1 }}>
+                                                                    <Box
+                                                                        sx={{
+                                                                            borderTop: '1px dashed',
+                                                                            borderColor: 'divider',
+                                                                            mx: 2,
+                                                                            mb: 1
+                                                                        }}
+                                                                    />
+                                                                    <ChildAttributeList
+                                                                        metahubId={metahubId!}
+                                                                        hubId={effectiveHubId}
+                                                                        catalogId={catalogId!}
+                                                                        parentAttributeId={row.id}
+                                                                        searchFilter={
+                                                                            childSearchMatchParentIds.includes(row.id)
+                                                                                ? searchValue
+                                                                                : undefined
+                                                                        }
+                                                                        onRefresh={async () => {
+                                                                            if (metahubId && catalogId) {
+                                                                                invalidateAttributesQueries.allCodenames(
+                                                                                    queryClient,
+                                                                                    metahubId!,
+                                                                                    catalogId!
+                                                                                )
+                                                                            }
+                                                                            if (effectiveHubId) {
+                                                                                await invalidateAttributesQueries.all(
+                                                                                    queryClient,
+                                                                                    metahubId!,
+                                                                                    effectiveHubId,
+                                                                                    catalogId!
+                                                                                )
+                                                                            } else {
+                                                                                queryClient.invalidateQueries({
+                                                                                    queryKey: metahubsQueryKeys.attributesDirect(
+                                                                                        metahubId!,
+                                                                                        catalogId!
+                                                                                    )
+                                                                                })
+                                                                            }
+                                                                        }}
+                                                                    />
+                                                                </Box>
+                                                            )
+                                                        }}
+                                                    />
+                                                )
+                                            }}
+                                        </DndDropTarget>
+                                    </AttributeDndProvider>
+                                </Box>
+                            )}
+
+                            {/* Table Pagination at bottom */}
+                            {!isLoading && attributes.length > 0 && (
+                                <Box sx={{ mx: { xs: -1.5, md: -2 }, mt: 2 }}>
+                                    <PaginationControls
+                                        pagination={paginationResult.pagination}
+                                        actions={paginationResult.actions}
+                                        isLoading={paginationResult.isLoading}
+                                        rowsPerPageOptions={[10, 20, 50, 100]}
+                                        namespace='common'
+                                    />
+                                </Box>
+                            )}
+                        </Stack>
+                    )}
+
+                    <EntityFormDialog
+                        open={isDialogOpen}
+                        title={t('attributes.createDialog.title', 'Add Attribute')}
+                        nameLabel={tc('fields.name', 'Name')}
+                        descriptionLabel={tc('fields.description', 'Description')}
+                        saveButtonText={tc('actions.create', 'Create')}
+                        savingButtonText={tc('actions.creating', 'Creating...')}
+                        cancelButtonText={tc('actions.cancel', 'Cancel')}
+                        loading={isCreating}
+                        error={dialogError || undefined}
+                        onClose={handleDialogClose}
+                        onSave={handleCreateAttribute}
+                        hideDefaultFields
+                        initialExtraValues={localizedFormDefaults}
+                        tabs={renderTabs}
+                        validate={validateAttributeForm}
+                        canSave={canSaveAttributeForm}
+                    />
+
+                    {/* Independent ConfirmDeleteDialog */}
+                    <ConfirmDeleteDialog
+                        open={deleteDialogState.open}
+                        title={t('attributes.deleteDialog.title')}
+                        description={t('attributes.deleteDialog.message')}
+                        confirmButtonText={tc('actions.delete', 'Delete')}
+                        deletingButtonText={tc('actions.deleting', 'Deleting...')}
+                        cancelButtonText={tc('actions.cancel', 'Cancel')}
+                        onCancel={() => setDeleteDialogState({ open: false, attribute: null })}
+                        onConfirm={async () => {
+                            if (deleteDialogState.attribute) {
+                                const actualAttribute = attributeMap.get(deleteDialogState.attribute.id) ?? deleteDialogState.attribute
+                                if (actualAttribute?.isDisplayAttribute) {
+                                    enqueueSnackbar(
+                                        t(
+                                            'attributes.deleteDisplayAttributeBlocked',
+                                            'Нельзя удалить атрибут-представление. Сначала назначьте представлением другой атрибут.'
+                                        ),
+                                        { variant: 'warning' }
+                                    )
+                                    setDeleteDialogState({ open: false, attribute: null })
+                                    return
+                                }
+                                try {
+                                    await deleteAttributeMutation.mutateAsync({
+                                        metahubId,
+                                        hubId: effectiveHubId,
+                                        catalogId,
+                                        attributeId: deleteDialogState.attribute.id
+                                    })
+                                    setDeleteDialogState({ open: false, attribute: null })
+                                } catch (err: unknown) {
+                                    const responseMessage = extractResponseMessage(err)
+                                    const message =
+                                        typeof responseMessage === 'string'
+                                            ? responseMessage
+                                            : err instanceof Error
+                                            ? err.message
+                                            : typeof err === 'string'
+                                            ? err
+                                            : t('attributes.deleteError')
+                                    enqueueSnackbar(message, { variant: 'error' })
+                                    setDeleteDialogState({ open: false, attribute: null })
+                                }
+                            }
                         }}
                     />
-                ) : (
-                    <Stack flexDirection='column' sx={{ gap: 1 }}>
-                        <ViewHeader
-                            search={true}
-                            searchPlaceholder={t('attributes.searchPlaceholder')}
-                            onSearchChange={handleSearchChange}
-                            title={t('attributes.title')}
-                        >
-                            <ToolbarControls
-                                primaryAction={{
-                                    label: tc('create'),
-                                    onClick: handleAddNew,
-                                    startIcon: <AddRoundedIcon />,
-                                    disabled: limitReached
-                                }}
-                            />
-                        </ViewHeader>
 
-                        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}>
-                            <Tabs
-                                value='attributes'
-                                onChange={handleCatalogTabChange}
-                                aria-label={t('catalogs.title', 'Catalogs')}
-                                textColor='primary'
-                                indicatorColor='primary'
-                                sx={{
-                                    minHeight: 40,
-                                    '& .MuiTab-root': {
-                                        minHeight: 40,
-                                        textTransform: 'none'
-                                    }
-                                }}
-                            >
-                                <Tab value='attributes' label={t('attributes.title')} />
-                                <Tab value='elements' label={t('elements.title')} />
-                            </Tabs>
-                        </Box>
+                    <ConfirmDialog />
 
-                        {limitReached && (
-                            <Alert
-                                severity='info'
-                                icon={<InfoIcon />}
-                                sx={{
-                                    mx: { xs: -1.5, md: -2 },
-                                    mt: 0,
-                                    mb: 2
-                                }}
-                            >
-                                {t('attributes.limitReached', { limit: limitValue })}
-                            </Alert>
-                        )}
-
-                        {isLoading && attributes.length === 0 ? (
-                            <Skeleton variant='rectangular' height={120} />
-                        ) : !isLoading && attributes.length === 0 ? (
-                            <EmptyListState
-                                image={APIEmptySVG}
-                                imageAlt='No attributes'
-                                title={t('attributes.empty')}
-                                description={t('attributes.emptyDescription')}
-                            />
-                        ) : (
-                            <Box sx={{ mx: { xs: -1.5, md: -2 } }}>
-                                <FlowListTable
-                                    data={attributes.map(getAttributeTableData)}
-                                    images={images}
-                                    isLoading={isLoading}
-                                    customColumns={attributeColumns}
-                                    i18nNamespace='flowList'
-                                    renderActions={(row: AttributeDisplay) => {
-                                        const originalAttribute = attributes.find((a) => a.id === row.id)
-                                        if (!originalAttribute) return null
-
-                                        const descriptors: ActionDescriptor<AttributeDisplay, AttributeLocalizedPayload>[] = [
-                                            ...attributeActions
-                                        ]
-
-                                        return (
-                                            <Stack direction='row' spacing={0} alignItems='center'>
-                                                {row.dataType === 'TABLE' && (
-                                                    <IconButton
-                                                        size='small'
-                                                        onClick={(e) => {
-                                                            e.stopPropagation()
-                                                            setExpandedTableIds((prev) => {
-                                                                const next = new Set(prev)
-                                                                if (next.has(row.id)) {
-                                                                    next.delete(row.id)
-                                                                } else {
-                                                                    next.add(row.id)
-                                                                }
-                                                                return next
-                                                            })
-                                                        }}
-                                                        sx={{ width: 28, height: 28, p: 0.5 }}
-                                                    >
-                                                        {expandedTableIds.has(row.id) ? (
-                                                            <KeyboardArrowUpIcon fontSize='small' />
-                                                        ) : (
-                                                            <KeyboardArrowDownIcon fontSize='small' />
-                                                        )}
-                                                    </IconButton>
-                                                )}
-                                                {descriptors.length > 0 && (
-                                                    <BaseEntityMenu<AttributeDisplay, AttributeLocalizedPayload>
-                                                        entity={toAttributeDisplay(originalAttribute, i18n.language)}
-                                                        entityKind='attribute'
-                                                        descriptors={descriptors}
-                                                        namespace='metahubs'
-                                                        menuButtonLabelKey='flowList:menu.button'
-                                                        i18nInstance={i18n}
-                                                        createContext={createAttributeContext}
-                                                    />
-                                                )}
-                                            </Stack>
-                                        )
-                                    }}
-                                    renderRowExpansion={(row: AttributeDisplay) => {
-                                        if (row.dataType !== 'TABLE') return null
-                                        if (!expandedTableIds.has(row.id)) return null
-                                        return (
-                                            <Box sx={{ pl: 1, pr: 1, pb: 1 }}>
-                                                <Box sx={{ borderTop: '1px dashed', borderColor: 'divider', mx: 2, mb: 1 }} />
-                                                <ChildAttributeList
-                                                    metahubId={metahubId!}
-                                                    hubId={effectiveHubId}
-                                                    catalogId={catalogId!}
-                                                    parentAttributeId={row.id}
-                                                    searchFilter={childSearchMatchParentIds.includes(row.id) ? searchValue : undefined}
-                                                    onRefresh={async () => {
-                                                        // Invalidate global codenames cache (for global scope duplicate checking)
-                                                        if (metahubId && catalogId) {
-                                                            invalidateAttributesQueries.allCodenames(queryClient, metahubId!, catalogId!)
-                                                        }
-                                                        if (effectiveHubId) {
-                                                            await invalidateAttributesQueries.all(
-                                                                queryClient,
-                                                                metahubId!,
-                                                                effectiveHubId,
-                                                                catalogId!
-                                                            )
-                                                        } else {
-                                                            queryClient.invalidateQueries({
-                                                                queryKey: metahubsQueryKeys.attributesDirect(metahubId!, catalogId!)
-                                                            })
-                                                        }
-                                                    }}
-                                                />
-                                            </Box>
-                                        )
-                                    }}
-                                />
-                            </Box>
-                        )}
-
-                        {/* Table Pagination at bottom */}
-                        {!isLoading && attributes.length > 0 && (
-                            <Box sx={{ mx: { xs: -1.5, md: -2 }, mt: 2 }}>
-                                <PaginationControls
-                                    pagination={paginationResult.pagination}
-                                    actions={paginationResult.actions}
-                                    isLoading={paginationResult.isLoading}
-                                    rowsPerPageOptions={[10, 20, 50, 100]}
-                                    namespace='common'
-                                />
-                            </Box>
-                        )}
-                    </Stack>
-                )}
-
-                <EntityFormDialog
-                    open={isDialogOpen}
-                    title={t('attributes.createDialog.title', 'Add Attribute')}
-                    nameLabel={tc('fields.name', 'Name')}
-                    descriptionLabel={tc('fields.description', 'Description')}
-                    saveButtonText={tc('actions.create', 'Create')}
-                    savingButtonText={tc('actions.creating', 'Creating...')}
-                    cancelButtonText={tc('actions.cancel', 'Cancel')}
-                    loading={isCreating}
-                    error={dialogError || undefined}
-                    onClose={handleDialogClose}
-                    onSave={handleCreateAttribute}
-                    hideDefaultFields
-                    initialExtraValues={localizedFormDefaults}
-                    tabs={renderTabs}
-                    validate={validateAttributeForm}
-                    canSave={canSaveAttributeForm}
-                />
-
-                {/* Independent ConfirmDeleteDialog */}
-                <ConfirmDeleteDialog
-                    open={deleteDialogState.open}
-                    title={t('attributes.deleteDialog.title')}
-                    description={t('attributes.deleteDialog.message')}
-                    confirmButtonText={tc('actions.delete', 'Delete')}
-                    deletingButtonText={tc('actions.deleting', 'Deleting...')}
-                    cancelButtonText={tc('actions.cancel', 'Cancel')}
-                    onCancel={() => setDeleteDialogState({ open: false, attribute: null })}
-                    onConfirm={async () => {
-                        if (deleteDialogState.attribute) {
-                            const actualAttribute = attributeMap.get(deleteDialogState.attribute.id) ?? deleteDialogState.attribute
-                            if (actualAttribute?.isDisplayAttribute) {
-                                enqueueSnackbar(
-                                    t(
-                                        'attributes.deleteDisplayAttributeBlocked',
-                                        'Нельзя удалить атрибут-представление. Сначала назначьте представлением другой атрибут.'
-                                    ),
-                                    { variant: 'warning' }
-                                )
-                                setDeleteDialogState({ open: false, attribute: null })
-                                return
+                    <ConflictResolutionDialog
+                        open={conflictState.open}
+                        conflict={conflictState.conflict}
+                        onCancel={() => {
+                            setConflictState({ open: false, conflict: null, pendingUpdate: null })
+                            if (metahubId && catalogId) {
+                                // Invalidate global codenames cache (for global scope duplicate checking)
+                                invalidateAttributesQueries.allCodenames(queryClient, metahubId, catalogId)
+                                if (effectiveHubId) {
+                                    invalidateAttributesQueries.all(queryClient, metahubId, effectiveHubId, catalogId)
+                                } else {
+                                    queryClient.invalidateQueries({ queryKey: metahubsQueryKeys.attributesDirect(metahubId, catalogId) })
+                                }
                             }
-                            try {
-                                await deleteAttributeMutation.mutateAsync({
+                        }}
+                        onOverwrite={async () => {
+                            if (conflictState.pendingUpdate && metahubId && catalogId) {
+                                const { id, patch } = conflictState.pendingUpdate
+                                await updateAttributeMutation.mutateAsync({
                                     metahubId,
                                     hubId: effectiveHubId,
                                     catalogId,
-                                    attributeId: deleteDialogState.attribute.id
+                                    attributeId: id,
+                                    data: patch
                                 })
-                                setDeleteDialogState({ open: false, attribute: null })
-                            } catch (err: unknown) {
-                                const responseMessage = extractResponseMessage(err)
-                                const message =
-                                    typeof responseMessage === 'string'
-                                        ? responseMessage
-                                        : err instanceof Error
-                                        ? err.message
-                                        : typeof err === 'string'
-                                        ? err
-                                        : t('attributes.deleteError')
-                                enqueueSnackbar(message, { variant: 'error' })
-                                setDeleteDialogState({ open: false, attribute: null })
+                                setConflictState({ open: false, conflict: null, pendingUpdate: null })
                             }
-                        }
-                    }}
-                />
-
-                <ConfirmDialog />
-
-                <ConflictResolutionDialog
-                    open={conflictState.open}
-                    conflict={conflictState.conflict}
-                    onCancel={() => {
-                        setConflictState({ open: false, conflict: null, pendingUpdate: null })
-                        if (metahubId && catalogId) {
-                            // Invalidate global codenames cache (for global scope duplicate checking)
-                            invalidateAttributesQueries.allCodenames(queryClient, metahubId, catalogId)
-                            if (effectiveHubId) {
-                                invalidateAttributesQueries.all(queryClient, metahubId, effectiveHubId, catalogId)
-                            } else {
-                                queryClient.invalidateQueries({ queryKey: metahubsQueryKeys.attributesDirect(metahubId, catalogId) })
-                            }
-                        }
-                    }}
-                    onOverwrite={async () => {
-                        if (conflictState.pendingUpdate && metahubId && catalogId) {
-                            const { id, patch } = conflictState.pendingUpdate
-                            await updateAttributeMutation.mutateAsync({
-                                metahubId,
-                                hubId: effectiveHubId,
-                                catalogId,
-                                attributeId: id,
-                                data: patch
-                            })
-                            setConflictState({ open: false, conflict: null, pendingUpdate: null })
-                        }
-                    }}
-                    isLoading={updateAttributeMutation.isPending}
-                />
-            </MainCard>
-        </ExistingCodenamesProvider>
+                        }}
+                        isLoading={updateAttributeMutation.isPending}
+                    />
+                </MainCard>
+            </ExistingCodenamesProvider>
+        </AttributeDndContainerRegistryProvider>
     )
 }
 

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/ChildAttributeList.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/ChildAttributeList.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useDroppable } from '@dnd-kit/core'
 import { Box, Stack, Typography, Chip, Skeleton, Alert, Tooltip, Button } from '@mui/material'
 import AddRoundedIcon from '@mui/icons-material/AddRounded'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -15,7 +16,7 @@ import { useCommonTranslations } from '@universo/i18n'
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
 import { useSnackbar } from 'notistack'
 import { EntityFormDialog, ConfirmDeleteDialog, type TabConfig } from '@universo/template-mui/components/dialogs'
-import { FlowListTable, BaseEntityMenu, notifyError } from '@universo/template-mui'
+import { BaseEntityMenu, notifyError, FlowListTable } from '@universo/template-mui'
 import type { ActionDescriptor, ActionContext } from '@universo/template-mui'
 import type { VersionedLocalizedContent, MetaEntityKind } from '@universo/types'
 import { TABLE_CHILD_DATA_TYPES } from '@universo/types'
@@ -45,6 +46,7 @@ import {
     useClearDisplayAttribute
 } from '../hooks/mutations'
 import AttributeFormFields, { PresentationTabFields } from './AttributeFormFields'
+import { useContainerRegistry, useAttributeDndState } from './dnd'
 import { ExistingCodenamesProvider } from '../../../components'
 
 type GenericFormValues = Record<string, unknown>
@@ -53,6 +55,43 @@ type ChildAttributeContextExtras = {
     moveAttribute?: (id: string, direction: 'up' | 'down') => Promise<void>
     toggleRequired?: (id: string, value: boolean) => Promise<void>
     toggleDisplayAttribute?: (id: string, value: boolean) => Promise<void>
+}
+
+interface EmptyDroppableChildAreaProps {
+    containerId: string
+    isDropTarget: boolean
+    message: string
+}
+
+/**
+ * Droppable placeholder shown when a child attribute list has no items.
+ * Uses @dnd-kit useDroppable so the area can receive cross-list transfers.
+ */
+// eslint-disable-next-line react/prop-types
+const EmptyDroppableChildArea: React.FC<EmptyDroppableChildAreaProps> = ({ containerId, isDropTarget, message }) => {
+    const { setNodeRef } = useDroppable({ id: containerId })
+    return (
+        <Box
+            ref={setNodeRef}
+            sx={{
+                py: 2,
+                textAlign: 'center',
+                border: 1,
+                borderRadius: 1,
+                borderColor: isDropTarget ? 'primary.main' : 'divider',
+                borderStyle: 'dashed',
+                ...(isDropTarget && {
+                    borderWidth: 2,
+                    backgroundColor: 'action.hover',
+                    transition: 'border-color 0.2s, background-color 0.2s'
+                })
+            }}
+        >
+            <Typography variant='body2' color='text.secondary'>
+                {message}
+            </Typography>
+        </Box>
+    )
 }
 
 const extractResponseMessage = (error: unknown): string | undefined => {
@@ -273,6 +312,20 @@ const ChildAttributeList = ({ metahubId, hubId, catalogId, parentAttributeId, se
         return map
     }, [childAttributes])
 
+    // DnD: Register this child list as a droppable container
+    const containerId = `child-${parentAttributeId}`
+    const { register, unregister } = useContainerRegistry()
+    const { activeContainerId, overContainerId, pendingTransfer, activeAttribute: dndActiveAttr } = useAttributeDndState()
+    const isDropTarget = overContainerId === containerId && activeContainerId !== null && activeContainerId !== containerId
+    useEffect(() => {
+        register({
+            id: containerId,
+            parentAttributeId,
+            items: childAttributes
+        })
+        return () => unregister(containerId)
+    }, [containerId, parentAttributeId, childAttributes, register, unregister])
+
     /** Invalidate both child-specific and parent-level queries */
     const invalidateChildQueries = useCallback(async () => {
         queryClient.invalidateQueries({ queryKey })
@@ -433,14 +486,6 @@ const ChildAttributeList = ({ metahubId, hubId, catalogId, parentAttributeId, se
         ],
         [t, tc, childAttributeMap]
     )
-
-    const images = useMemo(() => {
-        const map: Record<string, unknown[]> = {}
-        childAttributes.forEach((attr) => {
-            if (attr?.id) map[attr.id] = []
-        })
-        return map
-    }, [childAttributes])
 
     /** Action descriptors for child attribute context menu */
     const childActionDescriptors: ActionDescriptor<AttributeDisplay, AttributeLocalizedPayload>[] = useMemo(
@@ -1103,28 +1148,31 @@ const ChildAttributeList = ({ metahubId, hubId, catalogId, parentAttributeId, se
         }
     }, [codenameConfig.alphabet, codenameConfig.style, copyState.attribute, i18n.language])
 
-    const tableData = useMemo(() => {
-        let filtered = childAttributes
-        if (searchFilter) {
-            const lowerSearch = searchFilter.toLowerCase()
-            filtered = childAttributes.filter((attr) => {
-                if (attr.codename.toLowerCase().includes(lowerSearch)) return true
-                const name = attr.name
-                if (!name) return false
-                if (typeof name === 'string') return name.toLowerCase().includes(lowerSearch)
-                if (typeof name === 'object' && 'locales' in name) {
-                    const locales = (name as { locales?: Record<string, { content?: string }> }).locales ?? {}
-                    return Object.values(locales).some((entry) =>
-                        String(entry?.content ?? '')
-                            .toLowerCase()
-                            .includes(lowerSearch)
-                    )
-                }
-                return false
-            })
-        }
-        return filtered.map((attr) => toAttributeDisplay(attr, i18n.language))
-    }, [childAttributes, i18n.language, searchFilter])
+    // Filtered child attributes (for search) and their display representations
+    const filteredChildAttributes = useMemo(() => {
+        if (!searchFilter) return childAttributes
+        const lowerSearch = searchFilter.toLowerCase()
+        return childAttributes.filter((attr) => {
+            if (attr.codename.toLowerCase().includes(lowerSearch)) return true
+            const name = attr.name
+            if (!name) return false
+            if (typeof name === 'string') return name.toLowerCase().includes(lowerSearch)
+            if (typeof name === 'object' && 'locales' in name) {
+                const locales = (name as { locales?: Record<string, { content?: string }> }).locales ?? {}
+                return Object.values(locales).some((entry) =>
+                    String(entry?.content ?? '')
+                        .toLowerCase()
+                        .includes(lowerSearch)
+                )
+            }
+            return false
+        })
+    }, [childAttributes, searchFilter])
+
+    const tableData = useMemo(
+        () => filteredChildAttributes.map((attr) => toAttributeDisplay(attr, i18n.language)),
+        [filteredChildAttributes, i18n.language]
+    )
 
     if (error) {
         return (
@@ -1154,34 +1202,69 @@ const ChildAttributeList = ({ metahubId, hubId, catalogId, parentAttributeId, se
 
                 {isLoading ? (
                     <Skeleton variant='rectangular' height={60} />
-                ) : childAttributes.length === 0 ? (
-                    <Typography variant='body2' color='text.secondary' sx={{ py: 1, textAlign: 'center' }}>
-                        {t('attributes.noChildAttributes', 'No child attributes yet')}
-                    </Typography>
                 ) : (
-                    <FlowListTable
-                        data={tableData}
-                        images={images}
-                        isLoading={isLoading}
-                        customColumns={childColumns}
-                        i18nNamespace='flowList'
-                        compact
-                        renderActions={(row: AttributeDisplay) => {
-                            const originalAttribute = childAttributes.find((a) => a.id === row.id)
-                            if (!originalAttribute) return null
+                    (() => {
+                        // Compute effective data/IDs for ghost row rendering during cross-list drag
+                        const baseData = tableData
+                        const baseIds = filteredChildAttributes.map((a) => a.id)
+                        let effectiveData = baseData
+                        let effectiveIds = baseIds
+
+                        if (pendingTransfer) {
+                            if (pendingTransfer.fromContainerId === containerId) {
+                                // Source container: hide the dragged item
+                                effectiveData = baseData.filter((d) => d.id !== pendingTransfer.itemId)
+                                effectiveIds = baseIds.filter((id) => id !== pendingTransfer.itemId)
+                            } else if (pendingTransfer.toContainerId === containerId && dndActiveAttr) {
+                                // Target container: inject ghost at insertion point
+                                const ghost = toAttributeDisplay(dndActiveAttr, i18n.language)
+                                const insertAt = Math.min(pendingTransfer.insertIndex, baseData.length)
+                                effectiveData = [...baseData.slice(0, insertAt), ghost, ...baseData.slice(insertAt)]
+                                effectiveIds = [...baseIds.slice(0, insertAt), pendingTransfer.itemId, ...baseIds.slice(insertAt)]
+                            }
+                        }
+
+                        // When there are no child attributes and no ghost row to show,
+                        // render a droppable empty placeholder
+                        if (effectiveData.length === 0) {
                             return (
-                                <BaseEntityMenu<AttributeDisplay, AttributeLocalizedPayload>
-                                    entity={toAttributeDisplay(originalAttribute, i18n.language)}
-                                    entityKind='child-attribute'
-                                    descriptors={childActionDescriptors}
-                                    namespace='metahubs'
-                                    menuButtonLabelKey='flowList:menu.button'
-                                    i18nInstance={i18n}
-                                    createContext={createChildAttributeContext}
+                                <EmptyDroppableChildArea
+                                    containerId={containerId}
+                                    isDropTarget={isDropTarget}
+                                    message={t('attributes.noChildAttributes', 'No child attributes yet')}
                                 />
                             )
-                        }}
-                    />
+                        }
+
+                        return (
+                            <FlowListTable<AttributeDisplay>
+                                data={effectiveData}
+                                customColumns={childColumns}
+                                compact
+                                sortableRows
+                                externalDndContext
+                                droppableContainerId={containerId}
+                                sortableItemIds={effectiveIds}
+                                dragHandleAriaLabel={t('attributes.dnd.dragHandle', 'Drag to reorder')}
+                                isDropTarget={isDropTarget}
+                                renderActions={(row: AttributeDisplay) => {
+                                    const originalAttribute = childAttributes.find((a) => a.id === row.id)
+                                    if (!originalAttribute) return null
+                                    return (
+                                        <BaseEntityMenu<AttributeDisplay, AttributeLocalizedPayload>
+                                            entity={toAttributeDisplay(originalAttribute, i18n.language)}
+                                            entityKind='child-attribute'
+                                            descriptors={childActionDescriptors}
+                                            namespace='metahubs'
+                                            menuButtonLabelKey='flowList:menu.button'
+                                            i18nInstance={i18n}
+                                            createContext={createChildAttributeContext}
+                                        />
+                                    )
+                                }}
+                            />
+                        )
+                    })()
                 )}
 
                 <EntityFormDialog
@@ -1219,7 +1302,16 @@ const ChildAttributeList = ({ metahubId, hubId, catalogId, parentAttributeId, se
                     onSave={handleUpdate}
                     hideDefaultFields
                     initialExtraValues={editInitialValues}
-                    tabs={(args) => buildTabs(args, true, true, true, undefined, editState.attribute?.id ?? null)}
+                    tabs={(args) =>
+                        buildTabs(
+                            args,
+                            true,
+                            true,
+                            true,
+                            editState.attribute?.isDisplayAttribute ? true : undefined,
+                            editState.attribute?.id ?? null
+                        )
+                    }
                     validate={validate}
                     canSave={canSave}
                     showDeleteButton

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/AttributeDndContainerRegistry.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/AttributeDndContainerRegistry.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useCallback, useContext, useState } from 'react'
+import type { Attribute } from '../../../../types'
+
+export interface ContainerEntry {
+    id: string
+    parentAttributeId: string | null
+    items: Attribute[]
+}
+
+interface ContainerRegistryValue {
+    containers: ContainerEntry[]
+    register: (entry: ContainerEntry) => void
+    unregister: (id: string) => void
+}
+
+const AttributeDndContainerRegistryContext = createContext<ContainerRegistryValue | null>(null)
+
+export const AttributeDndContainerRegistryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [containers, setContainers] = useState<ContainerEntry[]>([])
+
+    const register = useCallback((entry: ContainerEntry) => {
+        setContainers((prev) => {
+            const filtered = prev.filter((c) => c.id !== entry.id)
+            return [...filtered, entry]
+        })
+    }, [])
+
+    const unregister = useCallback((id: string) => {
+        setContainers((prev) => prev.filter((c) => c.id !== id))
+    }, [])
+
+    return (
+        <AttributeDndContainerRegistryContext.Provider value={{ containers, register, unregister }}>
+            {children}
+        </AttributeDndContainerRegistryContext.Provider>
+    )
+}
+
+export function useContainerRegistry() {
+    const ctx = useContext(AttributeDndContainerRegistryContext)
+    if (!ctx) throw new Error('useContainerRegistry must be inside AttributeDndContainerRegistryProvider')
+    return ctx
+}
+
+export function useRegisteredContainers(): ContainerEntry[] {
+    const { containers } = useContainerRegistry()
+    return containers
+}

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/AttributeDndProvider.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/AttributeDndProvider.tsx
@@ -1,0 +1,141 @@
+import React, { createContext, useContext, useMemo } from 'react'
+import {
+    DndContext,
+    DragOverlay,
+    PointerSensor,
+    KeyboardSensor,
+    useSensors,
+    useSensor,
+    closestCenter,
+    MeasuringStrategy
+} from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { useAttributeDnd } from './useAttributeDnd'
+import type { ContainerInfo, PendingTransfer } from './useAttributeDnd'
+import { DragOverlayRow } from './DragOverlayRow'
+import { useRegisteredContainers } from './AttributeDndContainerRegistry'
+import type { Attribute } from '../../../../types'
+import { toAttributeDisplay } from '../../../../types'
+
+// ── DnD state context (for cross-list visual feedback) ──────────────────────
+
+interface AttributeDndState {
+    /** ID of the currently dragged item */
+    activeId: string | null
+    /** Container ID the dragged item belongs to */
+    activeContainerId: string | null
+    /** Container ID the item is currently being dragged over (cross-list only, null for same-list) */
+    overContainerId: string | null
+    /** Virtual cross-list transfer describing source, target, and insertion point (for ghost row) */
+    pendingTransfer: PendingTransfer | null
+    /** The full Attribute object being dragged (for ghost row data) */
+    activeAttribute: Attribute | undefined
+}
+
+const AttributeDndStateContext = createContext<AttributeDndState>({
+    activeId: null,
+    activeContainerId: null,
+    overContainerId: null,
+    pendingTransfer: null,
+    activeAttribute: undefined
+})
+
+/**
+ * Hook to access the current DnD state (activeId, activeContainerId, overContainerId).
+ * Use this in FlowListTable consumers to compute `isDropTarget`.
+ */
+export function useAttributeDndState(): AttributeDndState {
+    return useContext(AttributeDndStateContext)
+}
+
+interface AttributeDndProviderProps {
+    children: React.ReactNode
+    /** Root-level attribute items (always present) */
+    rootItems: Attribute[]
+    allowCrossListRootChildren: boolean
+    allowCrossListBetweenChildren: boolean
+    onReorder: (
+        attributeId: string,
+        newSortOrder: number,
+        newParentAttributeId?: string | null,
+        currentParentAttributeId?: string | null
+    ) => Promise<void>
+    onValidateTransfer?: (attribute: Attribute, targetParentId: string | null, targetContainerItemCount: number) => Promise<boolean>
+    uiLocale: string
+}
+
+export const AttributeDndProvider: React.FC<AttributeDndProviderProps> = ({
+    children,
+    rootItems,
+    allowCrossListRootChildren,
+    allowCrossListBetweenChildren,
+    onReorder,
+    onValidateTransfer,
+    uiLocale
+}) => {
+    // Build combined container list: root + registered child containers
+    const registeredChildContainers = useRegisteredContainers()
+    const containers = useMemo<ContainerInfo[]>(() => {
+        const rootContainer: ContainerInfo = {
+            id: 'root',
+            parentAttributeId: null,
+            items: rootItems
+        }
+        return [rootContainer, ...registeredChildContainers]
+    }, [rootItems, registeredChildContainers])
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 8 } // Prevent accidental drags
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates
+        })
+    )
+
+    const {
+        activeId,
+        activeAttribute,
+        activeContainerId,
+        overContainerId,
+        pendingTransfer,
+        handleDragStart,
+        handleDragOver,
+        handleDragEnd,
+        handleDragCancel
+    } = useAttributeDnd({
+        containers,
+        allowCrossListRootChildren,
+        allowCrossListBetweenChildren,
+        onReorder,
+        onValidateTransfer
+    })
+
+    const dndState = useMemo<AttributeDndState>(
+        () => ({ activeId, activeContainerId, overContainerId, pendingTransfer, activeAttribute }),
+        [activeId, activeContainerId, overContainerId, pendingTransfer, activeAttribute]
+    )
+
+    return (
+        <AttributeDndStateContext.Provider value={dndState}>
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragStart={handleDragStart}
+                onDragOver={handleDragOver}
+                onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
+                // Prevent validateDOMNesting warnings for <div> inside <table>
+                accessibility={{ container: document.body }}
+                measuring={{
+                    droppable: { strategy: MeasuringStrategy.Always }
+                }}
+            >
+                {children}
+                <DragOverlay dropAnimation={null}>
+                    {activeAttribute ? <DragOverlayRow attribute={toAttributeDisplay(activeAttribute, uiLocale)} /> : null}
+                </DragOverlay>
+            </DndContext>
+        </AttributeDndStateContext.Provider>
+    )
+}

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/DragOverlayRow.tsx
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/DragOverlayRow.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Paper, Typography, Chip, Stack } from '@mui/material'
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
+import type { AttributeDisplay } from '../../../../types'
+
+interface DragOverlayRowProps {
+    attribute: AttributeDisplay
+}
+
+export const DragOverlayRow: React.FC<DragOverlayRowProps> = ({ attribute }) => {
+    return (
+        <Paper
+            elevation={8}
+            sx={{
+                p: 1.5,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                minWidth: 300,
+                maxWidth: 500,
+                borderLeft: '3px solid',
+                borderColor: 'primary.main',
+                opacity: 0.95
+            }}
+        >
+            <DragIndicatorIcon fontSize='small' sx={{ color: 'primary.main' }} />
+            <Stack direction='row' alignItems='center' spacing={1} sx={{ flex: 1, overflow: 'hidden' }}>
+                <Typography variant='body2' fontWeight={500} noWrap>
+                    {attribute.name || attribute.codename}
+                </Typography>
+                <Chip label={attribute.dataType} size='small' sx={{ ml: 'auto' }} />
+            </Stack>
+        </Paper>
+    )
+}

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/index.ts
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/index.ts
@@ -1,0 +1,6 @@
+export { DragOverlayRow } from './DragOverlayRow'
+export { useAttributeDnd } from './useAttributeDnd'
+export type { ContainerInfo, PendingTransfer } from './useAttributeDnd'
+export { AttributeDndProvider, useAttributeDndState } from './AttributeDndProvider'
+export { AttributeDndContainerRegistryProvider, useContainerRegistry, useRegisteredContainers } from './AttributeDndContainerRegistry'
+export type { ContainerEntry } from './AttributeDndContainerRegistry'

--- a/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/useAttributeDnd.ts
+++ b/packages/metahubs-frontend/base/src/domains/attributes/ui/dnd/useAttributeDnd.ts
@@ -1,0 +1,274 @@
+import { useState, useCallback, useRef } from 'react'
+import type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core'
+import type { Attribute } from '../../../../types'
+
+export interface ContainerInfo {
+    id: string // 'root' | `child-${parentId}`
+    parentAttributeId: string | null
+    items: Attribute[]
+}
+
+/** Describes a virtual cross-list item transfer (used for ghost row rendering). */
+export interface PendingTransfer {
+    itemId: string
+    fromContainerId: string
+    toContainerId: string
+    /** Insertion index within the ORIGINAL target items array */
+    insertIndex: number
+}
+
+interface UseAttributeDndOptions {
+    containers: ContainerInfo[]
+    allowCrossListRootChildren: boolean
+    allowCrossListBetweenChildren: boolean
+    onReorder: (
+        attributeId: string,
+        newSortOrder: number,
+        newParentAttributeId?: string | null,
+        currentParentAttributeId?: string | null
+    ) => Promise<void>
+    onValidateTransfer?: (attribute: Attribute, targetParentId: string | null, targetContainerItemCount: number) => Promise<boolean>
+}
+
+export function useAttributeDnd({
+    containers,
+    allowCrossListRootChildren,
+    allowCrossListBetweenChildren,
+    onReorder,
+    onValidateTransfer
+}: UseAttributeDndOptions) {
+    const [activeId, setActiveId] = useState<string | null>(null)
+    const [overId, setOverId] = useState<string | null>(null)
+    /** Container ID the active (dragged) item belongs to */
+    const [activeContainerId, setActiveContainerId] = useState<string | null>(null)
+    /** Container ID the item is currently being dragged over (cross-list only) */
+    const [overContainerId, setOverContainerId] = useState<string | null>(null)
+    /** Virtual cross-list transfer for ghost row rendering */
+    const [pendingTransfer, setPendingTransfer] = useState<PendingTransfer | null>(null)
+
+    // Ref to avoid stale closure reads in handleDragOver
+    const pendingTransferRef = useRef<PendingTransfer | null>(null)
+
+    const findContainer = useCallback(
+        (itemId: string): ContainerInfo | undefined => {
+            return containers.find((c) => c.items.some((item) => item.id === itemId))
+        },
+        [containers]
+    )
+
+    const findAttribute = useCallback(
+        (itemId: string): Attribute | undefined => {
+            for (const c of containers) {
+                const found = c.items.find((item) => item.id === itemId)
+                if (found) return found
+            }
+            return undefined
+        },
+        [containers]
+    )
+
+    const isCrossListAllowed = useCallback(
+        (sourceContainer: ContainerInfo, targetContainer: ContainerInfo): boolean => {
+            if (sourceContainer.id === targetContainer.id) return true
+
+            const sourceIsRoot = sourceContainer.parentAttributeId === null
+            const targetIsRoot = targetContainer.parentAttributeId === null
+
+            if (sourceIsRoot || targetIsRoot) {
+                return allowCrossListRootChildren
+            }
+            return allowCrossListBetweenChildren
+        },
+        [allowCrossListRootChildren, allowCrossListBetweenChildren]
+    )
+
+    const handleDragStart = useCallback(
+        (event: DragStartEvent) => {
+            const id = String(event.active.id)
+            setActiveId(id)
+            const container = findContainer(id)
+            setActiveContainerId(container?.id ?? null)
+        },
+        [findContainer]
+    )
+
+    const handleDragOver = useCallback(
+        (event: DragOverEvent) => {
+            const { active, over } = event
+            if (!over) {
+                setOverContainerId(null)
+                if (pendingTransferRef.current) {
+                    pendingTransferRef.current = null
+                    setPendingTransfer(null)
+                }
+                return
+            }
+
+            // Guard: if hovering over the ghost of the dragged item itself, preserve current pending transfer
+            if (String(over.id) === String(active.id) && pendingTransferRef.current) {
+                return
+            }
+
+            const activeContainer = findContainer(String(active.id))
+            const overContainer = findContainer(String(over.id)) || containers.find((c) => c.id === String(over.id))
+
+            if (!activeContainer || !overContainer) {
+                setOverContainerId(null)
+                if (pendingTransferRef.current) {
+                    pendingTransferRef.current = null
+                    setPendingTransfer(null)
+                }
+                return
+            }
+
+            if (activeContainer.id === overContainer.id) {
+                // Same container — no cross-list highlight, clear pending transfer
+                setOverContainerId(null)
+                if (pendingTransferRef.current) {
+                    pendingTransferRef.current = null
+                    setPendingTransfer(null)
+                }
+                return
+            }
+
+            if (!isCrossListAllowed(activeContainer, overContainer)) {
+                setOverContainerId(null)
+                if (pendingTransferRef.current) {
+                    pendingTransferRef.current = null
+                    setPendingTransfer(null)
+                }
+                return
+            }
+
+            setOverId(String(over.id))
+            setOverContainerId(overContainer.id)
+
+            // Compute insertion index in the target container
+            const targetItems = overContainer.items
+            const overItemIndex = targetItems.findIndex((i) => i.id === String(over.id))
+
+            let insertIndex: number
+            if (overItemIndex < 0) {
+                // Over the container itself (not an item) → insert at end
+                insertIndex = targetItems.length
+            } else {
+                // Determine if cursor is below the center of the over item
+                const translated = active.rect.current.translated
+                const isBelowCenter = translated != null && over.rect != null && translated.top > over.rect.top + over.rect.height / 2
+                insertIndex = isBelowCenter ? overItemIndex + 1 : overItemIndex
+            }
+
+            // Only update state if something changed to avoid unnecessary re-renders
+            const prev = pendingTransferRef.current
+            if (
+                prev &&
+                prev.toContainerId === overContainer.id &&
+                prev.insertIndex === insertIndex &&
+                prev.fromContainerId === activeContainer.id
+            ) {
+                return
+            }
+
+            const newTransfer: PendingTransfer = {
+                itemId: String(active.id),
+                fromContainerId: activeContainer.id,
+                toContainerId: overContainer.id,
+                insertIndex
+            }
+            pendingTransferRef.current = newTransfer
+            setPendingTransfer(newTransfer)
+        },
+        [containers, findContainer, isCrossListAllowed]
+    )
+
+    const handleDragEnd = useCallback(
+        async (event: DragEndEvent) => {
+            const { active, over } = event
+            // Save pending transfer before clearing state (needed when dropping on ghost row)
+            const savedPendingTransfer = pendingTransferRef.current
+
+            setActiveId(null)
+            setOverId(null)
+            setActiveContainerId(null)
+            setOverContainerId(null)
+            pendingTransferRef.current = null
+            setPendingTransfer(null)
+
+            if (!over) return
+
+            const activeContainer = findContainer(String(active.id))
+            let overContainer: ContainerInfo | undefined =
+                findContainer(String(over.id)) || containers.find((c) => c.id === String(over.id))
+
+            // If dropped on the ghost of the dragged item itself, resolve target from saved pending transfer
+            if (String(over.id) === String(active.id) && savedPendingTransfer) {
+                overContainer = containers.find((c) => c.id === savedPendingTransfer.toContainerId)
+            }
+
+            if (!activeContainer || !overContainer) return
+
+            const attribute = findAttribute(String(active.id))
+            if (!attribute) return
+
+            if (activeContainer.id === overContainer.id) {
+                // Same-list reorder
+                const items = activeContainer.items
+                const oldIndex = items.findIndex((i) => i.id === String(active.id))
+                const overItem = items.findIndex((i) => i.id === String(over.id))
+
+                if (oldIndex === -1 || overItem === -1 || oldIndex === overItem) return
+
+                const newSortOrder = items[overItem].sortOrder ?? overItem + 1
+                await onReorder(String(active.id), newSortOrder)
+            } else {
+                // Cross-list transfer
+                if (!isCrossListAllowed(activeContainer, overContainer)) return
+
+                if (onValidateTransfer) {
+                    const allowed = await onValidateTransfer(attribute, overContainer.parentAttributeId, overContainer.items.length)
+                    if (!allowed) return
+                }
+
+                const targetItems = overContainer.items
+                const overIndex = targetItems.findIndex((i) => i.id === String(over.id))
+
+                let newSortOrder: number
+                if (overIndex >= 0) {
+                    newSortOrder = targetItems[overIndex].sortOrder ?? overIndex + 1
+                } else if (savedPendingTransfer) {
+                    // Dropped on ghost row — use pending transfer's insertion index
+                    newSortOrder = savedPendingTransfer.insertIndex + 1
+                } else {
+                    newSortOrder = targetItems.length + 1
+                }
+
+                await onReorder(String(active.id), newSortOrder, overContainer.parentAttributeId, activeContainer.parentAttributeId)
+            }
+        },
+        [containers, findContainer, findAttribute, isCrossListAllowed, onReorder, onValidateTransfer]
+    )
+
+    const handleDragCancel = useCallback(() => {
+        setActiveId(null)
+        setOverId(null)
+        setActiveContainerId(null)
+        setOverContainerId(null)
+        pendingTransferRef.current = null
+        setPendingTransfer(null)
+    }, [])
+
+    const activeAttribute = activeId ? findAttribute(activeId) : undefined
+
+    return {
+        activeId,
+        activeAttribute,
+        activeContainerId,
+        overContainerId,
+        overId,
+        pendingTransfer,
+        handleDragStart,
+        handleDragOver,
+        handleDragEnd,
+        handleDragCancel
+    }
+}

--- a/packages/metahubs-frontend/base/src/domains/enumerations/api/enumerations.ts
+++ b/packages/metahubs-frontend/base/src/domains/enumerations/api/enumerations.ts
@@ -251,6 +251,12 @@ export const updateEnumerationValue = (
 export const moveEnumerationValue = (metahubId: string, enumerationId: string, valueId: string, direction: 'up' | 'down') =>
     apiClient.patch<EnumerationValue>(`/metahub/${metahubId}/enumeration/${enumerationId}/value/${valueId}/move`, { direction })
 
+/**
+ * Reorder an enumeration value via DnD to a new sort_order position.
+ */
+export const reorderEnumerationValue = (metahubId: string, enumerationId: string, valueId: string, newSortOrder: number) =>
+    apiClient.patch<EnumerationValue>(`/metahub/${metahubId}/enumeration/${enumerationId}/values/reorder`, { valueId, newSortOrder })
+
 export const deleteEnumerationValue = (metahubId: string, enumerationId: string, valueId: string) =>
     apiClient.delete<void>(`/metahub/${metahubId}/enumeration/${enumerationId}/value/${valueId}`)
 

--- a/packages/metahubs-frontend/base/src/domains/enumerations/hooks/mutations.ts
+++ b/packages/metahubs-frontend/base/src/domains/enumerations/hooks/mutations.ts
@@ -336,17 +336,17 @@ export function useReorderEnumerationValue() {
 
             // Optimistically reorder items
             queryClient.setQueriesData<Record<string, unknown>>({ queryKey: baseKey }, (old) => {
-                if (!old || !Array.isArray((old as any).items)) return old
-                const items = [...(old as any).items]
-                const fromIndex = items.findIndex((i: any) => i.id === variables.valueId)
+                if (!old || !Array.isArray((old as Record<string, unknown> & { items?: unknown[] }).items)) return old
+                const items = [...(old as Record<string, unknown> & { items: Record<string, unknown>[] }).items]
+                const fromIndex = items.findIndex((i) => (i as Record<string, unknown>).id === variables.valueId)
                 if (fromIndex === -1) return old
 
-                let toIndex = items.findIndex((i: any) => (i.sortOrder ?? 0) === variables.newSortOrder)
+                let toIndex = items.findIndex((i) => ((i as Record<string, unknown>).sortOrder ?? 0) === variables.newSortOrder)
                 if (toIndex === -1) toIndex = items.length - 1
 
                 const [moved] = items.splice(fromIndex, 1)
                 items.splice(toIndex, 0, moved)
-                const updated = items.map((item: any, idx: number) => ({ ...item, sortOrder: idx + 1 }))
+                const updated = items.map((item, idx) => ({ ...item, sortOrder: idx + 1 }))
                 return { ...old, items: updated }
             })
 

--- a/packages/metahubs-frontend/base/src/domains/enumerations/hooks/mutations.ts
+++ b/packages/metahubs-frontend/base/src/domains/enumerations/hooks/mutations.ts
@@ -77,6 +77,13 @@ interface CopyEnumerationValueParams {
     data?: EnumerationValueCopyInput
 }
 
+interface ReorderEnumerationValueParams {
+    metahubId: string
+    enumerationId: string
+    valueId: string
+    newSortOrder: number
+}
+
 export function useCreateEnumerationAtMetahub() {
     const queryClient = useQueryClient()
     const { enqueueSnackbar } = useSnackbar()
@@ -302,6 +309,59 @@ export function useMoveEnumerationValue() {
         },
         onError: (error: Error) => {
             enqueueSnackbar(error.message || t('enumerationValues.moveError', 'Failed to move value'), { variant: 'error' })
+        }
+    })
+}
+
+/**
+ * Reorder an enumeration value via DnD to a new sort_order position.
+ * Includes optimistic updates for instant visual feedback.
+ */
+export function useReorderEnumerationValue() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: async ({ metahubId, enumerationId, valueId, newSortOrder }: ReorderEnumerationValueParams) => {
+            const response = await enumerationsApi.reorderEnumerationValue(metahubId, enumerationId, valueId, newSortOrder)
+            return response.data
+        },
+        onMutate: async (variables) => {
+            const baseKey = metahubsQueryKeys.enumerationValues(variables.metahubId, variables.enumerationId)
+
+            // Cancel in-flight queries
+            await queryClient.cancelQueries({ queryKey: baseKey })
+
+            // Snapshot for rollback
+            const previousQueries = queryClient.getQueriesData<Record<string, unknown>>({ queryKey: baseKey })
+
+            // Optimistically reorder items
+            queryClient.setQueriesData<Record<string, unknown>>({ queryKey: baseKey }, (old) => {
+                if (!old || !Array.isArray((old as any).items)) return old
+                const items = [...(old as any).items]
+                const fromIndex = items.findIndex((i: any) => i.id === variables.valueId)
+                if (fromIndex === -1) return old
+
+                let toIndex = items.findIndex((i: any) => (i.sortOrder ?? 0) === variables.newSortOrder)
+                if (toIndex === -1) toIndex = items.length - 1
+
+                const [moved] = items.splice(fromIndex, 1)
+                items.splice(toIndex, 0, moved)
+                const updated = items.map((item: any, idx: number) => ({ ...item, sortOrder: idx + 1 }))
+                return { ...old, items: updated }
+            })
+
+            return { previousQueries, baseKey }
+        },
+        onError: (_error, _variables, context) => {
+            // Rollback optimistic update
+            if (context?.previousQueries) {
+                for (const [key, data] of context.previousQueries) {
+                    queryClient.setQueryData(key, data)
+                }
+            }
+        },
+        onSuccess: (_data, variables) => {
+            invalidateEnumerationValuesQueries.all(queryClient, variables.metahubId, variables.enumerationId)
         }
     })
 }

--- a/packages/metahubs-frontend/base/src/domains/enumerations/ui/EnumerationValueList.tsx
+++ b/packages/metahubs-frontend/base/src/domains/enumerations/ui/EnumerationValueList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState, type ChangeEvent } from 'react'
 import { useParams } from 'react-router-dom'
 import { Box, Divider, Stack, Switch, FormControlLabel, Tooltip, Typography } from '@mui/material'
 import AddRoundedIcon from '@mui/icons-material/AddRounded'
@@ -28,7 +28,7 @@ import {
 } from '@universo/template-mui'
 import { ConfirmDeleteDialog, EntityFormDialog } from '@universo/template-mui/components/dialogs'
 import type { VersionedLocalizedContent } from '@universo/types'
-import type { ActionDescriptor } from '@universo/template-mui'
+import type { ActionDescriptor, ActionContext, DragEndEvent } from '@universo/template-mui'
 import type { EnumerationValue, EnumerationValueDisplay } from '../../../types'
 import { getVLCString, toEnumerationValueDisplay } from '../../../types'
 import { normalizeLocale, extractLocalizedInput, hasPrimaryContent, ensureLocalizedContent } from '../../../utils/localizedInput'
@@ -41,9 +41,11 @@ import {
     useCreateEnumerationValue,
     useDeleteEnumerationValue,
     useMoveEnumerationValue,
+    useReorderEnumerationValue,
     useUpdateEnumerationValue
 } from '../hooks'
 import { metahubsQueryKeys } from '../../shared'
+import { DragOverlayValueRow } from './dnd'
 
 type ValueFormValues = {
     nameVlc: VersionedLocalizedContent<string> | null
@@ -99,7 +101,7 @@ const appendCopySuffix = (
     }
     return {
         ...source,
-        locales: nextLocales
+        locales: nextLocales as VersionedLocalizedContent<string>['locales']
     }
 }
 
@@ -152,7 +154,7 @@ const ValueFormFields = ({
         codenameTouched,
         codenameVlc,
         nameVlc,
-        deriveCodename: (nameContent) =>
+        deriveCodename: (nameContent: string) =>
             sanitizeCodenameForStyle(
                 nameContent,
                 codenameConfig.style,
@@ -171,7 +173,7 @@ const ValueFormFields = ({
                 required
                 disabled={isLoading}
                 value={nameVlc}
-                onChange={(next) => setValue('nameVlc', next)}
+                onChange={(next: VersionedLocalizedContent<string> | null) => setValue('nameVlc', next)}
                 error={errors.nameVlc || null}
                 helperText={errors.nameVlc}
                 uiLocale={uiLocale}
@@ -182,7 +184,7 @@ const ValueFormFields = ({
                 label={translate('common:fields.description', 'Description')}
                 disabled={isLoading}
                 value={descriptionVlc}
-                onChange={(next) => setValue('descriptionVlc', next)}
+                onChange={(next: VersionedLocalizedContent<string> | null) => setValue('descriptionVlc', next)}
                 uiLocale={uiLocale}
                 multiline
                 rows={2}
@@ -204,13 +206,13 @@ const ValueFormFields = ({
 
             <CodenameField
                 value={codename}
-                onChange={(value) => setValue('codename', value)}
+                onChange={(value: string) => setValue('codename', value)}
                 touched={codenameTouched}
-                onTouchedChange={(touched) => setValue('codenameTouched', touched)}
+                onTouchedChange={(touched: boolean) => setValue('codenameTouched', touched)}
                 onDuplicateStatusChange={(dup) => setValue('_hasCodenameDuplicate', dup)}
                 localizedEnabled={codenameConfig.localizedEnabled}
                 localizedValue={codenameVlc}
-                onLocalizedChange={(next) => setValue('codenameVlc', next)}
+                onLocalizedChange={(next: VersionedLocalizedContent<string> | null) => setValue('codenameVlc', next)}
                 uiLocale={uiLocale}
                 label={translate('enumerationValues.codename', 'Codename')}
                 helperText={translate('enumerationValues.codenameHelper', 'Unique identifier')}
@@ -241,6 +243,27 @@ const EnumerationValueList = () => {
     const deleteMutation = useDeleteEnumerationValue()
     const moveMutation = useMoveEnumerationValue()
     const copyMutation = useCopyEnumerationValue()
+    const reorderMutation = useReorderEnumerationValue()
+
+    // DnD: Handle value reorder
+    const handleValueReorder = useCallback(
+        async (valueId: string, newSortOrder: number) => {
+            if (!metahubId || !enumerationId) return
+            try {
+                await reorderMutation.mutateAsync({
+                    metahubId,
+                    enumerationId,
+                    valueId,
+                    newSortOrder
+                })
+                enqueueSnackbar(t('enumerationValues.reorderSuccess', 'Value order updated'), { variant: 'success' })
+            } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : t('enumerationValues.reorderError', 'Failed to reorder value')
+                enqueueSnackbar(message, { variant: 'error' })
+            }
+        },
+        [metahubId, enumerationId, reorderMutation, enqueueSnackbar, t]
+    )
 
     const {
         data: valuesResponse,
@@ -274,6 +297,39 @@ const EnumerationValueList = () => {
             return displayName.toLowerCase().includes(searchValue) || value.codename.toLowerCase().includes(searchValue)
         })
     }, [values, search, i18n.language])
+
+    // Sorted raw values for DnD items — must match tableData order
+    const sortedFilteredValues = useMemo(
+        () => [...filteredValues].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)),
+        [filteredValues]
+    )
+
+    // DnD: Handle drag end event (from FlowListTable InternalDndWrapper)
+    const handleDragEnd = useCallback(
+        async (event: DragEndEvent) => {
+            const { active, over } = event
+            if (!over || active.id === over.id) return
+
+            const oldIndex = sortedFilteredValues.findIndex((v) => v.id === String(active.id))
+            const overIndex = sortedFilteredValues.findIndex((v) => v.id === String(over.id))
+            if (oldIndex === -1 || overIndex === -1) return
+
+            const newSortOrder = sortedFilteredValues[overIndex].sortOrder ?? overIndex + 1
+            await handleValueReorder(String(active.id), newSortOrder)
+        },
+        [sortedFilteredValues, handleValueReorder]
+    )
+
+    // DnD: Render drag overlay
+    const renderDragOverlay = useCallback(
+        (activeId: string | null) => {
+            if (!activeId) return null
+            const val = sortedFilteredValues.find((v) => v.id === activeId)
+            if (!val) return null
+            return <DragOverlayValueRow value={toEnumerationValueDisplay(val, i18n.language)} />
+        },
+        [sortedFilteredValues, i18n.language]
+    )
 
     const tableData = useMemo<EnumerationValueDisplay[]>(
         () =>
@@ -344,6 +400,8 @@ const EnumerationValueList = () => {
         [valueMap, valueOrderMap, values.length, metahubId, enumerationId, updateMutation, moveMutation]
     )
 
+    type ValueActionCtx = ActionContext<EnumerationValueDisplay, never>
+
     const valueActions = useMemo<readonly ActionDescriptor<EnumerationValueDisplay, never>[]>(
         () => [
             {
@@ -351,7 +409,7 @@ const EnumerationValueList = () => {
                 labelKey: 'common:actions.edit',
                 order: 10,
                 icon: <EditRoundedIcon fontSize='small' />,
-                onSelect: (ctx) => {
+                onSelect: (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         ;(ctx.openEditDialog as ((value: EnumerationValue) => void) | undefined)?.(source)
@@ -363,7 +421,7 @@ const EnumerationValueList = () => {
                 labelKey: 'common:actions.copy',
                 order: 11,
                 icon: <ContentCopyRoundedIcon fontSize='small' />,
-                onSelect: (ctx) => {
+                onSelect: (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         setCopyDialogError(null)
@@ -376,11 +434,11 @@ const EnumerationValueList = () => {
                 labelKey: 'enumerationValues.actions.setDefault',
                 order: 20,
                 icon: <StarRoundedIcon fontSize='small' />,
-                visible: (ctx) => {
+                visible: (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     return !source?.isDefault
                 },
-                onSelect: async (ctx) => {
+                onSelect: async (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         await (ctx.setDefaultValue as ((value: EnumerationValue) => Promise<void>) | undefined)?.(source)
@@ -392,11 +450,11 @@ const EnumerationValueList = () => {
                 labelKey: 'enumerationValues.actions.clearDefault',
                 order: 21,
                 icon: <StarOutlineRoundedIcon fontSize='small' />,
-                visible: (ctx) => {
+                visible: (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     return Boolean(source?.isDefault)
                 },
-                onSelect: async (ctx) => {
+                onSelect: async (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         await (ctx.clearDefaultValue as ((value: EnumerationValue) => Promise<void>) | undefined)?.(source)
@@ -409,13 +467,13 @@ const EnumerationValueList = () => {
                 order: 30,
                 dividerBefore: true,
                 icon: <ArrowUpwardRoundedIcon fontSize='small' />,
-                enabled: (ctx) => {
+                enabled: (ctx: ValueActionCtx) => {
                     const orderMap = ctx.valueOrderMap as Map<string, number> | undefined
                     if (!orderMap || orderMap.size <= 1) return false
                     const index = orderMap.get(ctx.entity.id)
                     return typeof index === 'number' && index > 0
                 },
-                onSelect: async (ctx) => {
+                onSelect: async (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         await (ctx.moveValue as ((value: EnumerationValue, direction: 'up' | 'down') => Promise<void>) | undefined)?.(
@@ -430,14 +488,14 @@ const EnumerationValueList = () => {
                 labelKey: 'attributes.actions.moveDown',
                 order: 40,
                 icon: <ArrowDownwardRoundedIcon fontSize='small' />,
-                enabled: (ctx) => {
+                enabled: (ctx: ValueActionCtx) => {
                     const orderMap = ctx.valueOrderMap as Map<string, number> | undefined
                     if (!orderMap || orderMap.size <= 1) return false
                     const index = orderMap.get(ctx.entity.id)
                     if (typeof index !== 'number') return false
                     return index < orderMap.size - 1
                 },
-                onSelect: async (ctx) => {
+                onSelect: async (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         await (ctx.moveValue as ((value: EnumerationValue, direction: 'up' | 'down') => Promise<void>) | undefined)?.(
@@ -454,7 +512,7 @@ const EnumerationValueList = () => {
                 dividerBefore: true,
                 icon: <DeleteRoundedIcon fontSize='small' />,
                 tone: 'danger',
-                onSelect: (ctx) => {
+                onSelect: (ctx: ValueActionCtx) => {
                     const source = (ctx.valueMap as Map<string, EnumerationValue> | undefined)?.get(ctx.entity.id)
                     if (source) {
                         ;(ctx.openDeleteDialog as ((value: EnumerationValue) => void) | undefined)?.(source)
@@ -465,13 +523,54 @@ const EnumerationValueList = () => {
         []
     )
 
-    const images = useMemo(() => {
-        const imageMap: Record<string, unknown[]> = {}
-        values.forEach((value) => {
-            imageMap[value.id] = []
-        })
-        return imageMap
-    }, [values])
+    const valueColumns = useMemo(
+        () => [
+            {
+                id: 'sortOrder',
+                label: t('attributes.table.order', '#'),
+                width: '4%',
+                align: 'center' as const,
+                render: (row: EnumerationValueDisplay) => (
+                    <Typography sx={{ fontSize: 13, fontWeight: 600 }}>{row.sortOrder ?? 0}</Typography>
+                )
+            },
+            {
+                id: 'name',
+                label: tc('table.name', 'Name'),
+                width: '30%',
+                align: 'left' as const,
+                render: (row: EnumerationValueDisplay) => (
+                    <Stack direction='row' spacing={0.5} alignItems='center'>
+                        {row.isDefault && (
+                            <Tooltip title={t('enumerationValues.defaultTooltip', 'This value is used by default.')} arrow>
+                                <StarIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                            </Tooltip>
+                        )}
+                        <Typography sx={{ fontSize: 14, fontWeight: 500, wordBreak: 'break-word' }}>{row.name || '—'}</Typography>
+                    </Stack>
+                )
+            },
+            {
+                id: 'description',
+                label: tc('table.description', 'Description'),
+                width: '30%',
+                align: 'left' as const,
+                render: (row: EnumerationValueDisplay) => (
+                    <Typography sx={{ fontSize: 14, wordBreak: 'break-word' }}>{row.description || '—'}</Typography>
+                )
+            },
+            {
+                id: 'codename',
+                label: t('enumerationValues.codename', 'Codename'),
+                width: '20%',
+                align: 'left' as const,
+                render: (row: EnumerationValueDisplay) => (
+                    <Typography sx={{ fontSize: 14, fontWeight: 600, fontFamily: 'monospace' }}>{row.codename}</Typography>
+                )
+            }
+        ],
+        [t, tc]
+    )
 
     const formDefaults = useMemo<ValueFormValues>(
         () => ({
@@ -658,7 +757,7 @@ const EnumerationValueList = () => {
                         <ViewHeader
                             search={true}
                             searchPlaceholder={t('enumerationValues.searchPlaceholder', 'Search enumeration values...')}
-                            onSearchChange={setSearch}
+                            onSearchChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setSearch(e.target.value)}
                             title={t('enumerationValues.title', 'Values')}
                         >
                             <ToolbarControls
@@ -686,67 +785,15 @@ const EnumerationValueList = () => {
                             />
                         ) : (
                             <Box sx={{ mx: { xs: -1.5, md: -2 } }}>
-                                <FlowListTable
+                                <FlowListTable<EnumerationValueDisplay>
                                     data={tableData}
-                                    images={images}
-                                    isLoading={isBusy}
-                                    customColumns={[
-                                        {
-                                            id: 'sortOrder',
-                                            label: t('attributes.table.order', '#'),
-                                            width: '4%',
-                                            align: 'center',
-                                            sortable: true,
-                                            sortAccessor: (row: EnumerationValueDisplay) => row.sortOrder ?? 0,
-                                            render: (row: EnumerationValueDisplay) => (
-                                                <Typography sx={{ fontSize: 13, fontWeight: 600 }}>{row.sortOrder ?? 0}</Typography>
-                                            )
-                                        },
-                                        {
-                                            id: 'name',
-                                            label: tc('table.name', 'Name'),
-                                            width: '30%',
-                                            align: 'left',
-                                            render: (row: EnumerationValueDisplay) => (
-                                                <Stack direction='row' spacing={0.5} alignItems='center'>
-                                                    {row.isDefault && (
-                                                        <Tooltip
-                                                            title={t('enumerationValues.defaultTooltip', 'This value is used by default.')}
-                                                            arrow
-                                                        >
-                                                            <StarIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-                                                        </Tooltip>
-                                                    )}
-                                                    <Typography sx={{ fontSize: 14, fontWeight: 500, wordBreak: 'break-word' }}>
-                                                        {row.name || '—'}
-                                                    </Typography>
-                                                </Stack>
-                                            )
-                                        },
-                                        {
-                                            id: 'description',
-                                            label: tc('table.description', 'Description'),
-                                            width: '30%',
-                                            align: 'left',
-                                            render: (row: EnumerationValueDisplay) => (
-                                                <Typography sx={{ fontSize: 14, wordBreak: 'break-word' }}>
-                                                    {row.description || '—'}
-                                                </Typography>
-                                            )
-                                        },
-                                        {
-                                            id: 'codename',
-                                            label: t('enumerationValues.codename', 'Codename'),
-                                            width: '20%',
-                                            align: 'left',
-                                            render: (row: EnumerationValueDisplay) => (
-                                                <Typography sx={{ fontSize: 14, fontWeight: 600, fontFamily: 'monospace' }}>
-                                                    {row.codename}
-                                                </Typography>
-                                            )
-                                        }
-                                    ]}
-                                    i18nNamespace='flowList'
+                                    customColumns={valueColumns}
+                                    sortableRows
+                                    sortableItemIds={sortedFilteredValues.map((v) => v.id)}
+                                    dragHandleAriaLabel={t('enumerationValues.dnd.dragHandle', 'Drag to reorder')}
+                                    dragDisabled={isBusy}
+                                    onSortableDragEnd={handleDragEnd}
+                                    renderDragOverlay={renderDragOverlay}
                                     renderActions={(row: EnumerationValueDisplay) => (
                                         <BaseEntityMenu<EnumerationValueDisplay, never>
                                             entity={row}
@@ -788,14 +835,24 @@ const EnumerationValueList = () => {
                     onSave={handleSave}
                     hideDefaultFields
                     initialExtraValues={initialFormValues}
-                    extraFields={({ values, setValue, isLoading, errors }) => (
+                    extraFields={({
+                        values,
+                        setValue,
+                        isLoading,
+                        errors
+                    }: {
+                        values: Record<string, unknown>
+                        setValue: (name: string, value: unknown) => void
+                        isLoading: boolean
+                        errors: Record<string, string>
+                    }) => (
                         <ValueFormFields
                             values={values}
                             setValue={setValue}
                             isLoading={isLoading}
                             errors={errors ?? {}}
                             uiLocale={i18n.language}
-                            translate={(key, defaultValue) => t(key, defaultValue)}
+                            translate={(key, defaultValue) => t(key, defaultValue ? { defaultValue } : {})}
                             editingEntityId={editingValue?.id}
                         />
                     )}
@@ -890,14 +947,24 @@ const EnumerationValueList = () => {
                     }}
                     hideDefaultFields
                     initialExtraValues={copyInitialValues}
-                    extraFields={({ values, setValue, isLoading, errors }) => (
+                    extraFields={({
+                        values,
+                        setValue,
+                        isLoading,
+                        errors
+                    }: {
+                        values: Record<string, unknown>
+                        setValue: (name: string, value: unknown) => void
+                        isLoading: boolean
+                        errors: Record<string, string>
+                    }) => (
                         <ValueFormFields
                             values={values}
                             setValue={setValue}
                             isLoading={isLoading}
                             errors={errors ?? {}}
                             uiLocale={i18n.language}
-                            translate={(key, defaultValue) => t(key, defaultValue)}
+                            translate={(key, defaultValue) => t(key, defaultValue ? { defaultValue } : {})}
                             editingEntityId={null}
                         />
                     )}
@@ -938,7 +1005,7 @@ const EnumerationValueList = () => {
                             enqueueSnackbar(message, { variant: 'error' })
                         }
                     }}
-                    deleting={deleteMutation.isPending}
+                    loading={deleteMutation.isPending}
                 />
             </ExistingCodenamesProvider>
         </MainCard>

--- a/packages/metahubs-frontend/base/src/domains/enumerations/ui/dnd/DragOverlayValueRow.tsx
+++ b/packages/metahubs-frontend/base/src/domains/enumerations/ui/dnd/DragOverlayValueRow.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Paper, Typography, Stack } from '@mui/material'
+import type { EnumerationValueDisplay } from '../../../../types'
+
+interface DragOverlayValueRowProps {
+    value: EnumerationValueDisplay
+}
+
+export const DragOverlayValueRow: React.FC<DragOverlayValueRowProps> = ({ value }) => (
+    <Paper
+        elevation={8}
+        sx={{
+            px: 2,
+            py: 1,
+            borderRadius: 1,
+            display: 'inline-flex',
+            alignItems: 'center',
+            maxWidth: 320
+        }}
+    >
+        <Stack direction='row' spacing={1} alignItems='center'>
+            <Typography variant='body2' noWrap sx={{ fontWeight: 500 }}>
+                {value.name || value.codename || '—'}
+            </Typography>
+            {value.codename && (
+                <Typography variant='caption' color='text.secondary' noWrap sx={{ fontFamily: 'monospace' }}>
+                    {value.codename}
+                </Typography>
+            )}
+        </Stack>
+    </Paper>
+)

--- a/packages/metahubs-frontend/base/src/domains/enumerations/ui/dnd/index.ts
+++ b/packages/metahubs-frontend/base/src/domains/enumerations/ui/dnd/index.ts
@@ -1,0 +1,1 @@
+export { DragOverlayValueRow } from './DragOverlayValueRow'

--- a/packages/metahubs-frontend/base/src/i18n/locales/en/metahubs.json
+++ b/packages/metahubs-frontend/base/src/i18n/locales/en/metahubs.json
@@ -671,6 +671,11 @@
             "codenameInvalid": "Use lowercase letters, numbers, and hyphens only",
             "codenameInvalidPascal": "Start with uppercase letter; use letters, digits, and underscores only",
             "codenameInvalidPascalEn": "Start with uppercase letter; use English letters, digits, and underscores only"
+        },
+        "reorderSuccess": "Value order updated",
+        "reorderError": "Failed to reorder value",
+        "dnd": {
+            "dragHandle": "Drag to reorder"
         }
     },
     "attributes": {
@@ -849,6 +854,20 @@
             "maxChildAttributes": "Maximum {{max}} child attributes per TABLE",
             "nestedTableNotAllowed": "Nested TABLE attributes are not allowed",
             "tableCannotBeDisplay": "TABLE attributes cannot be set as the display attribute"
+        },
+        "reorderSuccess": "Attribute order updated",
+        "reorderError": "Failed to reorder attribute",
+        "dnd": {
+            "dragHandle": "Drag to reorder",
+            "codenameConflictTitle": "Codename conflict",
+            "codenameConflictDescription": "An attribute with codename \"{{codename}}\" already exists in the target list. Move with automatic codename rename?",
+            "confirmMove": "Move",
+            "displayAttributeBlockedTitle": "Cannot move display attribute",
+            "displayAttributeBlockedDescription": "This attribute is the display attribute for its list. Assign another attribute as the display attribute first, then try again.",
+            "tableCannotMoveTitle": "Cannot move TABLE attribute",
+            "tableCannotMoveDescription": "TABLE attributes can only exist at the root level.",
+            "firstChildAttributeTitle": "First child attribute",
+            "firstChildAttributeDescription": "This will be the first attribute in the table. It will automatically become the display attribute and required. After that, it cannot be moved out until another attribute is set as the display attribute."
         }
     },
     "ref": {
@@ -1258,6 +1277,10 @@
             "catalogs.allowAttributeDelete.description": "Allow deleting attributes in catalogs",
             "catalogs.allowDeleteLastDisplayAttribute": "Allow Delete Last Display Attribute",
             "catalogs.allowDeleteLastDisplayAttribute.description": "Allow deleting the last display attribute in a scope (root attributes or table children)",
+            "catalogs.allowAttributeMoveBetweenRootAndChildren": "Allow Attribute Move Between Root and Children",
+            "catalogs.allowAttributeMoveBetweenRootAndChildren.description": "Allow moving attributes between root list and child lists of TABLE attributes",
+            "catalogs.allowAttributeMoveBetweenChildLists": "Allow Attribute Move Between Child Lists",
+            "catalogs.allowAttributeMoveBetweenChildLists.description": "Allow moving attributes between child lists of different TABLE attributes",
             "catalogs.allowElementCopy": "Allow Element Copy",
             "catalogs.allowElementCopy.description": "Allow copying predefined elements in catalogs",
             "catalogs.allowElementDelete": "Allow Element Delete",

--- a/packages/metahubs-frontend/base/src/i18n/locales/ru/metahubs.json
+++ b/packages/metahubs-frontend/base/src/i18n/locales/ru/metahubs.json
@@ -682,6 +682,11 @@
             "codenameInvalid": "Разрешены только строчные латинские буквы, цифры и дефисы",
             "codenameInvalidPascal": "Начинается с заглавной; разрешены буквы, цифры и подчёркивания",
             "codenameInvalidPascalEn": "Начинается с заглавной; разрешены только англ. буквы, цифры и подчёркивания"
+        },
+        "reorderSuccess": "Порядок значений обновлён",
+        "reorderError": "Не удалось изменить порядок значения",
+        "dnd": {
+            "dragHandle": "Перетащите для изменения порядка"
         }
     },
     "attributes": {
@@ -870,6 +875,20 @@
             "maxChildAttributes": "Максимум {{max}} дочерних атрибутов на ТАБЛИЦУ",
             "nestedTableNotAllowed": "Вложенные атрибуты ТАБЛИЦА не допускаются",
             "tableCannotBeDisplay": "Атрибуты ТАБЛИЦА не могут быть атрибутами представления"
+        },
+        "reorderSuccess": "Порядок атрибутов обновлён",
+        "reorderError": "Не удалось изменить порядок атрибута",
+        "dnd": {
+            "dragHandle": "Перетащите для изменения порядка",
+            "codenameConflictTitle": "Конфликт кодового имени",
+            "codenameConflictDescription": "Атрибут с кодовым именем «{{codename}}» уже существует в целевом списке. Переместить с автоматическим переименованием?",
+            "confirmMove": "Переместить",
+            "displayAttributeBlockedTitle": "Нельзя переместить атрибут отображения",
+            "displayAttributeBlockedDescription": "Этот атрибут является атрибутом отображения для своего списка. Сначала назначьте другой атрибут в качестве атрибута отображения, затем повторите попытку.",
+            "tableCannotMoveTitle": "Нельзя переместить TABLE-атрибут",
+            "tableCannotMoveDescription": "TABLE-атрибуты могут существовать только на корневом уровне.",
+            "firstChildAttributeTitle": "Первый дочерний атрибут",
+            "firstChildAttributeDescription": "Это будет первый атрибут в таблице. Он автоматически станет атрибутом представления и обязательным. После этого его нельзя будет переместить обратно, пока другой атрибут не будет назначен атрибутом представления."
         }
     },
     "ref": {
@@ -1289,6 +1308,10 @@
             "catalogs.allowAttributeDelete.description": "Разрешить удаление атрибутов в каталогах",
             "catalogs.allowDeleteLastDisplayAttribute": "Разрешить удаление последнего атрибута-представления",
             "catalogs.allowDeleteLastDisplayAttribute.description": "Разрешить удалять последний атрибут-представление в области (корневые атрибуты или дочерние атрибуты таблицы)",
+            "catalogs.allowAttributeMoveBetweenRootAndChildren": "Разрешить перемещение атрибутов между корнем и дочерними списками",
+            "catalogs.allowAttributeMoveBetweenRootAndChildren.description": "Разрешить перемещение атрибутов между корневым списком и дочерними списками TABLE-атрибутов",
+            "catalogs.allowAttributeMoveBetweenChildLists": "Разрешить перемещение атрибутов между дочерними списками",
+            "catalogs.allowAttributeMoveBetweenChildLists.description": "Разрешить перемещение атрибутов между дочерними списками разных TABLE-атрибутов",
             "catalogs.allowElementCopy": "Разрешить копирование элементов",
             "catalogs.allowElementCopy.description": "Разрешить копирование предзаданных элементов в каталогах",
             "catalogs.allowElementDelete": "Разрешить удаление элементов",

--- a/packages/universo-template-mui/base/package.json
+++ b/packages/universo-template-mui/base/package.json
@@ -38,6 +38,9 @@
         "test:watch": "NODE_OPTIONS='--require ./jest-canvas-mock.js' jest --watch"
     },
     "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@flowise/store": "workspace:*",
         "@flowise/template-mui": "workspace:*",
         "@flowise/apikey-frontend": "workspace:*",

--- a/packages/universo-template-mui/base/src/components/dialogs/ConfirmDialog.tsx
+++ b/packages/universo-template-mui/base/src/components/dialogs/ConfirmDialog.tsx
@@ -44,7 +44,7 @@ export const ConfirmDialog = () => {
     return createPortal(
         <Dialog
             fullWidth
-            maxWidth='xs'
+            maxWidth='sm'
             open={confirmState.show}
             onClose={onCancel}
             aria-labelledby='confirm-dialog-title'
@@ -56,8 +56,10 @@ export const ConfirmDialog = () => {
             <DialogContent id='confirm-dialog-description'>
                 <span>{confirmState.description}</span>
             </DialogContent>
-            <DialogActions>
-                <Button onClick={onCancel}>{confirmState.cancelButtonName || t('common:confirm.cancelButtonText')}</Button>
+            <DialogActions sx={{ px: 3, pb: 2 }}>
+                {!confirmState.hideCancelButton && (
+                    <Button onClick={onCancel}>{confirmState.cancelButtonName || t('common:confirm.cancelButtonText')}</Button>
+                )}
                 <Button variant='contained' color='primary' onClick={onConfirm}>
                     {confirmState.confirmButtonName || t('common:confirm.confirmButtonText')}
                 </Button>

--- a/packages/universo-template-mui/base/src/components/dialogs/EntityFormDialog.tsx
+++ b/packages/universo-template-mui/base/src/components/dialogs/EntityFormDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, Box, Typography, Tabs, Tab } from '@mui/material'
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, Box, Typography, Tabs, Tab, Tooltip } from '@mui/material'
 import DeleteIcon from '@mui/icons-material/Delete'
 
 /**
@@ -49,8 +49,8 @@ function a11yProps(index: number) {
 export interface EntityFormDialogProps {
     open: boolean
     title: string
-    /** Mode of the dialog: 'create' for new entities, 'edit' for existing ones (default: 'create') */
-    mode?: 'create' | 'edit'
+    /** Mode of the dialog: 'create' for new entities, 'edit' for existing ones, 'copy' for duplication (default: 'create') */
+    mode?: 'create' | 'edit' | 'copy'
     saveButtonText?: string
     /** Text shown on save button while loading (e.g., "Saving...") */
     savingButtonText?: string
@@ -75,6 +75,8 @@ export interface EntityFormDialogProps {
     showDeleteButton?: boolean
     /** Disable delete button (shows button but in disabled state) */
     deleteButtonDisabled?: boolean
+    /** Reason why the delete button is disabled (shown as tooltip) */
+    deleteButtonDisabledReason?: string
     /** Callback when delete button is clicked (only in edit mode) */
     onDelete?: () => void | Promise<void>
     /** Hide default name/description fields (useful for custom field rendering). */
@@ -128,6 +130,7 @@ export const EntityFormDialog: React.FC<EntityFormDialogProps> = ({
     autoCloseOnSuccess = true,
     showDeleteButton = false,
     deleteButtonDisabled = false,
+    deleteButtonDisabledReason,
     onDelete,
     hideDefaultFields = false,
     canSave,
@@ -314,18 +317,22 @@ export const EntityFormDialog: React.FC<EntityFormDialogProps> = ({
             <DialogTitle>{title}</DialogTitle>
             <DialogContent sx={{ overflowY: 'visible' }}>{renderContent()}</DialogContent>
             <DialogActions sx={{ p: 3, pt: 2, justifyContent: 'space-between' }}>
-                {/* Delete button - shown in edit mode when showDeleteButton is true */}
-                {mode === 'edit' && showDeleteButton ? (
-                    <Button
-                        onClick={deleteButtonDisabled ? undefined : onDelete}
-                        disabled={isLoading || deleteButtonDisabled}
-                        variant='outlined'
-                        color='error'
-                        startIcon={<DeleteIcon />}
-                        sx={{ borderRadius: 1, mr: 'auto' }}
-                    >
-                        {deleteButtonText}
-                    </Button>
+                {/* Delete button - shown in edit/copy mode when showDeleteButton is true */}
+                {(mode === 'edit' || mode === 'copy') && showDeleteButton ? (
+                    <Tooltip title={deleteButtonDisabled && deleteButtonDisabledReason ? deleteButtonDisabledReason : ''} arrow>
+                        <span>
+                            <Button
+                                onClick={deleteButtonDisabled ? undefined : onDelete}
+                                disabled={isLoading || deleteButtonDisabled}
+                                variant='outlined'
+                                color='error'
+                                startIcon={<DeleteIcon />}
+                                sx={{ borderRadius: 1, mr: 'auto' }}
+                            >
+                                {deleteButtonText}
+                            </Button>
+                        </span>
+                    </Tooltip>
                 ) : (
                     <Box /> // Empty box to maintain layout when no delete button
                 )}

--- a/packages/universo-template-mui/base/src/components/index.ts
+++ b/packages/universo-template-mui/base/src/components/index.ts
@@ -1,7 +1,9 @@
 export { default as ErrorBoundary } from './error/ErrorBoundary'
 export { MarketplaceTable } from './table/MarketplaceTable'
-export { FlowListTable } from './table/FlowListTable'
+export { FlowListTable, StyledTableCell, StyledTableRow } from './table/FlowListTable'
 export type { FlowListTableData, FlowListTableProps, TableColumn } from './table/FlowListTable'
+// Re-export DnD event types for FlowListTable DnD consumers
+export type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core'
 export { CompactListTable } from './table/CompactListTable'
 export type { CompactListTableProps, CompactListTableLinkMode } from './table/CompactListTable'
 export { TableViewOnly } from './table/Table'

--- a/packages/universo-template-mui/base/src/components/table/FlowListTable.tsx
+++ b/packages/universo-template-mui/base/src/components/table/FlowListTable.tsx
@@ -23,8 +23,10 @@ import { tableCellClasses } from '@mui/material/TableCell'
 import { FlowListMenu } from '@flowise/template-mui'
 import i18n from '@universo/i18n'
 import { Link } from 'react-router-dom'
+import type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core'
+import { SortableTableRow, SortableTableBody, InternalDndWrapper } from './FlowListTableDnd'
 
-const StyledTableCell = styled(TableCell)(({ theme }) => ({
+export const StyledTableCell = styled(TableCell)(({ theme }) => ({
     borderColor: (theme as any).vars?.palette?.outline ?? alpha(theme.palette.text.primary, 0.08),
 
     [`&.${tableCellClasses.head}`]: {
@@ -48,7 +50,7 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
     }
 }))
 
-const StyledTableRow = styled(TableRow)(() => ({
+export const StyledTableRow = styled(TableRow)(() => ({
     // hide last border
     '&:last-child td, &:last-child th': {
         border: 0
@@ -95,6 +97,35 @@ export interface FlowListTableProps<T extends FlowListTableData = FlowListTableD
     renderRowExpansion?: (row: T, index: number) => React.ReactNode | null
     /** Compact mode: reduced row heights and font sizes */
     compact?: boolean
+
+    // ── DnD support ──────────────────────────────────────────────────────
+    /** Enable drag-and-drop row reordering. Adds a drag handle column and makes rows sortable. */
+    sortableRows?: boolean
+    /** Item IDs for SortableContext. Defaults to data.map(d => d.id) when sortableRows=true. */
+    sortableItemIds?: string[]
+    /** Container ID for useDroppable (for multi-container DnD with external DndContext). */
+    droppableContainerId?: string
+    /**
+     * When true, FlowListTable does NOT create its own DndContext.
+     * Use this when an external DndContext (e.g. a cross-list DnD provider) wraps the table.
+     */
+    externalDndContext?: boolean
+    /** Called on drag end. Only used when externalDndContext is falsy. */
+    onSortableDragEnd?: (event: DragEndEvent) => void
+    /** Called on drag start. Only used when externalDndContext is falsy. */
+    onSortableDragStart?: (event: DragStartEvent) => void
+    /** Called on drag over. Only used when externalDndContext is falsy. */
+    onSortableDragOver?: (event: DragOverEvent) => void
+    /** Called on drag cancel. Only used when externalDndContext is falsy. */
+    onSortableDragCancel?: () => void
+    /** Render drag overlay content. Only used when externalDndContext is falsy. */
+    renderDragOverlay?: (activeId: string | null) => React.ReactNode
+    /** Accessible label for drag handle cells. */
+    dragHandleAriaLabel?: string
+    /** Disable all drag handles (e.g. during loading). */
+    dragDisabled?: boolean
+    /** Visual indicator that this table is a DnD drop target (e.g. during cross-list drag). */
+    isDropTarget?: boolean
 }
 
 const getLocalStorageKeyName = (name: string, isAgentCanvas?: boolean): string => {
@@ -118,7 +149,20 @@ export const FlowListTable = <T extends FlowListTableData = FlowListTableData>({
     customColumns,
     i18nNamespace = 'flowList',
     renderRowExpansion,
-    compact = false
+    compact = false,
+    // DnD props
+    sortableRows = false,
+    sortableItemIds,
+    droppableContainerId,
+    externalDndContext = false,
+    onSortableDragEnd,
+    onSortableDragStart,
+    onSortableDragOver,
+    onSortableDragCancel,
+    renderDragOverlay,
+    dragHandleAriaLabel,
+    dragDisabled = false,
+    isDropTarget = false
 }: FlowListTableProps<T>): React.ReactElement => {
     const { t } = useTranslation(i18nNamespace, { i18n })
     const theme = useTheme()
@@ -143,7 +187,11 @@ export const FlowListTable = <T extends FlowListTableData = FlowListTableData>({
 
     const columnsToRender = !isUnikTable && Array.isArray(customColumns) && customColumns.length > 0 ? customColumns : null
 
-    const sortedData = data
+    // When sortableRows is enabled, data order is controlled externally (by sortOrder),
+    // so we skip internal sorting and filtering.
+    const sortedData = sortableRows
+        ? data ?? []
+        : data
         ? [...data].sort((a, b) => {
               if (columnsToRender) {
                   const sortableColumn = columnsToRender.find((column) => column.sortable && column.id === orderBy)
@@ -175,6 +223,11 @@ export const FlowListTable = <T extends FlowListTableData = FlowListTableData>({
           })
         : []
 
+    // Effective item IDs for DnD SortableContext
+    const effectiveSortableIds = sortableRows
+        ? sortableItemIds ?? sortedData.map((d) => d.id)
+        : []
+
     const buildEntityLink = (row: T): string | undefined => {
         if (typeof getRowLink === 'function') {
             return getRowLink(row)
@@ -191,15 +244,30 @@ export const FlowListTable = <T extends FlowListTableData = FlowListTableData>({
 
     const activeFilter = typeof filterFunction === 'function' ? filterFunction : () => true
 
-    return (
-        <>
-            <TableContainer sx={{ border: 1, borderColor, borderRadius: 1 }} component={Paper}>
-                <Table
-                    sx={{ minWidth: compact ? 400 : 900 }}
-                    size='small'
-                    aria-label='a dense table'
-                    className={compact ? 'FlowListTable-compact' : undefined}
-                >
+    const tableElement = (
+        <TableContainer
+            sx={{
+                border: 1,
+                borderColor: isDropTarget ? 'primary.main' : borderColor,
+                borderRadius: 1,
+                ...(isDropTarget && {
+                    borderWidth: 2,
+                    borderStyle: 'dashed',
+                    backgroundColor: (th: any) => alpha(th.palette.primary.main, 0.04),
+                    transition: 'border-color 0.2s, background-color 0.2s',
+                    // Prevent horizontal scrollbar jitter when a wider ghost row
+                    // is injected during cross-list DnD (e.g. root → child table).
+                    overflowX: 'hidden'
+                })
+            }}
+            component={Paper}
+        >
+            <Table
+                sx={{ minWidth: compact ? 400 : 900 }}
+                size='small'
+                aria-label='a dense table'
+                className={compact ? 'FlowListTable-compact' : undefined}
+            >
                     <TableHead
                         sx={{
                             backgroundColor: customization.isDarkMode ? theme.palette.common.black : theme.palette.grey[100],
@@ -207,6 +275,8 @@ export const FlowListTable = <T extends FlowListTableData = FlowListTableData>({
                         }}
                     >
                         <TableRow>
+                            {/* Drag handle column header (when DnD enabled) */}
+                            {sortableRows && <StyledTableCell align='center' sx={{ width: 40 }} />}
                             {columnsToRender ? (
                                 <>
                                     {columnsToRender.map((column) => (
@@ -289,233 +359,267 @@ export const FlowListTable = <T extends FlowListTableData = FlowListTableData>({
                             )}
                         </TableRow>
                     </TableHead>
-                    <TableBody>
-                        {isLoading ? (
-                            <>
-                                <StyledTableRow>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                </StyledTableRow>
-                                <StyledTableRow>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                    <StyledTableCell>
-                                        <Skeleton variant='text' />
-                                    </StyledTableCell>
-                                </StyledTableRow>
-                            </>
-                        ) : (
-                            <>
-                                {(sortedData || []).filter(activeFilter).map((row, index) => {
-                                    const linkTarget = buildEntityLink(row)
-                                    const displayName = row.templateName || row.name
-                                    const normalizedUpdatedDate = resolveUpdatedDate(row)
-                                    const expansionContent = renderRowExpansion ? renderRowExpansion(row, index) : null
+                    {/* ── Table Body ─────────────────────────────────────── */}
+                    {(() => {
+                        // Shared rendering logic for row cells (used by both normal and sortable paths)
+                        const displayData = sortableRows ? sortedData : (sortedData || []).filter(activeFilter)
 
-                                    return (
-                                        <React.Fragment key={index}>
-                                            <StyledTableRow sx={expansionContent ? { '& td, & th': { borderBottom: 0 } } : undefined}>
-                                                {columnsToRender ? (
-                                                    <>
-                                                        {columnsToRender.map((column) => (
-                                                            <StyledTableCell key={column.id} align={column.align || 'left'}>
-                                                                {column.render ? column.render(row, index) : null}
-                                                            </StyledTableCell>
-                                                        ))}
-                                                        {renderActions && (
-                                                            <StyledTableCell key='actions' align='center'>
-                                                                <Stack
-                                                                    direction={{ xs: 'column', sm: 'row' }}
-                                                                    spacing={1}
-                                                                    justifyContent='center'
-                                                                    alignItems='center'
+                        const renderRowCells = (row: T, index: number) => {
+                            const linkTarget = buildEntityLink(row)
+                            const displayName = row.templateName || row.name
+                            const normalizedUpdatedDate = resolveUpdatedDate(row)
+
+                            if (columnsToRender) {
+                                return (
+                                    <>
+                                        {columnsToRender.map((column) => (
+                                            <StyledTableCell key={column.id} align={column.align || 'left'}>
+                                                {column.render ? column.render(row, index) : null}
+                                            </StyledTableCell>
+                                        ))}
+                                        {renderActions && (
+                                            <StyledTableCell key='actions' align='center'>
+                                                <Stack
+                                                    direction={{ xs: 'column', sm: 'row' }}
+                                                    spacing={1}
+                                                    justifyContent='center'
+                                                    alignItems='center'
+                                                >
+                                                    {renderActions(row)}
+                                                </Stack>
+                                            </StyledTableCell>
+                                        )}
+                                    </>
+                                )
+                            }
+
+                            // Default columns (name, category/spaces, nodes, date, actions)
+                            return (
+                                <>
+                                    <StyledTableCell key='0'>
+                                        <Typography
+                                            sx={{
+                                                fontSize: 14,
+                                                fontWeight: 500,
+                                                wordBreak: 'break-word',
+                                                overflowWrap: 'break-word'
+                                            }}
+                                        >
+                                            {linkTarget ? (
+                                                <Link to={linkTarget} style={{ color: '#2196f3', textDecoration: 'none' }}>
+                                                    {displayName}
+                                                </Link>
+                                            ) : (
+                                                displayName
+                                            )}
+                                        </Typography>
+                                    </StyledTableCell>
+                                    {isUnikTable ? (
+                                        <StyledTableCell key='1'>
+                                            <Typography sx={{ fontSize: 14 }}>
+                                                {(row as any).spacesCount != null ? (row as any).spacesCount : 0}
+                                            </Typography>
+                                        </StyledTableCell>
+                                    ) : (
+                                        <>
+                                            <StyledTableCell key='1'>
+                                                <div
+                                                    style={{
+                                                        display: 'flex',
+                                                        flexDirection: 'row',
+                                                        flexWrap: 'wrap',
+                                                        marginTop: 5
+                                                    }}
+                                                >
+                                                    &nbsp;
+                                                    {(row as any).category &&
+                                                        (row as any).category
+                                                            .split(';')
+                                                            .map((tag: string, tagIndex: number) => (
+                                                                <Chip
+                                                                    key={tagIndex}
+                                                                    label={tag}
+                                                                    style={{ marginRight: 5, marginBottom: 5 }}
+                                                                />
+                                                            ))}
+                                                </div>
+                                            </StyledTableCell>
+                                            <StyledTableCell key='2'>
+                                                {images && images[row.id] && (
+                                                    <Box
+                                                        sx={{
+                                                            display: 'flex',
+                                                            alignItems: 'center',
+                                                            justifyContent: 'start',
+                                                            gap: 1
+                                                        }}
+                                                    >
+                                                        {images[row.id]
+                                                            .slice(0, images[row.id].length > 5 ? 5 : images[row.id].length)
+                                                            .map((img: any) => (
+                                                                <Box
+                                                                    key={img}
+                                                                    sx={{
+                                                                        width: 30,
+                                                                        height: 30,
+                                                                        borderRadius: '50%',
+                                                                        backgroundColor: customization.isDarkMode
+                                                                            ? theme.palette.common.white
+                                                                            : theme.palette.grey[300] + 75
+                                                                    }}
                                                                 >
-                                                                    {renderActions(row)}
-                                                                </Stack>
-                                                            </StyledTableCell>
-                                                        )}
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        <StyledTableCell key='0'>
+                                                                    <img
+                                                                        style={{
+                                                                            width: '100%',
+                                                                            height: '100%',
+                                                                            padding: 5,
+                                                                            objectFit: 'contain'
+                                                                        }}
+                                                                        alt=''
+                                                                        src={img}
+                                                                    />
+                                                                </Box>
+                                                            ))}
+                                                        {images[row.id].length > 5 && (
                                                             <Typography
                                                                 sx={{
-                                                                    fontSize: 14,
-                                                                    fontWeight: 500,
-                                                                    wordBreak: 'break-word',
-                                                                    overflowWrap: 'break-word'
+                                                                    alignItems: 'center',
+                                                                    display: 'flex',
+                                                                    fontSize: '.9rem',
+                                                                    fontWeight: 200
                                                                 }}
                                                             >
-                                                                {linkTarget ? (
-                                                                    <Link
-                                                                        to={linkTarget}
-                                                                        style={{ color: '#2196f3', textDecoration: 'none' }}
-                                                                    >
-                                                                        {displayName}
-                                                                    </Link>
-                                                                ) : (
-                                                                    displayName
-                                                                )}
+                                                                {t('common:more', { count: images[row.id].length - 5 })}
                                                             </Typography>
-                                                        </StyledTableCell>
-                                                        {isUnikTable ? (
-                                                            <StyledTableCell key='1'>
-                                                                <Typography sx={{ fontSize: 14 }}>
-                                                                    {(row as any).spacesCount != null ? (row as any).spacesCount : 0}
-                                                                </Typography>
-                                                            </StyledTableCell>
-                                                        ) : (
-                                                            <>
-                                                                <StyledTableCell key='1'>
-                                                                    <div
-                                                                        style={{
-                                                                            display: 'flex',
-                                                                            flexDirection: 'row',
-                                                                            flexWrap: 'wrap',
-                                                                            marginTop: 5
-                                                                        }}
-                                                                    >
-                                                                        &nbsp;
-                                                                        {(row as any).category &&
-                                                                            (row as any).category
-                                                                                .split(';')
-                                                                                .map((tag: string, tagIndex: number) => (
-                                                                                    <Chip
-                                                                                        key={tagIndex}
-                                                                                        label={tag}
-                                                                                        style={{ marginRight: 5, marginBottom: 5 }}
-                                                                                    />
-                                                                                ))}
-                                                                    </div>
-                                                                </StyledTableCell>
-                                                                <StyledTableCell key='2'>
-                                                                    {images && images[row.id] && (
-                                                                        <Box
-                                                                            sx={{
-                                                                                display: 'flex',
-                                                                                alignItems: 'center',
-                                                                                justifyContent: 'start',
-                                                                                gap: 1
-                                                                            }}
-                                                                        >
-                                                                            {images[row.id]
-                                                                                .slice(
-                                                                                    0,
-                                                                                    images[row.id].length > 5 ? 5 : images[row.id].length
-                                                                                )
-                                                                                .map((img: any) => (
-                                                                                    <Box
-                                                                                        key={img}
-                                                                                        sx={{
-                                                                                            width: 30,
-                                                                                            height: 30,
-                                                                                            borderRadius: '50%',
-                                                                                            backgroundColor: customization.isDarkMode
-                                                                                                ? theme.palette.common.white
-                                                                                                : theme.palette.grey[300] + 75
-                                                                                        }}
-                                                                                    >
-                                                                                        <img
-                                                                                            style={{
-                                                                                                width: '100%',
-                                                                                                height: '100%',
-                                                                                                padding: 5,
-                                                                                                objectFit: 'contain'
-                                                                                            }}
-                                                                                            alt=''
-                                                                                            src={img}
-                                                                                        />
-                                                                                    </Box>
-                                                                                ))}
-                                                                            {images[row.id].length > 5 && (
-                                                                                <Typography
-                                                                                    sx={{
-                                                                                        alignItems: 'center',
-                                                                                        display: 'flex',
-                                                                                        fontSize: '.9rem',
-                                                                                        fontWeight: 200
-                                                                                    }}
-                                                                                >
-                                                                                    {t('common:more', { count: images[row.id].length - 5 })}
-                                                                                </Typography>
-                                                                            )}
-                                                                        </Box>
-                                                                    )}
-                                                                </StyledTableCell>
-                                                            </>
                                                         )}
-                                                        <StyledTableCell key='3'>
-                                                            {formatDate(normalizedUpdatedDate, 'full')}
-                                                        </StyledTableCell>
-                                                        <StyledTableCell key='4'>
-                                                            <Stack
-                                                                direction={{ xs: 'column', sm: 'row' }}
-                                                                spacing={1}
-                                                                justifyContent='center'
-                                                                alignItems='center'
-                                                            >
-                                                                {renderActions ? (
-                                                                    renderActions(row)
-                                                                ) : (
-                                                                    <FlowListMenu
-                                                                        isAgentCanvas={isAgentCanvas}
-                                                                        canvas={row as any}
-                                                                        setError={setError}
-                                                                        updateFlowsApi={updateFlowsApi}
-                                                                    />
-                                                                )}
-                                                            </Stack>
-                                                        </StyledTableCell>
-                                                    </>
+                                                    </Box>
                                                 )}
-                                            </StyledTableRow>
-                                            {expansionContent &&
-                                                (() => {
-                                                    const totalCols = (columnsToRender?.length ?? 5) + (renderActions ? 1 : 0)
-                                                    return (
-                                                        <TableRow>
-                                                            <TableCell
-                                                                colSpan={totalCols}
-                                                                sx={{ py: 0, px: 0, borderBottom: '1px solid', borderColor: 'divider' }}
-                                                            >
-                                                                {expansionContent}
-                                                            </TableCell>
-                                                        </TableRow>
-                                                    )
-                                                })()}
-                                        </React.Fragment>
-                                    )
-                                })}
+                                            </StyledTableCell>
+                                        </>
+                                    )}
+                                    <StyledTableCell key='3'>{formatDate(normalizedUpdatedDate, 'full')}</StyledTableCell>
+                                    <StyledTableCell key='4'>
+                                        <Stack
+                                            direction={{ xs: 'column', sm: 'row' }}
+                                            spacing={1}
+                                            justifyContent='center'
+                                            alignItems='center'
+                                        >
+                                            {renderActions ? (
+                                                renderActions(row)
+                                            ) : (
+                                                <FlowListMenu
+                                                    isAgentCanvas={isAgentCanvas}
+                                                    canvas={row as any}
+                                                    setError={setError}
+                                                    updateFlowsApi={updateFlowsApi}
+                                                />
+                                            )}
+                                        </Stack>
+                                    </StyledTableCell>
+                                </>
+                            )
+                        }
+
+                        // Total column count (for expansion row colSpan)
+                        const totalCols =
+                            (columnsToRender?.length ?? 5) + (renderActions ? 1 : 0) + (sortableRows ? 1 : 0)
+
+                        // Loading skeleton
+                        const skeletonContent = (
+                            <>
+                                <StyledTableRow>
+                                    {sortableRows && <StyledTableCell><Skeleton variant='text' /></StyledTableCell>}
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                </StyledTableRow>
+                                <StyledTableRow>
+                                    {sortableRows && <StyledTableCell><Skeleton variant='text' /></StyledTableCell>}
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                    <StyledTableCell><Skeleton variant='text' /></StyledTableCell>
+                                </StyledTableRow>
                             </>
-                        )}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-        </>
+                        )
+
+                        // Data rows
+                        const dataRows = displayData.map((row, index) => {
+                            const expansionContent = renderRowExpansion ? renderRowExpansion(row, index) : null
+                            const hasExpansion = Boolean(expansionContent)
+
+                            const rowContent = (
+                                <React.Fragment key={row.id}>
+                                    {sortableRows ? (
+                                        <SortableTableRow
+                                            id={row.id}
+                                            disabled={dragDisabled}
+                                            hasExpansion={hasExpansion}
+                                            dragHandleAriaLabel={dragHandleAriaLabel}
+                                        >
+                                            {renderRowCells(row, index)}
+                                        </SortableTableRow>
+                                    ) : (
+                                        <StyledTableRow
+                                            sx={hasExpansion ? { '& td, & th': { borderBottom: 0 } } : undefined}
+                                        >
+                                            {renderRowCells(row, index)}
+                                        </StyledTableRow>
+                                    )}
+                                    {expansionContent && (
+                                        <TableRow>
+                                            <TableCell
+                                                colSpan={totalCols}
+                                                sx={{ py: 0, px: 0, borderBottom: '1px solid', borderColor: 'divider' }}
+                                            >
+                                                {expansionContent}
+                                            </TableCell>
+                                        </TableRow>
+                                    )}
+                                </React.Fragment>
+                            )
+                            return rowContent
+                        })
+
+                        const bodyContent = isLoading ? skeletonContent : dataRows
+
+                        // Wrap in SortableTableBody or plain TableBody
+                        if (sortableRows) {
+                            return (
+                                <SortableTableBody
+                                    itemIds={effectiveSortableIds}
+                                    droppableContainerId={droppableContainerId}
+                                >
+                                    {bodyContent}
+                                </SortableTableBody>
+                            )
+                        }
+                        return <TableBody>{bodyContent}</TableBody>
+                    })()}
+            </Table>
+        </TableContainer>
     )
+
+    // When DnD is enabled and no external DndContext, wrap with InternalDndWrapper
+    if (sortableRows && !externalDndContext) {
+        return (
+            <InternalDndWrapper
+                onDragStart={onSortableDragStart}
+                onDragEnd={onSortableDragEnd}
+                onDragOver={onSortableDragOver}
+                onDragCancel={onSortableDragCancel}
+                renderDragOverlay={renderDragOverlay}
+            >
+                {tableElement}
+            </InternalDndWrapper>
+        )
+    }
+
+    return tableElement
 }
 
 export default FlowListTable

--- a/packages/universo-template-mui/base/src/components/table/FlowListTableDnd.tsx
+++ b/packages/universo-template-mui/base/src/components/table/FlowListTableDnd.tsx
@@ -1,0 +1,214 @@
+/**
+ * Internal DnD building blocks for FlowListTable.
+ *
+ * These components are used internally by FlowListTable when `sortableRows` is enabled.
+ * They should NOT be imported directly — use FlowListTable with DnD props instead.
+ */
+import React, { useCallback, useState } from 'react'
+import {
+    DndContext,
+    DragOverlay,
+    PointerSensor,
+    KeyboardSensor,
+    useSensors,
+    useSensor,
+    closestCenter,
+    MeasuringStrategy
+} from '@dnd-kit/core'
+import type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy, useSortable, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { useDroppable } from '@dnd-kit/core'
+import { TableBody } from '@mui/material'
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
+import { StyledTableCell, StyledTableRow } from './FlowListTable'
+
+// ---------------------------------------------------------------------------
+// SortableTableRow — wraps a single table row with useSortable
+// ---------------------------------------------------------------------------
+
+interface SortableTableRowProps {
+    id: string
+    disabled?: boolean
+    children: React.ReactNode
+    /** Hide bottom border when expansion content follows */
+    hasExpansion?: boolean
+    /** Accessible label for the drag handle */
+    dragHandleAriaLabel?: string
+}
+
+export const SortableTableRow: React.FC<SortableTableRowProps> = ({
+    id,
+    disabled = false,
+    children,
+    hasExpansion = false,
+    dragHandleAriaLabel
+}) => {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id, disabled })
+
+    const style: React.CSSProperties = {
+        transform: CSS.Translate.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+        cursor: disabled ? 'default' : 'grab',
+        position: 'relative',
+        zIndex: isDragging ? 1 : 'auto'
+    }
+
+    return (
+        <StyledTableRow
+            ref={setNodeRef}
+            style={style}
+            sx={hasExpansion ? { '& td, & th': { borderBottom: 0 } } : undefined}
+            {...attributes}
+        >
+            {/* Drag handle column */}
+            <StyledTableCell
+                align='center'
+                sx={{ width: 40, px: 0.5, cursor: disabled ? 'default' : 'grab', verticalAlign: 'middle' }}
+                aria-label={dragHandleAriaLabel}
+                {...listeners}
+            >
+                <DragIndicatorIcon
+                    fontSize='small'
+                    sx={{
+                        color: disabled ? 'action.disabled' : 'action.active',
+                        '&:hover': disabled ? {} : { color: 'primary.main' }
+                    }}
+                />
+            </StyledTableCell>
+            {children}
+        </StyledTableRow>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// SortableTableBody — wraps TableBody with SortableContext + optional droppable
+// ---------------------------------------------------------------------------
+
+interface SortableTableBodyProps {
+    itemIds: string[]
+    /** Container ID for useDroppable (for multi-container DnD). */
+    droppableContainerId?: string
+    children: React.ReactNode
+}
+
+/**
+ * Droppable variant: uses useDroppable for multi-container DnD scenarios.
+ */
+const DroppableSortableBody: React.FC<SortableTableBodyProps & { containerId: string }> = ({
+    itemIds,
+    containerId,
+    children
+}) => {
+    const { setNodeRef } = useDroppable({ id: containerId })
+    return (
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+            <TableBody ref={setNodeRef}>{children}</TableBody>
+        </SortableContext>
+    )
+}
+
+/**
+ * Standard variant: wraps rows in SortableContext without droppable.
+ */
+const SimpleSortableBody: React.FC<Omit<SortableTableBodyProps, 'droppableContainerId'>> = ({ itemIds, children }) => {
+    return (
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+            <TableBody>{children}</TableBody>
+        </SortableContext>
+    )
+}
+
+export const SortableTableBody: React.FC<SortableTableBodyProps> = ({ itemIds, droppableContainerId, children }) => {
+    if (droppableContainerId) {
+        return (
+            <DroppableSortableBody itemIds={itemIds} containerId={droppableContainerId}>
+                {children}
+            </DroppableSortableBody>
+        )
+    }
+    return <SimpleSortableBody itemIds={itemIds}>{children}</SimpleSortableBody>
+}
+
+// ---------------------------------------------------------------------------
+// InternalDndWrapper — wraps content with DndContext + sensors + DragOverlay
+// Used when FlowListTable manages its own DnD context (externalDndContext=false)
+// ---------------------------------------------------------------------------
+
+interface InternalDndWrapperProps {
+    children: React.ReactNode
+    onDragStart?: (event: DragStartEvent) => void
+    onDragEnd?: (event: DragEndEvent) => void
+    onDragOver?: (event: DragOverEvent) => void
+    onDragCancel?: () => void
+    renderDragOverlay?: (activeId: string | null) => React.ReactNode
+}
+
+export const InternalDndWrapper: React.FC<InternalDndWrapperProps> = ({
+    children,
+    onDragStart,
+    onDragEnd,
+    onDragOver,
+    onDragCancel,
+    renderDragOverlay
+}) => {
+    const [activeId, setActiveId] = useState<string | null>(null)
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 8 }
+        }),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates
+        })
+    )
+
+    const handleDragStart = useCallback(
+        (event: DragStartEvent) => {
+            setActiveId(String(event.active.id))
+            onDragStart?.(event)
+        },
+        [onDragStart]
+    )
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            setActiveId(null)
+            onDragEnd?.(event)
+        },
+        [onDragEnd]
+    )
+
+    const handleDragOver = useCallback(
+        (event: DragOverEvent) => {
+            onDragOver?.(event)
+        },
+        [onDragOver]
+    )
+
+    const handleDragCancel = useCallback(() => {
+        setActiveId(null)
+        onDragCancel?.()
+    }, [onDragCancel])
+
+    return (
+        <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+            accessibility={{ container: document.body }}
+            measuring={{
+                droppable: { strategy: MeasuringStrategy.Always }
+            }}
+        >
+            {children}
+            <DragOverlay dropAnimation={null}>
+                {renderDragOverlay ? renderDragOverlay(activeId) : null}
+            </DragOverlay>
+        </DndContext>
+    )
+}

--- a/packages/universo-template-mui/base/src/components/table/FlowListTableDnd.tsx
+++ b/packages/universo-template-mui/base/src/components/table/FlowListTableDnd.tsx
@@ -60,13 +60,13 @@ export const SortableTableRow: React.FC<SortableTableRowProps> = ({
             ref={setNodeRef}
             style={style}
             sx={hasExpansion ? { '& td, & th': { borderBottom: 0 } } : undefined}
-            {...attributes}
         >
-            {/* Drag handle column */}
+            {/* Drag handle column — attributes + listeners must be on the same focusable element for keyboard DnD */}
             <StyledTableCell
                 align='center'
                 sx={{ width: 40, px: 0.5, cursor: disabled ? 'default' : 'grab', verticalAlign: 'middle' }}
                 aria-label={dragHandleAriaLabel}
+                {...attributes}
                 {...listeners}
             >
                 <DragIndicatorIcon

--- a/packages/universo-template-mui/base/src/index.ts
+++ b/packages/universo-template-mui/base/src/index.ts
@@ -28,6 +28,8 @@ export {
     ErrorBoundary,
     MarketplaceTable,
     FlowListTable,
+    StyledTableCell,
+    StyledTableRow,
     CompactListTable,
     TableViewOnly,
     ToolsTable,
@@ -67,6 +69,8 @@ export type {
     FilterValues,
     FilterToolbarProps
 } from './components'
+// Re-export DnD event types so FlowListTable DnD consumers can import them directly
+export type { DragStartEvent, DragEndEvent, DragOverEvent } from '@dnd-kit/core'
 
 // Re-export dialogs (EntityFormDialog, ConfirmDialog, etc.) so consumers can import from '@universo/template-mui'
 export * from './components/dialogs'

--- a/packages/universo-template-mui/base/src/store/actions.ts
+++ b/packages/universo-template-mui/base/src/store/actions.ts
@@ -12,6 +12,8 @@ export interface ConfirmPayload {
     confirmButtonName?: string
     cancelButtonName?: string
     customBtnId?: string
+    /** When true, hides the Cancel button — useful for info-only dialogs */
+    hideCancelButton?: boolean
 }
 
 export type ConfirmAction = { type: typeof SHOW_CONFIRM; payload: ConfirmPayload } | { type: typeof HIDE_CONFIRM }

--- a/packages/universo-template-mui/base/src/store/reducers/confirmReducer.ts
+++ b/packages/universo-template-mui/base/src/store/reducers/confirmReducer.ts
@@ -10,7 +10,8 @@ export const initialState: ConfirmState = {
     description: '',
     confirmButtonName: 'OK',
     cancelButtonName: 'Cancel',
-    customBtnId: ''
+    customBtnId: '',
+    hideCancelButton: false
 }
 
 const confirmReducer = (state: ConfirmState = initialState, action: ConfirmAction): ConfirmState => {
@@ -22,7 +23,8 @@ const confirmReducer = (state: ConfirmState = initialState, action: ConfirmActio
                 description: action.payload.description,
                 confirmButtonName: action.payload.confirmButtonName,
                 cancelButtonName: action.payload.cancelButtonName,
-                customBtnId: action.payload.customBtnId || 'btn_confirm'
+                customBtnId: action.payload.customBtnId || 'btn_confirm',
+                hideCancelButton: action.payload.hideCancelButton
             }
         case HIDE_CONFIRM:
             return initialState

--- a/packages/universo-template-mui/base/tsdown.config.ts
+++ b/packages/universo-template-mui/base/tsdown.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     /^use-sync-external-store(\/.*)?$/,
     'canvas',  // Native module from transitive dependency
     /^@flowise\/executions-frontend(\/.*)?$/,
+    /^@dnd-kit\//,
     /^@ui\//,  // Imports from flowise-ui via @ui alias
     /^@mui\//,
     /^@emotion\//,

--- a/packages/universo-types/base/src/common/metahubs.ts
+++ b/packages/universo-types/base/src/common/metahubs.ts
@@ -232,6 +232,20 @@ export const METAHUB_SETTINGS_REGISTRY: readonly SettingDefinition[] = [
         defaultValue: true,
         sortOrder: 9
     },
+    {
+        key: 'catalogs.allowAttributeMoveBetweenRootAndChildren',
+        tab: 'catalogs',
+        valueType: 'boolean',
+        defaultValue: true,
+        sortOrder: 10
+    },
+    {
+        key: 'catalogs.allowAttributeMoveBetweenChildLists',
+        tab: 'catalogs',
+        valueType: 'boolean',
+        defaultValue: true,
+        sortOrder: 11
+    },
 
     // ── Enumerations ──
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4793,6 +4793,15 @@ importers:
 
   packages/universo-template-mui/base:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^8.0.0
+        version: 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@18.3.27)(react@18.3.1)


### PR DESCRIPTION
Fixes #703

# Description

Implement a complete drag-and-drop (DnD) system for catalog attributes and enumeration values in the Metahubs module. This includes same-list reordering, cross-list transfers between root and child TABLE attribute lists, codename conflict resolution, ghost row previews, and optimistic cache updates with rollback.

## Changes Made

- **Multi-container Attribute DnD**: Same-list reorder for root attributes + cross-list transfers between root and child (TABLE) attribute lists with ghost row insertion preview
- **Validation layer**: Display attribute transfer block, TABLE-only-at-root constraint, codename conflict dialog with auto-rename, first-child confirmation
- **Backend reorder endpoints**: PATCH endpoints for attributes and enumeration values with sort order normalization, cross-list validation, codename uniqueness with auto-rename retry loop
- **Single-container Enum Value DnD**: Reorder enumeration values within a single list
- **Shared DnD infrastructure**: Generic `FlowListTableDnd.tsx` with `SortableTableRow`, `SortableTableBody`, `InternalDndWrapper` in `universo-template-mui`
- **FlowListTable extensions**: 12 DnD-specific props for external and internal DnD contexts
- **Dialog enhancements**: `hideCancelButton` prop for `ConfirmDialog`, `disabledFields` prop for `EntityFormDialog`
- **Optimistic cache updates**: Both same-list and cross-list mutations with rollback on error, pre-extracted movedItem pattern for reliable optimistic updates
- **i18n**: Full EN + RU translations for all DnD-related messages
- **Dependencies**: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`

## Additional Work

- Memory bank updates (activeContext.md, progress.md, tasks.md)
- DnD implementation plan document (memory-bank/plan/)
- Backend route tests for reorder endpoints
- `codenameStyleHelper.ts` utility for codename conflict resolution
- `universo-types` metahubs type extensions for reorder payloads

## Testing

- [x] Manual testing completed
- [x] Automated tests pass (97/97 metahubs-backend tests)
- [x] Lint passes (0 errors)
- [x] Full project build passes
- [x] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #703

# Описание

Реализована полная система перетаскивания (DnD) для атрибутов каталогов и значений перечислений в модуле Metahubs. Включает переупорядочивание в одном списке, кросс-списочные переносы между корневыми и дочерними TABLE-списками атрибутов, разрешение конфликтов codename, предпросмотр призрачных строк и оптимистичные обновления кеша с откатом.

## Внесенные изменения

- **Мульти-контейнерный DnD атрибутов**: Переупорядочивание в одном списке для корневых атрибутов + кросс-списочные переносы между корневыми и дочерними (TABLE) списками атрибутов с предпросмотром призрачной строки вставки
- **Слой валидации**: Блокировка переноса display-атрибута, ограничение TABLE-только-на-корневом-уровне, диалог конфликта codename с автопереименованием, подтверждение для первого дочернего элемента
- **Бэкенд-эндпоинты переупорядочивания**: PATCH-эндпоинты для атрибутов и значений перечислений с нормализацией порядка сортировки, кросс-списочной валидацией, уникальностью codename с циклом повторных попыток автопереименования
- **Одноконтейнерный DnD значений перечислений**: Переупорядочивание значений перечислений в одном списке
- **Общая DnD-инфраструктура**: Универсальный `FlowListTableDnd.tsx` с `SortableTableRow`, `SortableTableBody`, `InternalDndWrapper` в `universo-template-mui`
- **Расширения FlowListTable**: 12 DnD-специфичных пропсов для внешнего и внутреннего DnD-контекстов
- **Улучшения диалогов**: Проп `hideCancelButton` для `ConfirmDialog`, проп `disabledFields` для `EntityFormDialog`
- **Оптимистичные обновления кеша**: Мутации как в одном списке, так и кросс-списочные с откатом при ошибке, паттерн предварительного извлечения movedItem для надёжных оптимистичных обновлений
- **i18n**: Полные EN + RU переводы для всех DnD-сообщений
- **Зависимости**: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`

## Дополнительная работа

- Обновления банка памяти (activeContext.md, progress.md, tasks.md)
- Документ плана реализации DnD (memory-bank/plan/)
- Тесты бэкенд-маршрутов для эндпоинтов переупорядочивания
- Утилита `codenameStyleHelper.ts` для разрешения конфликтов codename
- Расширения типов metahubs в `universo-types` для payload-ов переупорядочивания

## Тестирование

- [x] Ручное тестирование выполнено
- [x] Автоматические тесты проходят (97/97 тестов metahubs-backend)
- [x] Линтинг проходит (0 ошибок)
- [x] Полная сборка проекта проходит
- [x] Нет нарушающих изменений
</details>