### PR TITLE
GH732 Implement automatic bootstrap superuser creation on first startup

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -159,8 +159,14 @@ Universo Platformo разрабатывается на нескольких те
         ```
         SUPABASE_URL=your_supabase_url
         SUPABASE_ANON_KEY=your_supabase_anon_key
+        SERVICE_ROLE_KEY=your_server_only_service_role_key
         SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+        BOOTSTRAP_SUPERUSER_ENABLED=true
+        BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+        BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
         ```
+    - `SERVICE_ROLE_KEY` обязателен для server-side provisioning-задач, включая стартовый bootstrap суперпользователя и создание пользователей из админ-панели.
+    - `BOOTSTRAP_SUPERUSER_EMAIL` и `BOOTSTRAP_SUPERUSER_PASSWORD` являются demo credentials только для первого локального bootstrap. Перед любым реальным развёртыванием обязательно замените их.
     - При необходимости создайте `.env` в `packages/universo-core-frontend/base` для UI-специфичных настроек, например `VITE_PORT`.
 
 4. Соберите workspace.

--- a/README.md
+++ b/README.md
@@ -159,8 +159,14 @@ Each implementation shares the same strategic direction, and the high-level abst
         ```
         SUPABASE_URL=your_supabase_url
         SUPABASE_ANON_KEY=your_supabase_anon_key
+        SERVICE_ROLE_KEY=your_server_only_service_role_key
         SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+        BOOTSTRAP_SUPERUSER_ENABLED=true
+        BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+        BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
         ```
+    - `SERVICE_ROLE_KEY` is required for server-side provisioning tasks such as startup superuser bootstrap and admin-side user creation.
+    - `BOOTSTRAP_SUPERUSER_EMAIL` and `BOOTSTRAP_SUPERUSER_PASSWORD` are demo credentials for first local bootstrap only. Change both before any real deployment.
     - Optionally create `.env` in `packages/universo-core-frontend/base` for UI-specific settings such as `VITE_PORT`.
 
 4. Build the workspace.

--- a/docs/en/architecture/auth.md
+++ b/docs/en/architecture/auth.md
@@ -13,6 +13,19 @@ identity and request-scoped database context.
 - Frontend auth helpers and UI flows live in `@universo/auth-frontend`.
 - Clients use session-aware requests and CSRF protection.
 - Request-scoped RLS context is applied for protected database operations.
+- Server-side provisioning flows use the Supabase Admin API through a server-only client built from `SUPABASE_URL` + `SERVICE_ROLE_KEY`.
+
+## Startup Superuser Bootstrap
+
+During the first platform startup, `@universo/core-backend` can automatically create or confirm a bootstrap superuser when `BOOTSTRAP_SUPERUSER_ENABLED=true`.
+
+The flow is intentionally strict:
+
+- It creates a real Supabase auth account through `supabase.auth.admin.createUser(...)`.
+- It repairs the profile row through the shared profile service if the trigger-created row is missing.
+- It assigns the exclusive global `superuser` role through the shared admin provisioning pipeline.
+- It does not synthesize public-registration legal-consent acceptance.
+- It fails fast if the configured bootstrap email already belongs to an existing non-superuser account.
 
 ## Important Contracts
 

--- a/docs/en/getting-started/configuration.md
+++ b/docs/en/getting-started/configuration.md
@@ -13,6 +13,26 @@ Typical values include the Supabase URL, anonymous key, JWT secret, database
 connection settings, session configuration, and other deployment-specific
 secrets.
 
+Minimum backend contract for first startup:
+
+```env
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your_public_anon_key
+SERVICE_ROLE_KEY=your_server_only_service_role_key
+SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+BOOTSTRAP_SUPERUSER_ENABLED=true
+BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
+```
+
+Important notes:
+
+- `SERVICE_ROLE_KEY` is server-only. Never expose it to browser bundles.
+- `BOOTSTRAP_SUPERUSER_ENABLED` defaults to `true`.
+- When bootstrap is enabled, the backend creates or confirms a real Supabase auth user and assigns the exclusive global `superuser` role during startup.
+- The demo bootstrap email and password are for local/dev bootstrap only. Change both before any real deployment.
+- If the bootstrap email already belongs to an existing non-superuser account, startup fails fast instead of silently elevating that account.
+
 ## Frontend Environment
 
 If you need frontend overrides, create a local `.env` file in

--- a/docs/ru/architecture/auth.md
+++ b/docs/ru/architecture/auth.md
@@ -13,6 +13,19 @@ description: Описывает аутентификацию, сессии, CSRF
 - Фронтенд-хелперы auth и UI-потоки живут в `@universo/auth-frontend`.
 - Клиенты используют запросы с учётом сессии и CSRF-защиту.
 - Для защищённых операций с базой применяется RLS-контекст, привязанный к запросу.
+- Server-side provisioning-потоки используют Supabase Admin API через server-only client, собранный из `SUPABASE_URL` + `SERVICE_ROLE_KEY`.
+
+## Стартовый bootstrap суперпользователя
+
+Во время первого запуска платформы `@universo/core-backend` может автоматически создать или подтвердить bootstrap superuser, если `BOOTSTRAP_SUPERUSER_ENABLED=true`.
+
+Этот поток намеренно строгий:
+
+- создаёт реальный Supabase auth account через `supabase.auth.admin.createUser(...)`;
+- восстанавливает profile row через общий profile service, если триггерный профиль отсутствует;
+- назначает эксклюзивную глобальную роль `superuser` через общий admin provisioning pipeline;
+- не имитирует acceptance legal-consent из публичной регистрации;
+- завершает старт явной ошибкой, если настроенный bootstrap email уже принадлежит существующему non-superuser аккаунту.
 
 ## Важные контракты
 

--- a/docs/ru/getting-started/configuration.md
+++ b/docs/ru/getting-started/configuration.md
@@ -13,6 +13,26 @@ description: Настройте бэкенд- и фронтенд-конфигу
 подключения к базе, конфигурация сессий и другие секреты конкретного
 развёртывания.
 
+Минимальный backend-контракт для первого запуска:
+
+```env
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your_public_anon_key
+SERVICE_ROLE_KEY=your_server_only_service_role_key
+SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+BOOTSTRAP_SUPERUSER_ENABLED=true
+BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
+```
+
+Важные замечания:
+
+- `SERVICE_ROLE_KEY` является строго server-only секретом. Никогда не отдавайте его в browser bundle.
+- `BOOTSTRAP_SUPERUSER_ENABLED` по умолчанию равен `true`.
+- Когда bootstrap включён, backend во время старта создаёт или подтверждает реального Supabase auth user и назначает ему эксклюзивную глобальную роль `superuser`.
+- Demo bootstrap email и пароль предназначены только для local/dev bootstrap. Перед любым реальным развёртыванием обязательно замените их.
+- Если bootstrap email уже принадлежит существующему non-superuser аккаунту, старт завершится явной ошибкой вместо молчаливого повышения привилегий.
+
 ## Окружение фронтенда
 
 Если нужны переопределения для фронтенда, создайте локальный `.env` в

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -4,7 +4,63 @@
 
 ---
 
-## Current Focus: QA Comprehensive Fix — Complete
+## Current Focus: Bootstrap Superuser Final QA Remediation — Complete
+
+- Date: 2026-03-20.
+- Closed the final QA remediation wave for bootstrap superuser by fixing the remaining operational template defect and proving the live Supabase integration suite with the real client instead of the global Jest mock.
+- The bootstrap env contract is now internally consistent end to end:
+  1. `.env.example` uses `demo-admin@example.com` / `ChangeMe_123456!`.
+  2. The runtime warning in `bootstrapSuperuser.ts` watches the same demo credentials.
+  3. Root/package README files and GitBook docs already point to the same values.
+- The live integration boundary is now genuinely executable in Jest:
+  1. The integration suite imports the real `createClient(...)` via `jest.requireActual('@supabase/supabase-js')`.
+  2. The test no longer reuses the global mocked Supabase client from the shared backend test harness.
+  3. A real `UP-test` run now passes both the bootstrap happy-path and rollback failure-path scenarios.
+- Validation: live `@universo/admin-backend` integration suite passed (2/2) against `UP-test`, focused admin regression suites passed (23/23), focused core bootstrap tests passed (6/6), and touched admin lint stayed green on errors with the same pre-existing warning-only debt outside this closure.
+
+## Previous Focus: Bootstrap Superuser QA Reopen Closure — Complete
+
+- Date: 2026-03-19.
+- Closed the second QA reopen for startup bootstrap and admin-side provisioning by removing the last rollback consistency seam and adding the missing real failure-path coverage.
+- Auth-user provisioning rollback is now privilege-safe end to end:
+  1. Compensation no longer depends on request-scoped RLS sessions.
+  2. Profile cleanup now always runs through the privileged executor before auth-user deletion, so admin create-user failures do not leave orphan active profile rows behind.
+  3. The admin route no longer passes request-scoped cleanup state into the provisioning service.
+- The live Supabase integration suite now covers both edges of the critical external boundary:
+  1. Real bootstrap/provision happy-path against Supabase Auth + profile/role persistence.
+  2. Real rollback behavior when role synchronization fails after auth-user creation, including verification that both auth and profile rows are cleaned up.
+- Startup bootstrap now emits an explicit warning when the public demo bootstrap credentials are still configured, reducing the risk of an unsafe deployment with unchanged defaults.
+- Validation: `@universo/admin-backend` tests `43 passed / 2 skipped / 45 total`, `@universo/core-backend` tests 23/23, touched admin/core lint green with warning-only pre-existing debt outside this change-set, standalone admin/core builds green, final root `pnpm build` green (28/28 tasks in 2m52.491s).
+
+## Previous Focus: Bootstrap Superuser QA Closure — Complete
+
+- Date: 2026-03-19.
+- Closed the post-implementation QA reopen for startup bootstrap and admin-side user provisioning with no remaining open remediation work in that wave.
+- Role-assignment mutation paths are now fail-closed for protected roles:
+  1. Non-superusers cannot assign `superuser` or any `is_system=true` role through `setUserRoles(...)`.
+  2. Non-superusers cannot use legacy `grantRole(...)` to promote another account into `superuser` / system-role state.
+  3. Non-superusers cannot revoke or downgrade an account that currently holds a protected role through `revokeGlobalAccess(...)`, `revokeAssignment(...)`, or the legacy single-role update path.
+- The shared provisioning service now has deeper regression coverage for invite-based provisioning (`inviteUserByEmail(...)`) in addition to password-based admin creation, rollback, bootstrap no-op, and bootstrap fail-fast behavior.
+- `@universo/admin-backend` now also carries an env-gated live integration suite for real Supabase provisioning. It stays skipped in default local/CI runs unless `DATABASE_TEST_URL`, `SUPABASE_URL`, and `SERVICE_ROLE_KEY` are present, but it closes the earlier “mocks only” coverage gap for a real auth/profile/role bootstrap path.
+- Bootstrap config coverage now includes invalid-email rejection, and `.env.example` has been restored to neutral demo credentials: `demo-admin@example.com` / `ChangeMe_123456!`.
+- Validation: `@universo/admin-backend` tests `43 passed / 1 skipped / 44 total`, `@universo/core-backend` tests 22/22, touched admin/core lint green with warning-only pre-existing debt outside this change-set, standalone admin/core builds green, final root `pnpm build` green (28/28 tasks in 2m40.814s).
+
+## Previous Focus: Bootstrap Superuser Startup Closure — Complete
+
+- Date: 2026-03-19.
+- Implemented a shared auth-user provisioning pipeline in `@universo/admin-backend` and moved both startup bootstrap and admin-side create-user onto that same rollback-safe flow.
+- `@universo/core-backend` now runs bootstrap-superuser provisioning during `App.initDatabase()` after migrations/role seed, protected by a transaction-scoped advisory lock and strict env validation.
+- Bootstrap behavior is now fail-closed:
+  1. If `BOOTSTRAP_SUPERUSER_ENABLED=false`, startup skips the feature.
+  2. If bootstrap is enabled but `SUPABASE_URL`, `SERVICE_ROLE_KEY`, email, or password are invalid, startup fails fast before the HTTP server comes up.
+  3. If the configured bootstrap email already belongs to an existing non-superuser account, startup fails instead of silently elevating that account.
+  4. If the account already exists and is already a superuser, startup is a safe no-op that only repairs the missing profile row.
+- The bootstrap flow creates a real Supabase auth user, repairs the profile row through `ProfileService.getOrCreateProfile(...)`, and assigns the exclusive global `superuser` role without synthesizing public-registration legal-consent acceptance.
+- CLI/env parity is now in place for `SERVICE_ROLE_KEY`, `BOOTSTRAP_SUPERUSER_ENABLED`, `BOOTSTRAP_SUPERUSER_EMAIL`, and `BOOTSTRAP_SUPERUSER_PASSWORD`.
+- Docs updated: root README/README-RU, `@universo/core-backend` README/README-RU, `@universo/admin-backend` README/README-RU, and GitBook pages under `docs/en` + `docs/ru`.
+- Validation: `@universo/admin-backend` tests 39/39, `@universo/core-backend` tests 21/21, touched lint green with warning-only pre-existing debt, standalone admin/core builds green, final root `pnpm build` green (28/28 tasks in 3m25.588s).
+
+## Previous Focus: QA Comprehensive Fix — Complete
 
 - Date: 2026-03-19.
 - Applied all 13 code fixes from the comprehensive QA audit (4 CRITICAL, 10 HIGH severity):
@@ -65,7 +121,12 @@
 
 ## Current State
 
+- Startup bootstrap superuser support is now live and documented end-to-end.
+- Shared auth-user provisioning now has one canonical backend path for create-user, profile repair, role sync, and rollback, instead of separate startup/admin implementations.
+- Core backend startup now depends on explicit server-only Supabase provisioning configuration when bootstrap is enabled, and the demo bootstrap credentials are documented as local/dev-only values that must be changed for real deployments.
 - The residual QA follow-through items are closed with no remaining open implementation work in this wave.
+- Protected-role mutation now requires a superuser actor end-to-end across shared role-sync, legacy grant/update paths, and global-access revocation paths.
+- Bootstrap regression coverage now includes invite provisioning and stricter config validation, and the public env template once again ships only neutral demo bootstrap credentials.
 - Shared contracts, backend role lifecycle work, admin frontend refactoring, multi-role user management, onboarding completion flow, explicit `/start` routing, role-aware shell guards, and the new `@universo/metapanel-frontend` package are all in place.
 - Root routing now follows the final UX contract: guests see the landing/start surface on `/`, authenticated `registered`-only users stay on `/start`, authenticated workspace users render the metapanel directly on `/`, and admin-only users are redirected to `/admin` instead of leaking into the workspace shell.
 - The registered-only shell leak is now fail-closed in both shared frontend/backend access contracts: `resolveShellAccess(...)` rejects `registered`-only role sets even when `profile:read` exists, and `hasWorkspaceAccess(...)` mirrors that policy on the backend before capability checks.
@@ -102,6 +163,8 @@
 - AD-16: Post-auth lifecycle helpers must compensate prior writes when later role-assignment steps fail; rollback status should be explicit instead of hidden behind a generic 500.
 - AD-20: Lifecycle system-role seeding/backfill must execute from one canonical migration path, and legacy admin permission rows using `manage` must be normalized because backend SQL helper contracts are defined around exact action or `*`.
 - AD-21: Shared feature-route composition belongs in `@universo/core-frontend`, not in `@universo/template-mui`, when the route graph imports leaf feature packages such as metapanel.
+- AD-22: Startup bootstrap superuser provisioning must reuse the same shared backend provisioning service as admin-side create-user, so auth-user creation, profile repair, role sync, and rollback remain behaviorally identical.
+- AD-23: Automatic startup bootstrap may create a new superuser or confirm an existing superuser, but it must never auto-elevate an existing non-superuser account and must not auto-reset the password of an existing account in v1.
 
 ## Key QA Corrections Applied (v1 → v3)
 

--- a/memory-bank/plan/bootstrap-superuser-startup-plan-2026-03-19.md
+++ b/memory-bank/plan/bootstrap-superuser-startup-plan-2026-03-19.md
@@ -1,0 +1,574 @@
+# Plan: Bootstrap Superuser On First Startup
+
+> **Date**: 2026-03-19
+> **Mode**: PLAN
+> **Status**: DRAFT FOR DISCUSSION
+> **Complexity**: Level 3 (Significant / cross-package backend bootstrap)
+> **Scope**: core-backend startup bootstrap, Supabase Auth Admin provisioning, global-role assignment, profile repair, env contract, tests, README updates, and GitBook documentation
+
+---
+
+## Overview
+
+The platform already creates the fixed data structure and global roles on first startup, but it still requires a manual SQL step to create the first superuser.
+
+The goal of this plan is to add a **safe, idempotent, startup-time superuser bootstrap** controlled by environment variables in `packages/universo-core-backend/base/.env` and `.env.example`.
+
+When enabled, the backend must:
+
+1. Create a **real Supabase Auth user** through `supabase.auth.admin.createUser(...)`.
+2. Ensure the user can sign in immediately as a normal password-based user.
+3. Ensure the user has the **global `superuser` role** in `admin.rel_user_roles`.
+4. Avoid unsafe shortcuts such as direct inserts into `auth.users`.
+5. Remain safe under repeated startup, partial failure, and concurrent startup.
+
+Fresh database recreation is allowed.
+Legacy preservation is not required.
+The implementation should reuse current package boundaries instead of inventing a parallel bootstrap stack.
+
+---
+
+## Additional Findings From The Extra Analysis
+
+### Verified Current Repository Risks
+
+1. **`.env.example` does not document the backend `SERVICE_ROLE_KEY`.**
+   - The backend already uses `SERVICE_ROLE_KEY` to create a server-only Supabase admin client for admin user provisioning.
+   - Without documenting it, the future startup bootstrap will appear broken on a fresh install even though the code path is valid.
+
+2. **`BaseCommand` does not currently support `SERVICE_ROLE_KEY` or future bootstrap env overrides.**
+   - `packages/universo-core-backend/base/src/commands/base.ts` only forwards a subset of env values into `process.env`.
+   - If the feature is implemented only in `.env` but not in CLI overrides, command-based runs and CI flows will drift.
+
+3. **Admin-side user provisioning logic is currently route-local and duplicated in shape.**
+   - `packages/admin-backend/base/src/routes/globalUsersRoutes.ts` already provisions auth users and rolls them back on role assignment failure.
+   - Startup bootstrap would currently duplicate the same create-user / role-sync / rollback logic unless it is extracted.
+
+4. **Admin-side provisioning currently trusts the `auth.users -> profiles.cat_profiles` trigger without explicit repair.**
+   - Public registration performs an additional profile update / upsert safety pass.
+   - Admin provisioning and the future startup bootstrap do not currently verify that a profile row exists after auth user creation.
+   - This is a correctness gap for partial-trigger or timing issues.
+
+5. **`ProfileService` already contains the correct profile repair primitive.**
+   - `ProfileService.getOrCreateProfile(userId, email)` can create a safe fallback nickname and recover missing profile rows.
+   - The bootstrap plan should reuse this service instead of creating a second nickname/profile repair implementation.
+
+6. **The repository already has an advisory-lock helper suitable for bootstrap serialization.**
+   - `@universo/utils/database` exports `withAdvisoryLock(...)`.
+   - That gives us an existing concurrency control primitive for multi-instance startup without creating a custom lock subsystem.
+
+7. **Current documentation structure is only partially populated.**
+   - `docs/en/SUMMARY.md` and `docs/ru/SUMMARY.md` reference many GitBook pages that do not yet exist in the workspace.
+   - The documentation phase must therefore include both updating existing docs and creating missing GitBook pages where this feature belongs.
+
+8. **The current `.cursor/rules/i18n-docs.mdc` rule file is not present in the workspace.**
+   - The repository instructions refer to it, but the file is not available at the expected path.
+   - The docs phase should follow the current GitBook structure in `docs/` and keep EN canonical + RU synchronized unless the missing rule file is restored later.
+
+9. **`AUTH_EMAIL_CONFIRMATION_REQUIRED` is a UI/feature-toggle contract, not the actual confirmation source of truth.**
+   - The real confirmed state is carried by Supabase Auth user fields.
+   - Using `email_confirm: true` during bootstrap is therefore architecturally correct for an immediately usable bootstrap admin account.
+
+10. **The startup bootstrap should not silently elevate arbitrary pre-existing users.**
+    - If the configured bootstrap email already belongs to an unrelated account, blindly granting `superuser` would be unsafe.
+    - The plan must define explicit takeover / repair rules for existing users.
+
+---
+
+## External Research Notes
+
+### Supabase Docs / Official Guidance
+
+1. `auth.admin.createUser()` is a **server-only** operation and should never expose the `service_role` key in the browser.
+2. `createUser()` does **not** send a confirmation email; `inviteUserByEmail()` is the invite path.
+3. `email_confirm: true` is the documented way to create an immediately confirmed password user.
+4. Supabase recommends a **separate server-side service-role client** with `persistSession: false` and `autoRefreshToken: false`.
+5. Supabase explicitly warns not to use normal auth flows like `signUp()` from a service-role client when you intend to provision users; the correct path is `admin.createUser()`.
+
+### Inference For This Repository
+
+The safest repository-aligned approach is:
+
+- create a dedicated startup-only admin client,
+- serialize bootstrap with an advisory lock,
+- reuse current SQL-first role and profile services for repository state,
+- and keep all `auth.users` writes behind Supabase Admin API only.
+
+---
+
+## Affected Areas
+
+| Area | Package / Location | Planned Responsibility |
+|---|---|---|
+| Startup lifecycle | `packages/universo-core-backend/base/src/index.ts` | Trigger bootstrap after migrations and fixed-role seed |
+| Startup config | `packages/universo-core-backend/base/.env.example`, `.env`, `src/commands/base.ts` | Add env contract and CLI parity |
+| Shared provisioning logic | `packages/admin-backend/base/src/services/*` | Extract reusable auth-user provisioning / rollback / role-sync helper |
+| Global access / role assignment | `packages/admin-backend/base/src/services/globalAccessService.ts` | Reuse or extend role resolution / superuser sync helpers |
+| Profile repair | `packages/profile-backend/base/src/services/profileService.ts` | Reuse existing `getOrCreateProfile()` |
+| Auth route parity | `packages/auth-backend/base/src/routes/auth.ts` | Keep semantics aligned, avoid divergent cleanup / repair logic |
+| Core-backend tests | `packages/universo-core-backend/base/src/__tests__/App.initDatabase.test.ts` | Add startup bootstrap test coverage |
+| Admin-backend tests | `packages/admin-backend/base/src/tests/routes/dashboardAndGlobalUsersRoutes.test.ts` and new service tests | Cover shared provisioning helper and route reuse |
+| README docs | root `README.md`, `README-RU.md`, package READMEs | Document env, security warnings, first-run behavior |
+| GitBook docs | `docs/en/*`, `docs/ru/*`, `SUMMARY.md` | Add configuration/auth/bootstrap documentation |
+
+---
+
+## Architecture Decisions
+
+### 1. Provision The Bootstrap User Through Supabase Admin API Only
+
+Do not write directly into `auth.users`.
+Do not build a SQL-only side-channel for auth identity creation.
+
+**Decision**:
+
+- use `supabase.auth.admin.createUser(...)` for new bootstrap users,
+- use `supabase.auth.admin.updateUserById(...)` only for explicit repair actions that we intentionally support,
+- use `supabase.auth.admin.deleteUser(...)` for rollback of a freshly provisioned user on failure.
+
+### 2. Keep Startup Config Local To Core Backend
+
+The bootstrap env contract is **server-only** and specific to startup behavior.
+It should not be exported to frontend bundles or general browser runtime env helpers.
+
+**Decision**:
+
+- implement a local config parser in `@universo/core-backend`,
+- keep only generic boolean / number parsers in shared utils,
+- avoid pushing private startup config into shared browser-facing env surfaces.
+
+### 3. Extract A Reusable Backend Provisioning Service
+
+The repository already has route-level admin provisioning.
+Startup bootstrap should not duplicate it.
+
+**Decision**:
+
+- extract a reusable service in `@universo/admin-backend`,
+- let both the admin route and startup bootstrap call the same provisioning pipeline,
+- keep route parsing / HTTP responses in the route layer and all create-user / repair / rollback logic in the service layer.
+
+### 4. Use Advisory Locking For Bootstrap Serialization
+
+Multiple startup processes must not race on the same bootstrap email.
+
+**Decision**:
+
+- use `withAdvisoryLock(getPoolExecutor(), lockKey, ...)`,
+- lock by normalized email, for example `bootstrap-superuser:<lowercase-email>`,
+- keep the lock scope limited to the one bootstrap account flow.
+
+### 5. Be Strict About Existing Users
+
+The startup bootstrap must be idempotent, but not permissive.
+
+**Decision**:
+
+- if the configured email does not exist: create the user and assign `superuser`,
+- if the configured email exists and is already an active `superuser`: no-op,
+- if the configured email exists but is **not** a `superuser`: fail fast with a clear startup error by default,
+- do **not** silently change the password of an unrelated existing user in v1,
+- do **not** silently elevate an unrelated existing user in v1.
+
+This is the safest default for a platform root account.
+
+### 6. Ensure Profile Existence Explicitly
+
+Even though the DB trigger should create the profile row, startup bootstrap must not depend on that side effect blindly.
+
+**Decision**:
+
+- after successful auth user provisioning or discovery, call `ProfileService.getOrCreateProfile(userId, email)`,
+- avoid duplicating nickname generation logic outside `profile-backend`,
+- keep consent fields empty unless explicitly required by the product contract.
+
+### 7. Keep Role Sync Canonical And Exclusive
+
+The repository already treats `superuser` as an exclusive role.
+
+**Decision**:
+
+- assign bootstrap root access through the same canonical multi-role synchronization path as admin user management,
+- resolve the `superuser` role by codename and then call the canonical role replacement flow,
+- avoid adding a second ad hoc SQL insert path for `admin.rel_user_roles`.
+
+### 8. No Frontend Surface In V1
+
+This feature is a startup/admin concern, not a UI workflow.
+
+**Decision**:
+
+- no new frontend screens in v1,
+- no new TanStack Query integration in v1,
+- only documentation and server-side behavior change.
+
+### 9. Document Demo Credentials Aggressively
+
+The env example must include demo values, but they must not look production-safe.
+
+**Decision**:
+
+- example email: `demo-admin@example.com`
+- example password: `ChangeMe_123456!`
+- documentation must explicitly state that real deployments must replace both before first real use.
+
+---
+
+## Proposed Env Contract
+
+### Required For The Bootstrap Feature
+
+```env
+# Server-side admin client for Supabase Auth Admin API
+# Required when BOOTSTRAP_SUPERUSER_ENABLED=true
+# SERVICE_ROLE_KEY=...
+
+# BOOTSTRAP_SUPERUSER_ENABLED:
+# Automatically provision the first platform superuser during startup bootstrap.
+# Default: true
+BOOTSTRAP_SUPERUSER_ENABLED=true
+
+# BOOTSTRAP_SUPERUSER_EMAIL:
+# Demo bootstrap admin email for first startup.
+# Change before any real deployment.
+BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+
+# BOOTSTRAP_SUPERUSER_PASSWORD:
+# Demo bootstrap admin password for first startup.
+# Change before any real deployment.
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
+```
+
+### Startup Validation Rules
+
+When `BOOTSTRAP_SUPERUSER_ENABLED=true`:
+
+1. `SUPABASE_URL` must exist.
+2. `SERVICE_ROLE_KEY` must exist.
+3. `BOOTSTRAP_SUPERUSER_EMAIL` must be a valid email.
+4. `BOOTSTRAP_SUPERUSER_PASSWORD` must pass a minimum-strength policy.
+5. Startup should fail fast if validation fails.
+
+When `BOOTSTRAP_SUPERUSER_ENABLED=false`:
+
+- the feature is a pure no-op,
+- missing bootstrap email/password should not fail startup.
+
+---
+
+## Detailed Implementation Plan
+
+### Phase 0: Finalize Behavioral Contract
+
+- [ ] **0.1** Confirm that the default behavior for an existing non-superuser with the configured bootstrap email is **fail fast**, not auto-escalate.
+- [ ] **0.2** Confirm that v1 will **not** automatically rotate passwords for pre-existing users.
+- [ ] **0.3** Confirm that v1 only guarantees a valid auth account + profile row + `superuser` role, and does **not** simulate end-user legal consent acceptance.
+- [ ] **0.4** Confirm demo env values and warning text for `.env.example`, README, and GitBook docs.
+
+### Phase 1: Extract A Reusable Provisioning Service
+
+- [ ] **1.1** Create a new internal service in `@universo/admin-backend` for provisioning a Supabase auth user and synchronizing global roles.
+- [ ] **1.2** Move route-local cleanup logic out of `globalUsersRoutes.ts` into the reusable service layer.
+- [ ] **1.3** Reuse `GlobalAccessService.setUserRoles(...)` for canonical superuser assignment.
+- [ ] **1.4** Add a helper that resolves role IDs by codename inside the service layer so startup code does not need to know admin schema details.
+- [ ] **1.5** Inject `ProfileService` and call `getOrCreateProfile(...)` after user creation or user discovery.
+- [ ] **1.6** Return a structured provisioning result, for example:
+  - created new auth user vs reused existing user,
+  - created or repaired profile,
+  - roles synchronized,
+  - no-op state if the configured user is already a superuser.
+- [ ] **1.7** Keep HTTP-specific concerns out of the service so the startup path can reuse it without Express request objects.
+
+### Phase 2: Add A Dedicated Startup Bootstrap Orchestrator
+
+- [ ] **2.1** Add a local core-backend bootstrap module, for example `src/bootstrap/bootstrapSuperuser.ts`.
+- [ ] **2.2** Add a local config parser, for example `src/bootstrap/bootstrapSuperuserConfig.ts`, instead of scattering raw `process.env` reads.
+- [ ] **2.3** Normalize the configured email once and build an advisory lock key from it.
+- [ ] **2.4** Run the bootstrap after migration validation, schema generation, post-schema migrations, and fixed system-app structure bootstrap have completed successfully.
+- [ ] **2.5** Create a dedicated service-role Supabase client in the bootstrap path with:
+  - `persistSession: false`
+  - `autoRefreshToken: false`
+- [ ] **2.6** Under advisory lock:
+  - lookup the existing auth user by email,
+  - create via `auth.admin.createUser(...)` if missing,
+  - ensure profile exists,
+  - synchronize the exclusive `superuser` role,
+  - rollback only the newly created auth user if role synchronization fails.
+- [ ] **2.7** Fail startup if an existing account with the configured email is present but is not already a superuser.
+- [ ] **2.8** Add high-signal logs without secrets:
+  - feature enabled/disabled,
+  - created / reused / skipped,
+  - existing-user conflict,
+  - rollback outcome.
+- [ ] **2.9** Do not log raw password, service role key, full JWT, or unsafe PII.
+
+### Phase 3: Bring CLI / Config Parity To Commands
+
+- [ ] **3.1** Extend `BaseCommand.flags` with:
+  - `SERVICE_ROLE_KEY`
+  - `BOOTSTRAP_SUPERUSER_ENABLED`
+  - `BOOTSTRAP_SUPERUSER_EMAIL`
+  - `BOOTSTRAP_SUPERUSER_PASSWORD`
+- [ ] **3.2** Forward those flags into `process.env` in the same style as the current command bootstrap.
+- [ ] **3.3** Keep env naming stable between `.env`, CLI flags, README, and GitBook docs.
+
+### Phase 4: Reuse The Shared Provisioning Service In Admin Routes
+
+- [ ] **4.1** Refactor `POST /api/v1/admin/global-users/create-user` to call the shared provisioning service instead of keeping a separate create-user flow.
+- [ ] **4.2** Preserve current HTTP behavior and validation semantics.
+- [ ] **4.3** Keep route-specific inputs like `roleIds`, `comment`, and request user ID in the route layer only.
+- [ ] **4.4** Ensure the shared service still supports cleanup and structured failure reporting for the route path.
+
+### Phase 5: Deep Test Plan
+
+#### Core-backend startup tests
+
+- [ ] **5.1** `App.initDatabase()` calls startup bootstrap only after migrations and fixed role seed are ready.
+- [ ] **5.2** Startup bootstrap is skipped when `BOOTSTRAP_SUPERUSER_ENABLED=false`.
+- [ ] **5.3** Startup fails fast when bootstrap is enabled but `SERVICE_ROLE_KEY` is missing.
+- [ ] **5.4** Startup fails fast when email/password config is invalid.
+- [ ] **5.5** Startup logs no-op when the configured superuser already exists and is valid.
+
+#### Admin-backend service tests
+
+- [ ] **5.6** Creating a missing bootstrap user provisions auth user, repairs/creates profile, and synchronizes only the `superuser` role.
+- [ ] **5.7** Role synchronization failure after fresh auth user creation triggers rollback through `deleteUser(...)`.
+- [ ] **5.8** Existing valid superuser is treated as idempotent success, not duplicate failure.
+- [ ] **5.9** Existing non-superuser with the configured email causes explicit hard failure.
+- [ ] **5.10** Missing profile on an existing auth user is repaired through `ProfileService.getOrCreateProfile(...)`.
+- [ ] **5.11** Advisory lock path is exercised so concurrent bootstrap attempts cannot both create a user.
+
+#### Route regression tests
+
+- [ ] **5.12** Admin create-user route still works after switching to the shared provisioning service.
+- [ ] **5.13** Admin route rollback semantics remain intact.
+- [ ] **5.14** Admin route still supports non-superuser role creation flows.
+
+#### Optional integration / live verification plan
+
+- [ ] **5.15** On a fresh `UP-test` reset or a dedicated scratch project, verify:
+  - startup creates the auth user,
+  - profile row exists,
+  - `admin.rel_user_roles` contains exactly one active `superuser` assignment,
+  - login succeeds through the normal password flow.
+
+### Phase 6: README And GitBook Documentation
+
+- [ ] **6.1** Update root `README.md` and `README-RU.md` with first-run bootstrap behavior and env warnings.
+- [ ] **6.2** Update `packages/universo-core-backend/base/README.md` and `README-RU.md` with:
+  - startup lifecycle addition,
+  - required `SERVICE_ROLE_KEY`,
+  - bootstrap superuser env contract,
+  - security warning about demo credentials.
+- [ ] **6.3** Update `packages/admin-backend/base/README.md` and `README-RU.md` to note that admin route provisioning and startup bootstrap share the same backend provisioning pipeline.
+- [ ] **6.4** Create or update GitBook pages in `docs/en` and `docs/ru` for:
+  - getting-started configuration,
+  - authentication / authorization architecture,
+  - first startup / bootstrap behavior.
+- [ ] **6.5** Update `docs/en/SUMMARY.md` and `docs/ru/SUMMARY.md` so the new pages are reachable from GitBook navigation.
+- [ ] **6.6** Keep English docs canonical and provide synchronized Russian translation in the same commit / implementation wave.
+
+---
+
+## Safe Code Sketches
+
+### Example 1: Local Startup Config Parser
+
+```ts
+interface BootstrapSuperuserConfig {
+  enabled: boolean
+  email: string | null
+  password: string | null
+}
+
+const parseEnvBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined || value.trim() === '') return fallback
+  const normalized = value.trim().toLowerCase()
+  return normalized === 'true' || normalized === '1'
+}
+
+export function getBootstrapSuperuserConfig(): BootstrapSuperuserConfig {
+  const enabled = parseEnvBoolean(process.env.BOOTSTRAP_SUPERUSER_ENABLED, true)
+
+  return {
+    enabled,
+    email: process.env.BOOTSTRAP_SUPERUSER_EMAIL?.trim().toLowerCase() || null,
+    password: process.env.BOOTSTRAP_SUPERUSER_PASSWORD || null
+  }
+}
+```
+
+### Example 2: Serialized Startup Bootstrap Flow
+
+```ts
+await withAdvisoryLock(getPoolExecutor(), `bootstrap-superuser:${normalizedEmail}`, async () => {
+  const existingUserId = await globalAccessService.findUserIdByEmail(normalizedEmail)
+
+  if (existingUserId) {
+    const info = await globalAccessService.getGlobalAccessInfo(existingUserId)
+    if (info.isSuperuser) {
+      await profileService.getOrCreateProfile(existingUserId, normalizedEmail)
+      return { status: 'noop_existing_superuser' as const }
+    }
+
+    throw new Error(
+      `Bootstrap email ${normalizedEmail} already belongs to an existing non-superuser account. ` +
+        `Refusing automatic privilege escalation.`
+    )
+  }
+
+  const adminResponse = await supabaseAdmin.auth.admin.createUser({
+    email: normalizedEmail,
+    password,
+    email_confirm: true
+  })
+
+  if (adminResponse.error || !adminResponse.data.user) {
+    throw adminResponse.error ?? new Error('Failed to create bootstrap superuser')
+  }
+
+  const userId = adminResponse.data.user.id
+
+  try {
+    await profileService.getOrCreateProfile(userId, normalizedEmail)
+    await provisioningService.replaceUserRolesByCodenames(userId, ['superuser'], null, 'startup bootstrap')
+    return { status: 'created' as const, userId }
+  } catch (error) {
+    await supabaseAdmin.auth.admin.deleteUser(userId)
+    throw error
+  }
+})
+```
+
+### Example 3: Focused Test Shape
+
+```ts
+it('fails startup when configured bootstrap email already belongs to a non-superuser', async () => {
+  mockFindUserIdByEmail.mockResolvedValue('user-1')
+  mockGetGlobalAccessInfo.mockResolvedValue({
+    isSuperuser: false,
+    canAccessAdmin: false,
+    globalRoles: []
+  })
+
+  await expect(runBootstrap()).rejects.toThrow(
+    'already belongs to an existing non-superuser account'
+  )
+
+  expect(mockCreateUser).not.toHaveBeenCalled()
+  expect(mockSetUserRoles).not.toHaveBeenCalled()
+})
+```
+
+---
+
+## Potential Challenges And How To Address Them
+
+### 1. Transaction-scoped advisory lock around an external admin API call
+
+Holding a DB transaction while calling `auth.admin.createUser(...)` is not ideal in a hot path.
+Here it is acceptable because this is a cold-start bootstrap flow, not a high-frequency request path.
+
+Mitigation:
+
+- keep the lock key very narrow,
+- keep timeout bounded,
+- keep the bootstrap logic small and single-account only,
+- avoid expanding this pattern into normal request flows.
+
+### 2. Existing user takeover policy
+
+There is product pressure to “just make the env user root”.
+That is operationally convenient but unsafe.
+
+Mitigation:
+
+- default to fail-fast for existing non-superuser accounts,
+- if product later wants an explicit takeover mode, add it as a second, intentionally named env flag in a separate follow-up.
+
+### 3. Profile trigger timing
+
+Relying only on the trigger can leave rare gaps.
+
+Mitigation:
+
+- explicitly repair profile existence through `ProfileService.getOrCreateProfile(...)`.
+
+### 4. Route / startup semantic drift
+
+If startup bootstrap and admin create-user evolve independently, bugs will reappear.
+
+Mitigation:
+
+- one shared provisioning service,
+- one cleanup strategy,
+- one test matrix covering both callers.
+
+### 5. Documentation sprawl
+
+This feature touches root README, package READMEs, and GitBook.
+
+Mitigation:
+
+- treat docs as a first-class implementation phase,
+- update EN and RU together,
+- keep one canonical env contract string across all documents.
+
+---
+
+## Design Notes
+
+### Why This Does Not Need A Separate CREATIVE Phase
+
+This feature is backend/bootstrap-oriented.
+No new screen, visual flow, or design system work is required in v1.
+
+### Why This Still Needs Careful Architecture Review
+
+It modifies:
+
+- startup ordering,
+- security-sensitive auth provisioning,
+- root access semantics,
+- rollback behavior,
+- and first-run documentation.
+
+That combination is operationally sensitive even without UI work.
+
+---
+
+## Dependencies
+
+1. **Supabase Admin API availability**
+   - The feature requires `SERVICE_ROLE_KEY`.
+
+2. **Current role seed contract**
+   - The `superuser` role must continue to be seeded before bootstrap runs.
+
+3. **Current profile service contract**
+   - `ProfileService.getOrCreateProfile(...)` must remain exported and backend-safe.
+
+4. **Documentation synchronization**
+   - EN and RU docs should ship together to avoid conflicting setup guidance.
+
+---
+
+## Recommended Execution Order
+
+1. Finalize the takeover / existing-user policy.
+2. Extract shared provisioning + rollback service.
+3. Add startup bootstrap orchestrator and config parser.
+4. Add CLI parity for env overrides.
+5. Refactor admin create-user route onto the shared service.
+6. Add the full regression suite.
+7. Update root README, package READMEs, and GitBook docs.
+8. Validate on a fresh Supabase database or controlled reset.
+
+---
+
+## Discussion Points Requiring Explicit Approval
+
+1. Should existing non-superuser accounts with the configured bootstrap email cause a **hard startup failure** by default?
+2. Is it correct that v1 should **not** auto-reset the password of an existing account?
+3. Is it acceptable that v1 creates a valid bootstrap admin account **without synthetic legal-consent acceptance fields**, while still ensuring full login/profile/role readiness?
+

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -29,6 +29,55 @@
 | 0.35.0-alpha | 2025-10-30 | Bold Steps 💃                                      | i18n TypeScript migration, Rate limiting                                                            |
 | 0.34.0-alpha | 2025-10-23 | Black Hole ☕️                                     | Global monorepo refactoring, tsdown build system                                                    |
 
+## 2026-03-20 Bootstrap Superuser Final QA Remediation
+
+Closed the final bootstrap-superuser QA follow-up by correcting the last unsafe template mismatch and fixing the previously unexecuted live integration harness so it runs against real Supabase instead of the global Jest mock.
+
+| Area | Resolution |
+| --- | --- |
+| Env-template safety | `packages/universo-core-backend/base/.env.example` now uses the same neutral demo bootstrap credentials as runtime/docs: `demo-admin@example.com` / `ChangeMe_123456!`. This restores the intended safety warning path and removes the stale public old-values mismatch. |
+| Live Supabase test harness | `authUserProvisioningService.integration.test.ts` now imports the real `createClient(...)` via `jest.requireActual('@supabase/supabase-js')`, bypassing the backend Jest setup mock that previously made `auth.admin` undefined and silently invalidated the integration suite. |
+| Real integration proof | Re-ran the env-gated live suite against `UP-test` with a real `DATABASE_TEST_URL`, `SUPABASE_URL`, and `SERVICE_ROLE_KEY`. Both the bootstrap happy-path and the rollback failure-path passed against the actual Supabase Auth + Postgres boundary. |
+| Validation | Live `@universo/admin-backend` integration tests passed (2/2), focused admin regression suites passed (23/23), focused core bootstrap tests passed (6/6), and touched admin lint remained green on errors with the same pre-existing warning-only debt outside this closure. |
+
+## 2026-03-19 Bootstrap Superuser QA Reopen Closure
+
+Closed the second QA reopen for startup bootstrap and admin-side provisioning by removing the last rollback consistency seam and adding the missing real failure-path verification.
+
+| Area | Resolution |
+| --- | --- |
+| Privileged rollback cleanup | `createAuthUserProvisioningService(...)` no longer accepts request-scoped cleanup executors. Compensation now always runs profile cleanup through the privileged executor before deleting the Supabase auth user, so admin-side create-user failures cannot leave orphan active profile rows behind because of RLS. |
+| Admin route alignment | The admin global-users create-user route no longer passes request-scoped session state into provisioning cleanup, keeping the route fully aligned with the shared privileged rollback contract. |
+| Real failure-path integration coverage | Extended the env-gated live Supabase integration suite to verify a real rollback after auth-user creation when role synchronization fails. The test now proves that both the Supabase auth account and the generated profile row are removed, not only the happy-path bootstrap/provision flow. |
+| Deployment safety warning | Startup bootstrap now emits an explicit warning when `BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com` and `BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!` are still configured, reducing the chance of shipping public demo credentials into a real environment. |
+| Validation | `@universo/admin-backend` tests passed with `43 passed / 2 skipped / 45 total`, `@universo/core-backend` tests passed (23/23), touched admin/core lint stayed green with warning-only pre-existing debt outside this change-set, standalone `@universo/admin-backend` and `@universo/core-backend` builds passed, and the final root `pnpm build` completed green with 28/28 successful tasks in 2m52.491s. |
+
+## 2026-03-19 Bootstrap Superuser QA Closure
+
+Closed the follow-up QA reopen for startup bootstrap and admin-side user provisioning by hardening protected-role mutation rules, filling the remaining regression gaps, and restoring safe demo bootstrap defaults.
+
+| Area | Resolution |
+| --- | --- |
+| Protected-role security boundary | `createGlobalAccessService(...)` now blocks non-superusers from assigning, downgrading, or revoking `superuser` / `is_system=true` role state across `setUserRoles(...)`, `grantRole(...)`, `revokeGlobalAccess(...)`, `revokeAssignment(...)`, and the legacy single-role update path. |
+| Legacy role-shape correctness | Legacy role grant/update responses now preserve `isSystem` correctly for system roles instead of flattening them to `false`, keeping the API role model aligned with the database metadata. |
+| Provisioning regression depth | Added invite-path coverage for `createAuthUserProvisioningService(...)` so admin-side provisioning is tested both for password-based auth-user creation and `inviteUserByEmail(...)`, alongside existing rollback/bootstrap regressions. Added an env-gated live integration suite for the real Supabase bootstrap path (`DATABASE_TEST_URL` + `SUPABASE_URL` + `SERVICE_ROLE_KEY`) so the security-critical auth/profile/role flow no longer relies only on mocks. |
+| Bootstrap config coverage | Extended bootstrap tests to reject invalid email configuration explicitly and kept the fail-fast env contract around `SUPABASE_URL`, `SERVICE_ROLE_KEY`, and password quality. |
+| Safe demo defaults | Restored the public `.env.example` bootstrap credentials to neutral demo values (`demo-admin@example.com` / `ChangeMe_123456!`) with the existing “change before real use” guidance. |
+| Validation | `@universo/admin-backend` tests passed with `43 passed / 1 skipped / 44 total`, `@universo/core-backend` tests passed (22/22), touched admin/core lint stayed green with warning-only pre-existing debt outside this change-set, standalone `@universo/admin-backend` and `@universo/core-backend` builds passed, and the final root `pnpm build` completed green with 28/28 successful tasks in 2m40.814s. |
+
+## 2026-03-19 Bootstrap Superuser Startup Closure
+
+Implemented automatic startup bootstrap for the first platform superuser so a fresh Supabase environment no longer requires a manual SQL step after first launch.
+
+| Area | Resolution |
+| --- | --- |
+| Shared provisioning pipeline | Extracted `createAuthUserProvisioningService(...)` in `@universo/admin-backend` so startup bootstrap and admin-side `POST /api/v1/admin/global-users/create-user` now share one canonical flow for auth-user creation, profile repair, global-role synchronization, and rollback. |
+| Safe startup bootstrap | `@universo/core-backend` now runs bootstrap provisioning during `App.initDatabase()` after migrations and fixed role seed. The flow is guarded by a transaction-scoped advisory lock, requires valid `SUPABASE_URL` + `SERVICE_ROLE_KEY` when enabled, creates a real Supabase auth user, repairs the profile row through `ProfileService.getOrCreateProfile(...)`, and assigns the exclusive `superuser` role. |
+| Fail-closed privilege policy | Automatic bootstrap now refuses to elevate an existing non-superuser account, does not auto-reset the password of an existing account in v1, and remains a safe no-op when the configured bootstrap account already exists as a superuser. |
+| Env and CLI parity | Added `SERVICE_ROLE_KEY`, `BOOTSTRAP_SUPERUSER_ENABLED`, `BOOTSTRAP_SUPERUSER_EMAIL`, and `BOOTSTRAP_SUPERUSER_PASSWORD` to the core-backend CLI/env contract and documented the demo bootstrap credentials in `.env` / `.env.example` with explicit “change before real use” guidance. |
+| Documentation sync | Updated root README/README-RU, `@universo/core-backend` README/README-RU, `@universo/admin-backend` README/README-RU, and GitBook docs in `docs/en` + `docs/ru` so startup behavior, security constraints, and server-only provisioning requirements match the implementation. |
+| Validation | `@universo/admin-backend` tests passed (39/39), `@universo/core-backend` tests passed (21/21), touched lint passed with warning-only pre-existing debt outside this change-set, standalone admin/core builds passed, and the final root `pnpm build` completed green with 28/28 successful tasks in 3m25.588s. |
+
 ## 2026-03-19 PR #731 Bot Review Closure
 
 Validated every bot review comment on PR #731 against the live codebase and only accepted the recommendations that improved correctness without regressing the recently delivered application workspace/public-access functionality.

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -3,6 +3,45 @@
 
 ---
 
+## Bootstrap Superuser Final QA Remediation — 2026-03-20
+- Status: COMPLETE
+- [x] BSF1: Align `.env.example` bootstrap demo credentials with the runtime warning contract and the README / GitBook documentation
+- [x] BSF2: Fix the env-gated live Supabase integration harness so it uses the real `@supabase/supabase-js` client instead of the global Jest mock
+- [x] BSF3: Re-run real Supabase integration verification plus touched bootstrap/admin regressions and sync memory-bank closure state
+  - Note: `.env.example` now uses `demo-admin@example.com` / `ChangeMe_123456!`, the integration suite bypasses the global Jest `createClient` mock via `jest.requireActual(...)`, the live Supabase suite passed (`2/2`) against `UP-test`, focused admin regressions passed (`23/23`), focused core bootstrap tests passed (`6/6`), and touched admin lint remained green on errors with the same pre-existing `no-explicit-any` warnings outside this closure.
+
+---
+
+## Bootstrap Superuser QA Reopen — 2026-03-19
+- Status: COMPLETE
+- [x] BSR1: Remove request-scoped / RLS-dependent cleanup from auth-user provisioning rollback so admin create-user compensation always uses a privileged executor
+- [x] BSR2: Add live failure-path regression coverage for real Supabase rollback so auth/profile cleanup is verified beyond mock-only tests
+- [x] BSR3: Add an explicit startup warning when demo bootstrap credentials are still in use, then rerun touched validation and sync memory-bank closure state
+  - Note: rollback cleanup now uses the privileged executor only, the env-gated live integration suite covers both real bootstrap happy-path and a real rollback failure-path, `@universo/admin-backend` tests passed with `43 passed / 2 skipped / 45 total`, `@universo/core-backend` tests passed (23/23), touched admin/core lint stayed green with warning-only pre-existing debt outside this change-set, standalone `@universo/admin-backend` and `@universo/core-backend` builds passed, and the final root `pnpm build` completed green with 28/28 successful tasks in 2m52.491s.
+
+---
+
+## Bootstrap Superuser QA Closure — 2026-03-19
+- Status: COMPLETE
+- [x] BQ1: Harden role-assignment security so non-superusers cannot create, elevate, downgrade, or revoke `superuser` / system-role assignments through admin user-management flows
+- [x] BQ2: Add deeper regression coverage for role-assignment restrictions, invite-path provisioning, bootstrap config contract, and failure-path behavior
+- [x] BQ3: Restore safe neutral demo bootstrap credentials in `.env.example`, revalidate touched packages, and sync memory-bank closure state
+  - Note: `@universo/admin-backend` now includes an env-gated live Supabase integration suite (`1 skipped` without test env) alongside the focused unit/regression suite (`43 passed`, `44 total`); `@universo/core-backend` tests passed (22/22), touched admin/core lint stayed green with warning-only pre-existing debt outside this change-set, standalone `@universo/admin-backend` and `@universo/core-backend` builds passed, and the final root `pnpm build` completed green with 28/28 successful tasks in 2m40.814s.
+
+---
+
+## Bootstrap Superuser Startup Implementation — 2026-03-19
+- Status: COMPLETE
+- [x] BS1: Extract shared backend auth-user provisioning / rollback / profile-repair service in `@universo/admin-backend`
+- [x] BS2: Implement startup bootstrap orchestrator in `@universo/core-backend` with strict env validation, advisory lock, and fail-fast existing-user policy
+- [x] BS3: Add CLI/env parity for `SERVICE_ROLE_KEY` and bootstrap superuser env flags in core-backend commands
+- [x] BS4: Refactor admin create-user route to reuse the shared provisioning pipeline without breaking existing behavior
+- [x] BS5: Add deep regression coverage for startup bootstrap, shared provisioning, rollback, existing-user conflict, and route reuse
+- [x] BS6: Update `.env.example`, root/package README files, GitBook docs, and memory-bank closure state; rerun focused validation and final root build
+  - Note: `@universo/admin-backend` tests passed (39/39), `@universo/core-backend` tests passed (21/21), touched lint passed with warning-only pre-existing debt outside this change-set, standalone `@universo/admin-backend` and `@universo/core-backend` builds passed, and the final root `pnpm build` completed green with 28/28 successful tasks in 3m25.588s.
+
+---
+
 ## PR #731 Bot Review Closure — 2026-03-19
 - Status: COMPLETE
 - [x] PR731-1: Review every bot comment from PR #731 against the live code and accept only the changes that are technically justified and safe

--- a/packages/admin-backend/base/README-RU.md
+++ b/packages/admin-backend/base/README-RU.md
@@ -61,18 +61,32 @@ POST   /api/v1/admin/roles/:id/copy        # Скопировать сущест
 ### Интеграция с Express
 
 ```typescript
-import { createGlobalUsersRoutes, createGlobalAccessService } from '@universo/admin-backend'
+import {
+  createAuthUserProvisioningService,
+  createGlobalUsersRoutes,
+  createGlobalAccessService
+} from '@universo/admin-backend'
 import { getPermissionService } from '@universo/auth-backend'
 import { createKnexExecutor, getKnex } from '@universo/database'
+import { createClient } from '@supabase/supabase-js'
 
 const globalAccessService = createGlobalAccessService({ getDbExecutor: () => createKnexExecutor(getKnex()) })
 const permissionService = getPermissionService()
-const globalUsersRoutes = createGlobalUsersRoutes({ globalAccessService, permissionService })
+const supabaseAdmin = createClient(process.env.SUPABASE_URL!, process.env.SERVICE_ROLE_KEY!, {
+  auth: { persistSession: false, autoRefreshToken: false }
+})
+const provisioningService = createAuthUserProvisioningService({
+  getDbExecutor: () => createKnexExecutor(getKnex()),
+  globalAccessService,
+  supabaseAdmin
+})
+const globalUsersRoutes = createGlobalUsersRoutes({ globalAccessService, permissionService, provisioningService })
 
 app.use('/api/v1/admin/global-users', globalUsersRoutes)
 ```
 
-Также передавайте `supabaseAdmin`, если включаете прямое создание пользователей из админ-панели через `POST /create-user`.
+Для прямого создания пользователей из админ-панели через `POST /create-user` используйте общий provisioning service.
+Так startup bootstrap и admin-side create-user будут идти через один rollback-safe pipeline.
 
 ### Проверка доступа в других модулях
 

--- a/packages/admin-backend/base/README.md
+++ b/packages/admin-backend/base/README.md
@@ -61,18 +61,32 @@ POST   /api/v1/admin/roles/:id/copy        # Copy an existing role into a new ed
 ### Express Integration
 
 ```typescript
-import { createGlobalUsersRoutes, createGlobalAccessService } from '@universo/admin-backend'
+import {
+  createAuthUserProvisioningService,
+  createGlobalUsersRoutes,
+  createGlobalAccessService
+} from '@universo/admin-backend'
 import { getPermissionService } from '@universo/auth-backend'
 import { createKnexExecutor, getKnex } from '@universo/database'
+import { createClient } from '@supabase/supabase-js'
 
 const globalAccessService = createGlobalAccessService({ getDbExecutor: () => createKnexExecutor(getKnex()) })
 const permissionService = getPermissionService()
-const globalUsersRoutes = createGlobalUsersRoutes({ globalAccessService, permissionService })
+const supabaseAdmin = createClient(process.env.SUPABASE_URL!, process.env.SERVICE_ROLE_KEY!, {
+  auth: { persistSession: false, autoRefreshToken: false }
+})
+const provisioningService = createAuthUserProvisioningService({
+  getDbExecutor: () => createKnexExecutor(getKnex()),
+  globalAccessService,
+  supabaseAdmin
+})
+const globalUsersRoutes = createGlobalUsersRoutes({ globalAccessService, permissionService, provisioningService })
 
 app.use('/api/v1/admin/global-users', globalUsersRoutes)
 ```
 
-Pass `supabaseAdmin` as well when you enable direct admin-side user provisioning via `POST /create-user`.
+Use the shared provisioning service when you enable direct admin-side user provisioning via `POST /create-user`.
+This keeps startup bootstrap and admin-side create-user on the same rollback-safe pipeline.
 
 ### Access Guard in Other Modules
 

--- a/packages/admin-backend/base/package.json
+++ b/packages/admin-backend/base/package.json
@@ -47,6 +47,7 @@
         "@supabase/supabase-js": "^2.45.4",
         "@universo/auth-backend": "workspace:*",
         "@universo/migrations-core": "workspace:*",
+        "@universo/profile-backend": "workspace:*",
         "@universo/types": "workspace:*",
         "@universo/utils": "workspace:*",
         "express": "^4.18.2",
@@ -54,6 +55,7 @@
         "zod": "catalog:"
     },
     "devDependencies": {
+        "@universo/database": "workspace:*",
         "@types/express": "^4.17.21",
         "@types/http-errors": "catalog:",
         "@types/jest": "^29.5.12",

--- a/packages/admin-backend/base/src/index.ts
+++ b/packages/admin-backend/base/src/index.ts
@@ -18,6 +18,15 @@ export {
     type ListGlobalUsersParams,
     type GlobalAccessInfo
 } from './services/globalAccessService'
+export {
+    createAuthUserProvisioningService,
+    type AuthUserProvisioningService,
+    type AuthUserProvisioningServiceDeps,
+    type ProvisionAuthUserWithRoleIdsInput,
+    type ProvisionAuthUserWithRoleIdsResult,
+    type EnsureBootstrapSuperuserInput,
+    type EnsureBootstrapSuperuserResult
+} from './services/authUserProvisioningService'
 
 // Guards
 export {

--- a/packages/admin-backend/base/src/routes/globalUsersRoutes.ts
+++ b/packages/admin-backend/base/src/routes/globalUsersRoutes.ts
@@ -1,16 +1,16 @@
 import { Router } from 'express'
-import type { SupabaseClient } from '@supabase/supabase-js'
 import type { IPermissionService } from '@universo/auth-backend'
 import type { GlobalAccessService } from '../services/globalAccessService'
+import type { AuthUserProvisioningService } from '../services/authUserProvisioningService'
 import { createEnsureGlobalAccess, type RequestWithGlobalRole } from '../guards/ensureGlobalAccess'
-import { activeAppRowCondition, getRequestDbSession, isAdminPanelEnabled, softDeleteSetClause, uuid } from '@universo/utils'
+import { getRequestDbSession, isAdminPanelEnabled, uuid } from '@universo/utils'
 import { GrantRoleSchema, UpdateGlobalUserSchema, formatZodError, validateListQuery } from '../schemas'
 import { z } from 'zod'
 
 export interface GlobalUsersRoutesConfig {
     globalAccessService: GlobalAccessService
     permissionService: IPermissionService
-    supabaseAdmin?: SupabaseClient
+    provisioningService?: AuthUserProvisioningService
 }
 
 const SetUserRolesSchema = z.object({
@@ -29,52 +29,9 @@ const CreateUserSchema = z.object({
  * Create routes for global users management
  * Uses new GlobalAccessService with RBAC and role metadata
  */
-export function createGlobalUsersRoutes({ globalAccessService, permissionService, supabaseAdmin }: GlobalUsersRoutesConfig): Router {
+export function createGlobalUsersRoutes({ globalAccessService, permissionService, provisioningService }: GlobalUsersRoutesConfig): Router {
     const router = Router()
     const ensureGlobalAccess = createEnsureGlobalAccess({ globalAccessService, permissionService })
-
-    const cleanupProvisionedUser = async (
-        userId: string,
-        dbSession?: { query<T = unknown>(sql: string, parameters?: unknown[]): Promise<T[]>; isReleased(): boolean } | null
-    ) => {
-        const cleanupErrors: string[] = []
-
-        if (dbSession && !dbSession.isReleased()) {
-            try {
-                await dbSession.query(
-                    `UPDATE profiles.cat_profiles
-                     SET ${softDeleteSetClause('$2')}
-                     WHERE user_id = $1 AND ${activeAppRowCondition()}`,
-                    [userId, null]
-                )
-            } catch (profileCleanupError) {
-                cleanupErrors.push(
-                    `profile cleanup failed: ${
-                        profileCleanupError instanceof Error ? profileCleanupError.message : String(profileCleanupError)
-                    }`
-                )
-            }
-        }
-
-        if (!supabaseAdmin) {
-            cleanupErrors.push('auth cleanup skipped: Supabase Admin API is not configured')
-            return {
-                cleaned: false,
-                cleanupErrors
-            }
-        }
-
-        const { error } = await supabaseAdmin.auth.admin.deleteUser(userId)
-
-        if (error) {
-            cleanupErrors.push(`auth cleanup failed: ${error.message}`)
-        }
-
-        return {
-            cleaned: cleanupErrors.length === 0,
-            cleanupErrors
-        }
-    }
 
     /**
      * GET /api/v1/admin/global-users
@@ -169,10 +126,10 @@ export function createGlobalUsersRoutes({ globalAccessService, permissionService
 
     router.post('/create-user', ensureGlobalAccess('users', 'create'), async (req, res, next) => {
         try {
-            if (!supabaseAdmin) {
+            if (!provisioningService) {
                 return res.status(503).json({
                     success: false,
-                    error: 'Supabase Admin API is not configured on the backend'
+                    error: 'Auth user provisioning is not configured on the backend'
                 })
             }
 
@@ -186,47 +143,20 @@ export function createGlobalUsersRoutes({ globalAccessService, permissionService
 
             const { email, password, roleIds, comment } = parsed.data
             const grantedBy = (req as RequestWithGlobalRole).user!.id
-            const adminResponse = password
-                ? await supabaseAdmin.auth.admin.createUser({
-                      email,
-                      password,
-                      email_confirm: true
-                  })
-                : await supabaseAdmin.auth.admin.inviteUserByEmail(email)
-
-            if (adminResponse.error || !adminResponse.data.user) {
-                return res.status(400).json({
-                    success: false,
-                    error: adminResponse.error?.message || 'Failed to create user'
-                })
-            }
-
-            let roles
-
-            try {
-                roles = await globalAccessService.setUserRoles(
-                    adminResponse.data.user.id,
-                    roleIds,
-                    grantedBy,
-                    comment || 'created from admin panel'
-                )
-            } catch (roleAssignmentError) {
-                const cleanupResult = await cleanupProvisionedUser(adminResponse.data.user.id, getRequestDbSession(req))
-                const cleanupSuffix = cleanupResult.cleaned
-                    ? ' Newly created auth account was rolled back.'
-                    : ` Cleanup failed: ${cleanupResult.cleanupErrors.join('; ')}`
-
-                const wrappedError = new Error(`Failed to assign roles to the newly created user.${cleanupSuffix}`)
-                ;(wrappedError as Error & { cause?: unknown }).cause = roleAssignmentError
-                throw wrappedError
-            }
+            const result = await provisioningService.provisionAuthUserWithRoleIds({
+                email,
+                password,
+                roleIds,
+                grantedBy,
+                comment: comment || 'created from admin panel'
+            })
 
             res.status(201).json({
                 success: true,
                 data: {
-                    userId: adminResponse.data.user.id,
-                    email: adminResponse.data.user.email ?? email,
-                    roles
+                    userId: result.userId,
+                    email: result.email,
+                    roles: result.roles
                 }
             })
         } catch (error) {
@@ -400,7 +330,7 @@ export function createGlobalUsersRoutes({ globalAccessService, permissionService
                 })
             }
 
-            const success = await globalAccessService.revokeGlobalAccess(memberId)
+            const success = await globalAccessService.revokeGlobalAccess(memberId, currentUserId)
             if (!success) {
                 return res.status(404).json({
                     success: false,

--- a/packages/admin-backend/base/src/services/authUserProvisioningService.ts
+++ b/packages/admin-backend/base/src/services/authUserProvisioningService.ts
@@ -1,0 +1,239 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { ProfileService } from '@universo/profile-backend'
+import type { GlobalUserRoleAssignment } from '@universo/types'
+import { activeAppRowCondition, softDeleteSetClause, type DbExecutor, type DbSession } from '@universo/utils'
+import type { GlobalAccessService } from './globalAccessService'
+
+type CleanupQueryable = Pick<DbExecutor, 'query'> | DbSession
+
+export interface ProvisionAuthUserWithRoleIdsInput {
+    email: string
+    password?: string
+    roleIds: string[]
+    grantedBy: string | null
+    comment?: string
+}
+
+export interface ProvisionAuthUserWithRoleIdsResult {
+    userId: string
+    email: string
+    roles: GlobalUserRoleAssignment[]
+    createdAuthUser: boolean
+    profileEnsured: boolean
+}
+
+export interface EnsureBootstrapSuperuserInput {
+    email: string
+    password: string
+}
+
+export interface EnsureBootstrapSuperuserResult {
+    userId: string
+    email: string
+    createdAuthUser: boolean
+    profileEnsured: boolean
+    status: 'created' | 'noop_existing_superuser'
+}
+
+export interface AuthUserProvisioningServiceDeps {
+    getDbExecutor: () => DbExecutor
+    globalAccessService: Pick<GlobalAccessService, 'findUserIdByEmail' | 'getGlobalAccessInfo' | 'setUserRoles'>
+    supabaseAdmin: SupabaseClient
+}
+
+const normalizeEmail = (value: string): string => value.trim().toLowerCase()
+
+export function createAuthUserProvisioningService({ getDbExecutor, globalAccessService, supabaseAdmin }: AuthUserProvisioningServiceDeps) {
+    const profileService = new ProfileService(getDbExecutor())
+
+    const resolveRoleIdsByCodenames = async (roleCodenames: string[]): Promise<string[]> => {
+        const requested = Array.from(new Set(roleCodenames.map((value) => value.trim()).filter(Boolean)))
+        if (requested.length === 0) {
+            return []
+        }
+
+        const rows = await getDbExecutor().query<{ id: string; codename: string }>(
+            `SELECT id, codename
+             FROM admin.cat_roles
+             WHERE codename = ANY($1::text[])
+               AND ${activeAppRowCondition()}`,
+            [requested]
+        )
+
+        if (rows.length !== requested.length) {
+            const found = new Set(rows.map((row) => row.codename))
+            const missing = requested.filter((codename) => !found.has(codename))
+            throw Object.assign(new Error(`One or more role codenames are invalid: ${missing.join(', ')}`), { statusCode: 400 })
+        }
+
+        const roleIdByCodename = new Map(rows.map((row) => [row.codename, row.id]))
+        return requested.map((codename) => roleIdByCodename.get(codename) as string)
+    }
+
+    const cleanupProvisionedUser = async (userId: string): Promise<{ cleaned: boolean; cleanupErrors: string[] }> => {
+        const cleanupErrors: string[] = []
+        const queryable: CleanupQueryable = getDbExecutor()
+
+        try {
+            await queryable.query(
+                `UPDATE profiles.cat_profiles
+                 SET ${softDeleteSetClause('$2')}
+                 WHERE user_id = $1 AND ${activeAppRowCondition()}`,
+                [userId, null]
+            )
+        } catch (profileCleanupError) {
+            cleanupErrors.push(
+                `profile cleanup failed: ${
+                    profileCleanupError instanceof Error ? profileCleanupError.message : String(profileCleanupError)
+                }`
+            )
+        }
+
+        const { error } = await supabaseAdmin.auth.admin.deleteUser(userId)
+        if (error) {
+            cleanupErrors.push(`auth cleanup failed: ${error.message}`)
+        }
+
+        return {
+            cleaned: cleanupErrors.length === 0,
+            cleanupErrors
+        }
+    }
+
+    const ensureProfile = async (userId: string, email: string): Promise<void> => {
+        await profileService.getOrCreateProfile(userId, email)
+    }
+
+    const syncRoles = async (
+        userId: string,
+        roleIds: string[],
+        grantedBy: string | null,
+        comment?: string
+    ): Promise<GlobalUserRoleAssignment[]> => {
+        return globalAccessService.setUserRoles(userId, roleIds, grantedBy, comment)
+    }
+
+    const finalizeProvisionedUser = async (
+        userId: string,
+        email: string,
+        roleIds: string[],
+        grantedBy: string | null,
+        comment?: string
+    ): Promise<{ roles: GlobalUserRoleAssignment[]; profileEnsured: boolean }> => {
+        await ensureProfile(userId, email)
+        const roles = await syncRoles(userId, roleIds, grantedBy, comment)
+        return { roles, profileEnsured: true }
+    }
+
+    const createAuthUser = async (email: string, password?: string): Promise<{ id: string; email: string }> => {
+        const adminResponse = password
+            ? await supabaseAdmin.auth.admin.createUser({
+                  email,
+                  password,
+                  email_confirm: true
+              })
+            : await supabaseAdmin.auth.admin.inviteUserByEmail(email)
+
+        if (adminResponse.error || !adminResponse.data.user) {
+            throw Object.assign(new Error(adminResponse.error?.message || 'Failed to create user'), { statusCode: 400 })
+        }
+
+        return {
+            id: adminResponse.data.user.id,
+            email: adminResponse.data.user.email ?? email
+        }
+    }
+
+    async function provisionAuthUserWithRoleIds({
+        email,
+        password,
+        roleIds,
+        grantedBy,
+        comment
+    }: ProvisionAuthUserWithRoleIdsInput): Promise<ProvisionAuthUserWithRoleIdsResult> {
+        const normalizedEmail = normalizeEmail(email)
+        const createdUser = await createAuthUser(normalizedEmail, password)
+
+        try {
+            const { roles, profileEnsured } = await finalizeProvisionedUser(
+                createdUser.id,
+                normalizedEmail,
+                roleIds,
+                grantedBy,
+                comment ?? 'created from admin panel'
+            )
+
+            return {
+                userId: createdUser.id,
+                email: createdUser.email,
+                roles,
+                createdAuthUser: true,
+                profileEnsured
+            }
+        } catch (provisioningError) {
+            const cleanupResult = await cleanupProvisionedUser(createdUser.id)
+            const cleanupSuffix = cleanupResult.cleaned
+                ? ' Newly created auth account was rolled back.'
+                : ` Cleanup failed: ${cleanupResult.cleanupErrors.join('; ')}`
+
+            const wrappedError = new Error(`Failed to assign roles to the newly created user.${cleanupSuffix}`)
+            ;(wrappedError as Error & { cause?: unknown }).cause = provisioningError
+            throw wrappedError
+        }
+    }
+
+    async function ensureBootstrapSuperuser({ email, password }: EnsureBootstrapSuperuserInput): Promise<EnsureBootstrapSuperuserResult> {
+        const normalizedEmail = normalizeEmail(email)
+        const existingUserId = await globalAccessService.findUserIdByEmail(normalizedEmail)
+
+        if (existingUserId) {
+            const accessInfo = await globalAccessService.getGlobalAccessInfo(existingUserId)
+            if (!accessInfo.isSuperuser) {
+                throw new Error(
+                    `Bootstrap email ${normalizedEmail} already belongs to an existing non-superuser account. Refusing automatic privilege escalation.`
+                )
+            }
+
+            await ensureProfile(existingUserId, normalizedEmail)
+
+            return {
+                userId: existingUserId,
+                email: normalizedEmail,
+                createdAuthUser: false,
+                profileEnsured: true,
+                status: 'noop_existing_superuser'
+            }
+        }
+
+        const createdUser = await createAuthUser(normalizedEmail, password)
+        const superuserRoleIds = await resolveRoleIdsByCodenames(['superuser'])
+
+        try {
+            await finalizeProvisionedUser(createdUser.id, normalizedEmail, superuserRoleIds, null, 'startup bootstrap superuser')
+
+            return {
+                userId: createdUser.id,
+                email: createdUser.email,
+                createdAuthUser: true,
+                profileEnsured: true,
+                status: 'created'
+            }
+        } catch (provisioningError) {
+            const cleanupResult = await cleanupProvisionedUser(createdUser.id)
+            const cleanupSuffix = cleanupResult.cleaned
+                ? ' Newly created auth account was rolled back.'
+                : ` Cleanup failed: ${cleanupResult.cleanupErrors.join('; ')}`
+
+            const wrappedError = new Error(`Bootstrap superuser provisioning failed.${cleanupSuffix}`)
+            ;(wrappedError as Error & { cause?: unknown }).cause = provisioningError
+            throw wrappedError
+        }
+    }
+
+    return {
+        provisionAuthUserWithRoleIds,
+        ensureBootstrapSuperuser
+    }
+}
+
+export type AuthUserProvisioningService = ReturnType<typeof createAuthUserProvisioningService>

--- a/packages/admin-backend/base/src/services/globalAccessService.ts
+++ b/packages/admin-backend/base/src/services/globalAccessService.ts
@@ -11,6 +11,7 @@ import {
     isSuperuserEnabled,
     type DbSession,
     type DbExecutor,
+    type SqlQueryable,
     activeAppRowCondition,
     softDeleteSetClause
 } from '@universo/utils'
@@ -47,6 +48,18 @@ interface DashboardRoleCountRow {
     role_codename: string
     count: string
 }
+
+interface RoleMutationGuardRow {
+    id: string
+    codename: string
+    is_superuser: boolean
+    is_system: boolean
+}
+
+const PROTECTED_ROLE_ASSIGNMENT_ERROR = 'Only superusers can modify superuser or system-role assignments'
+
+const isProtectedRoleAssignment = (role: Pick<RoleMutationGuardRow, 'is_superuser' | 'is_system'>): boolean =>
+    role.is_superuser || role.is_system
 
 const compareGlobalRoles = (left: GlobalRoleInfo, right: GlobalRoleInfo): number => {
     if (left.metadata.isSuperuser !== right.metadata.isSuperuser) {
@@ -182,6 +195,59 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
         }
 
         return getDbExecutor().query<T>(sql, params)
+    }
+
+    const isUserSuperuserWithQueryable = async (queryable: SqlQueryable, userId: string): Promise<boolean> => {
+        const result = await queryable.query<{ is_super: boolean }>(
+            `
+            SELECT admin.is_superuser($1::uuid) as is_super
+        `,
+            [userId]
+        )
+
+        return result[0]?.is_super ?? false
+    }
+
+    const listActiveRolesForUser = async (queryable: SqlQueryable, userId: string): Promise<RoleMutationGuardRow[]> => {
+        return queryable.query<RoleMutationGuardRow>(
+            `SELECT r.id, r.codename, r.is_superuser, r.is_system
+             FROM admin.rel_user_roles ur
+             JOIN admin.cat_roles r ON r.id = ur.role_id
+             WHERE ur.user_id = $1
+               AND ${activeAppRowCondition('ur')}
+               AND ${activeAppRowCondition('r')}`,
+            [userId]
+        )
+    }
+
+    const assertCanMutateProtectedRoles = async (
+        queryable: SqlQueryable,
+        {
+            actorUserId,
+            targetUserId,
+            requestedRoles
+        }: {
+            actorUserId?: string | null
+            targetUserId: string
+            requestedRoles: Array<Pick<RoleMutationGuardRow, 'is_superuser' | 'is_system'>>
+        }
+    ): Promise<void> => {
+        if (!actorUserId) {
+            return
+        }
+
+        const actorIsSuperuser = await isUserSuperuserWithQueryable(queryable, actorUserId)
+        if (actorIsSuperuser) {
+            return
+        }
+
+        const currentTargetRoles = await listActiveRolesForUser(queryable, targetUserId)
+        const touchesProtectedCurrentRole = currentTargetRoles.some(isProtectedRoleAssignment)
+        const touchesProtectedRequestedRole = requestedRoles.some(isProtectedRoleAssignment)
+
+        if (touchesProtectedCurrentRole || touchesProtectedRequestedRole) {
+            throw Object.assign(new Error(PROTECTED_ROLE_ASSIGNMENT_ERROR), { statusCode: 403 })
+        }
     }
 
     /**
@@ -578,7 +644,7 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
     async function setUserRoles(
         userId: string,
         roleIds: string[],
-        grantedBy: string,
+        grantedBy: string | null,
         comment?: string
     ): Promise<GlobalUserRoleAssignment[]> {
         const exec = getDbExecutor()
@@ -607,10 +673,22 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
                     throw Object.assign(new Error('One or more role IDs are invalid'), { statusCode: 400 })
                 }
 
+                await assertCanMutateProtectedRoles(trx, {
+                    actorUserId: grantedBy,
+                    targetUserId: userId,
+                    requestedRoles: validRoles
+                })
+
                 const superuserRole = validRoles.find((role) => role.is_superuser)
                 if (superuserRole) {
                     normalizedRoleIds = [superuserRole.id]
                 }
+            } else {
+                await assertCanMutateProtectedRoles(trx, {
+                    actorUserId: grantedBy,
+                    targetUserId: userId,
+                    requestedRoles: []
+                })
             }
 
             await trx.query(
@@ -657,9 +735,16 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
         const exec = getDbExecutor()
 
         // Get role ID (any role, not filtered by can_access_admin)
-        const roleResult = await exec.query<{ id: string; name: VersionedLocalizedContent<string>; color: string; is_superuser: boolean }>(
+        const roleResult = await exec.query<{
+            id: string
+            name: VersionedLocalizedContent<string>
+            color: string
+            is_superuser: boolean
+            is_system: boolean
+        }>(
             `
             SELECT id, name, color, is_superuser
+                   , is_system
             FROM admin.cat_roles
             WHERE codename = $1 AND ${activeAppRowCondition()}
         `,
@@ -673,6 +758,12 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
         const roleId = roleResult[0].id
 
         const assignmentId = await exec.transaction(async (trx) => {
+            await assertCanMutateProtectedRoles(trx, {
+                actorUserId: grantedBy,
+                targetUserId: userId,
+                requestedRoles: [{ is_superuser: roleResult[0].is_superuser, is_system: roleResult[0].is_system }]
+            })
+
             if (roleResult[0].is_superuser) {
                 await trx.query(
                     `UPDATE admin.rel_user_roles
@@ -749,7 +840,7 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
             name: (roleResult[0].name || null) as VersionedLocalizedContent<string> | null,
             color: roleResult[0].color || '#9e9e9e',
             is_superuser: roleResult[0].is_superuser,
-            is_system: false
+            is_system: roleResult[0].is_system
         })
 
         return {
@@ -778,7 +869,8 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
      */
     async function updateAssignment(
         assignmentId: string,
-        updates: { roleCodename?: string; comment?: string }
+        updates: { roleCodename?: string; comment?: string },
+        changedBy?: string | null
     ): Promise<GlobalUserMember | null> {
         const exec = getDbExecutor()
 
@@ -798,28 +890,41 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
         }
 
         const assignment = current[0]
+        const currentRoleRows = await exec.query<RoleMutationGuardRow>(
+            `SELECT r.id, r.codename, r.is_superuser, r.is_system
+             FROM admin.cat_roles r
+             WHERE r.id = $1
+               AND ${activeAppRowCondition('r')}`,
+            [assignment.role_id]
+        )
+        const nextRoleRows =
+            updates.roleCodename && updates.roleCodename !== assignment.role_codename
+                ? await exec.query<RoleMutationGuardRow>(
+                      `SELECT id, codename, is_superuser, is_system
+                       FROM admin.cat_roles
+                       WHERE codename = $1 AND ${activeAppRowCondition()}`,
+                      [updates.roleCodename]
+                  )
+                : currentRoleRows
+
+        if (nextRoleRows.length === 0) {
+            throw new Error(`Role '${updates.roleCodename}' not found`)
+        }
+
+        await assertCanMutateProtectedRoles(exec, {
+            actorUserId: changedBy,
+            targetUserId: assignment.user_id,
+            requestedRoles: nextRoleRows
+        })
 
         if (updates.roleCodename && updates.roleCodename !== assignment.role_codename) {
-            // Get new role ID (allow any role)
-            const newRole = await exec.query<{ id: string }>(
-                `
-                SELECT id FROM admin.cat_roles
-                WHERE codename = $1 AND ${activeAppRowCondition()}
-            `,
-                [updates.roleCodename]
-            )
-
-            if (newRole.length === 0) {
-                throw new Error(`Role '${updates.roleCodename}' not found`)
-            }
-
             await exec.query(
                 `
                 UPDATE admin.rel_user_roles
                 SET role_id = $1, comment = $2
                 WHERE id = $3 AND ${activeAppRowCondition()}
             `,
-                [newRole[0].id, updates.comment ?? assignment.comment, assignmentId]
+                [nextRoleRows[0].id, updates.comment ?? assignment.comment, assignmentId]
             )
         } else if (updates.comment !== undefined) {
             await exec.query(
@@ -840,7 +945,8 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
                 r.codename as role_codename,
                 r.name,
                 r.color,
-                r.is_superuser
+                r.is_superuser,
+                r.is_system
             FROM admin.rel_user_roles ur
             JOIN admin.cat_roles r ON ur.role_id = r.id AND ${activeAppRowCondition('r')}
             WHERE ur.id = $1
@@ -991,33 +1097,78 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
     /**
      * Revoke global access from a user (remove all global roles)
      */
-    async function revokeGlobalAccess(userId: string): Promise<boolean> {
-        const result = await getDbExecutor().query<{ id: string }>(
-            `
-            UPDATE admin.rel_user_roles
-            SET ${softDeleteSetClause('$2')}
-            WHERE user_id = $1
-              AND ${activeAppRowCondition()}
-            RETURNING id
-        `,
-            [userId, null]
-        )
-        return result.length > 0
+    async function revokeGlobalAccess(userId: string, revokedBy?: string | null): Promise<boolean> {
+        const exec = getDbExecutor()
+
+        return exec.transaction(async (trx) => {
+            await assertCanMutateProtectedRoles(trx, {
+                actorUserId: revokedBy,
+                targetUserId: userId,
+                requestedRoles: []
+            })
+
+            const result = await trx.query<{ id: string }>(
+                `
+                UPDATE admin.rel_user_roles
+                SET ${softDeleteSetClause('$2')}
+                WHERE user_id = $1
+                  AND ${activeAppRowCondition()}
+                RETURNING id
+            `,
+                [userId, revokedBy ?? null]
+            )
+
+            return result.length > 0
+        })
     }
 
     /**
      * Revoke specific role assignment (SQL)
      */
-    async function revokeAssignment(assignmentId: string): Promise<boolean> {
-        const result = await getDbExecutor().query<{ id: string }>(
-            `UPDATE admin.rel_user_roles
-             SET ${softDeleteSetClause('$2')}
-             WHERE id = $1
-               AND ${activeAppRowCondition()}
-             RETURNING id`,
-            [assignmentId, null]
-        )
-        return result.length > 0
+    async function revokeAssignment(assignmentId: string, revokedBy?: string | null): Promise<boolean> {
+        const exec = getDbExecutor()
+
+        return exec.transaction(async (trx) => {
+            const assignmentRows = await trx.query<{
+                user_id: string
+                role_id: string
+            }>(
+                `SELECT user_id, role_id
+                 FROM admin.rel_user_roles
+                 WHERE id = $1
+                   AND ${activeAppRowCondition()}`,
+                [assignmentId]
+            )
+
+            if (assignmentRows.length === 0) {
+                return false
+            }
+
+            const targetRoleRows = await trx.query<RoleMutationGuardRow>(
+                `SELECT id, codename, is_superuser, is_system
+                 FROM admin.cat_roles
+                 WHERE id = $1
+                   AND ${activeAppRowCondition()}`,
+                [assignmentRows[0].role_id]
+            )
+
+            await assertCanMutateProtectedRoles(trx, {
+                actorUserId: revokedBy,
+                targetUserId: assignmentRows[0].user_id,
+                requestedRoles: targetRoleRows
+            })
+
+            const result = await trx.query<{ id: string }>(
+                `UPDATE admin.rel_user_roles
+                 SET ${softDeleteSetClause('$2')}
+                 WHERE id = $1
+                   AND ${activeAppRowCondition()}
+                 RETURNING id`,
+                [assignmentId, revokedBy ?? null]
+            )
+
+            return result.length > 0
+        })
     }
 
     /**
@@ -1104,11 +1255,6 @@ export function createGlobalAccessService({ getDbExecutor }: GlobalAccessService
 }
 
 export type GlobalAccessService = ReturnType<typeof createGlobalAccessService>
-
-/** Minimal interface for SQL query execution — satisfied by DbSession, DbExecutor, and DataSource */
-interface SqlQueryable {
-    query<T = unknown>(sql: string, parameters?: unknown[]): Promise<T[]>
-}
 
 // ── Neutral versions (accept any SqlQueryable) ──
 

--- a/packages/admin-backend/base/src/tests/routes/dashboardAndGlobalUsersRoutes.test.ts
+++ b/packages/admin-backend/base/src/tests/routes/dashboardAndGlobalUsersRoutes.test.ts
@@ -70,31 +70,24 @@ describe('dashboard and global users routes', () => {
     })
 
     it('rolls back a newly created auth user when role assignment fails', async () => {
-        const globalAccessService = {
-            setUserRoles: jest.fn().mockRejectedValue(new Error('role assignment failed'))
-        }
-        const deleteUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
-        const supabaseAdmin = {
-            auth: {
-                admin: {
-                    createUser: jest.fn().mockResolvedValue({
-                        data: { user: { id: 'user-1', email: 'neo@example.com' } },
-                        error: null
-                    }),
-                    deleteUser
-                }
-            }
+        const globalAccessService = {}
+        const provisioningService = {
+            provisionAuthUserWithRoleIds: jest
+                .fn()
+                .mockRejectedValue(
+                    new Error('Failed to assign roles to the newly created user. Newly created auth account was rolled back.')
+                )
         }
 
         const app = express()
         app.use(express.json())
-        const { sessionQuery } = attachRequestContext(app, 'admin-1')
+        attachRequestContext(app, 'admin-1')
         app.use(
             '/global-users',
             createGlobalUsersRoutes({
                 globalAccessService,
                 permissionService: {} as never,
-                supabaseAdmin: supabaseAdmin as never
+                provisioningService: provisioningService as never
             })
         )
 
@@ -107,8 +100,13 @@ describe('dashboard and global users routes', () => {
             })
 
         expect(response.status).toBe(500)
-        expect(sessionQuery).toHaveBeenCalledWith(expect.stringContaining('UPDATE profiles.cat_profiles'), ['user-1', null])
-        expect(deleteUser).toHaveBeenCalledWith('user-1')
+        expect(provisioningService.provisionAuthUserWithRoleIds).toHaveBeenCalledWith({
+            email: 'neo@example.com',
+            password: 'password123',
+            roleIds: ['00000000-0000-4000-a000-000000000001'],
+            grantedBy: 'admin-1',
+            comment: 'created from admin panel'
+        })
         expect(response.text).toContain('rolled back')
     })
 
@@ -191,6 +189,6 @@ describe('dashboard and global users routes', () => {
         const response = await request(app).delete(`/global-users/${memberId}`)
 
         expect(response.status).toBe(200)
-        expect(globalAccessService.revokeGlobalAccess).toHaveBeenCalledWith(memberId)
+        expect(globalAccessService.revokeGlobalAccess).toHaveBeenCalledWith(memberId, 'admin-1')
     })
 })

--- a/packages/admin-backend/base/src/tests/services/authUserProvisioningService.integration.test.ts
+++ b/packages/admin-backend/base/src/tests/services/authUserProvisioningService.integration.test.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto'
+import { jest } from '@jest/globals'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createKnexExecutor } from '@universo/database'
+import { activeAppRowCondition } from '@universo/utils'
+import type { Knex } from 'knex'
+import { createAuthUserProvisioningService } from '../../services/authUserProvisioningService'
+import { createGlobalAccessService } from '../../services/globalAccessService'
+
+const { createClient } = jest.requireActual('@supabase/supabase-js') as typeof import('@supabase/supabase-js')
+
+/**
+ * Integration tests for auth-user provisioning against a real Supabase project.
+ * Requires DATABASE_TEST_URL, SUPABASE_URL, and SERVICE_ROLE_KEY.
+ *
+ * Run:
+ * DATABASE_TEST_URL=postgresql://... \
+ * SUPABASE_URL=https://<project>.supabase.co \
+ * SERVICE_ROLE_KEY=<service-role> \
+ * pnpm --filter @universo/admin-backend test
+ */
+
+const DATABASE_TEST_URL = process.env.DATABASE_TEST_URL
+const SUPABASE_URL = process.env.SUPABASE_URL
+const SERVICE_ROLE_KEY = process.env.SERVICE_ROLE_KEY
+
+const describeIntegration = DATABASE_TEST_URL && SUPABASE_URL && SERVICE_ROLE_KEY ? describe : describe.skip
+
+describeIntegration('createAuthUserProvisioningService integration (requires Supabase)', () => {
+    let knex: Knex
+    let supabaseAdmin: SupabaseClient
+    let createdUserIds: string[] = []
+    let trackedEmails: string[] = []
+    let trackedProfilePrefixes: string[] = []
+
+    beforeAll(async () => {
+        const knexModule = await import('knex')
+        knex = knexModule.default({
+            client: 'pg',
+            connection: DATABASE_TEST_URL
+        })
+
+        supabaseAdmin = createClient(SUPABASE_URL as string, SERVICE_ROLE_KEY as string, {
+            auth: {
+                persistSession: false,
+                autoRefreshToken: false
+            }
+        })
+    })
+
+    afterEach(async () => {
+        if (!knex) {
+            return
+        }
+
+        const executor = createKnexExecutor(knex)
+        const userIds = new Set(createdUserIds)
+        createdUserIds = []
+
+        if (trackedEmails.length > 0) {
+            const authRows = await executor.query<{ id: string }>(
+                `SELECT id
+                 FROM auth.users
+                 WHERE LOWER(email) = ANY($1::text[])`,
+                [Array.from(new Set(trackedEmails.map((email) => email.toLowerCase())))]
+            )
+            for (const row of authRows) {
+                userIds.add(row.id)
+            }
+        }
+
+        if (userIds.size > 0) {
+            const normalizedUserIds = Array.from(userIds)
+            await executor.query(`DELETE FROM admin.rel_user_roles WHERE user_id = ANY($1::uuid[])`, [normalizedUserIds])
+            await executor.query(`DELETE FROM profiles.cat_profiles WHERE user_id = ANY($1::uuid[])`, [normalizedUserIds])
+
+            for (const userId of normalizedUserIds) {
+                await supabaseAdmin.auth.admin.deleteUser(userId)
+            }
+        }
+
+        for (const profilePrefix of Array.from(new Set(trackedProfilePrefixes))) {
+            await executor.query(`DELETE FROM profiles.cat_profiles WHERE POSITION($1 IN nickname) = 1`, [profilePrefix])
+        }
+
+        trackedEmails = []
+        trackedProfilePrefixes = []
+    })
+
+    afterAll(async () => {
+        if (knex) {
+            await knex.destroy()
+        }
+    })
+
+    it('creates a real bootstrap superuser with auth row, profile row, and exclusive role state', async () => {
+        const executor = createKnexExecutor(knex)
+        const globalAccessService = createGlobalAccessService({ getDbExecutor: () => executor })
+        const provisioningService = createAuthUserProvisioningService({
+            getDbExecutor: () => executor,
+            globalAccessService,
+            supabaseAdmin
+        })
+
+        const email = `bootstrap-int-${randomUUID()}@example.com`
+        trackedEmails.push(email)
+        const result = await provisioningService.ensureBootstrapSuperuser({
+            email,
+            password: 'ChangeMe_123456!'
+        })
+        createdUserIds.push(result.userId)
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                email,
+                createdAuthUser: true,
+                profileEnsured: true,
+                status: 'created'
+            })
+        )
+
+        const authUserResult = await supabaseAdmin.auth.admin.getUserById(result.userId)
+        expect(authUserResult.error).toBeNull()
+        expect(authUserResult.data.user?.email).toBe(email)
+
+        const profileRows = await executor.query<{ user_id: string }>(
+            `SELECT user_id
+             FROM profiles.cat_profiles
+             WHERE user_id = $1
+               AND ${activeAppRowCondition()}`,
+            [result.userId]
+        )
+        expect(profileRows).toHaveLength(1)
+
+        const accessInfo = await globalAccessService.getGlobalAccessInfo(result.userId)
+        expect(accessInfo.isSuperuser).toBe(true)
+        expect(accessInfo.globalRoles).toHaveLength(1)
+        expect(accessInfo.globalRoles[0]).toEqual(
+            expect.objectContaining({
+                codename: 'superuser',
+                metadata: expect.objectContaining({
+                    isSuperuser: true
+                })
+            })
+        )
+    })
+
+    it('rolls back real auth and profile rows when role synchronization fails after user creation', async () => {
+        const executor = createKnexExecutor(knex)
+        const globalAccessService = createGlobalAccessService({ getDbExecutor: () => executor })
+        const provisioningService = createAuthUserProvisioningService({
+            getDbExecutor: () => executor,
+            globalAccessService,
+            supabaseAdmin
+        })
+
+        const localPart = `rollbackint${randomUUID().replace(/-/g, '').slice(0, 8)}`
+        const email = `${localPart}@example.com`
+        const profilePrefix = `${localPart}_`
+        trackedEmails.push(email)
+        trackedProfilePrefixes.push(profilePrefix)
+
+        await expect(
+            provisioningService.provisionAuthUserWithRoleIds({
+                email,
+                password: 'ChangeMe_123456!',
+                roleIds: [randomUUID()],
+                grantedBy: null,
+                comment: 'integration rollback verification'
+            })
+        ).rejects.toThrow('Failed to assign roles to the newly created user. Newly created auth account was rolled back.')
+
+        const authRows = await executor.query<{ id: string }>(`SELECT id FROM auth.users WHERE LOWER(email) = LOWER($1)`, [email])
+        expect(authRows).toHaveLength(0)
+
+        const profileRows = await executor.query<{ user_id: string; nickname: string }>(
+            `SELECT user_id, nickname
+             FROM profiles.cat_profiles
+             WHERE POSITION($1 IN nickname) = 1
+               AND ${activeAppRowCondition()}`,
+            [profilePrefix]
+        )
+        expect(profileRows).toHaveLength(0)
+    })
+})

--- a/packages/admin-backend/base/src/tests/services/authUserProvisioningService.test.ts
+++ b/packages/admin-backend/base/src/tests/services/authUserProvisioningService.test.ts
@@ -1,0 +1,299 @@
+const mockGetOrCreateProfile = jest.fn()
+
+jest.mock('@universo/profile-backend', () => ({
+    ProfileService: jest.fn().mockImplementation(() => ({
+        getOrCreateProfile: mockGetOrCreateProfile
+    }))
+}))
+
+import { createAuthUserProvisioningService } from '../../services/authUserProvisioningService'
+
+const createMockExecutor = () => ({
+    query: jest.fn(),
+    transaction: jest.fn(),
+    isReleased: jest.fn(() => false)
+})
+
+describe('createAuthUserProvisioningService', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetOrCreateProfile.mockResolvedValue({ id: 'profile-1' })
+    })
+
+    it('creates a real auth user, repairs the profile, and assigns roles', async () => {
+        const executor = createMockExecutor()
+        const globalAccessService = {
+            findUserIdByEmail: jest.fn(),
+            getGlobalAccessInfo: jest.fn(),
+            setUserRoles: jest
+                .fn()
+                .mockResolvedValue([
+                    { id: 'role-1', codename: 'editor', isSuperuser: false, isSystem: false, name: null, color: '#111111' }
+                ])
+        }
+        const supabaseAdmin = {
+            auth: {
+                admin: {
+                    createUser: jest.fn().mockResolvedValue({
+                        data: { user: { id: 'user-1', email: 'Neo@Example.com' } },
+                        error: null
+                    }),
+                    deleteUser: jest.fn()
+                }
+            }
+        }
+
+        const service = createAuthUserProvisioningService({
+            getDbExecutor: () => executor as never,
+            globalAccessService: globalAccessService as never,
+            supabaseAdmin: supabaseAdmin as never
+        })
+
+        const result = await service.provisionAuthUserWithRoleIds({
+            email: ' Neo@Example.com ',
+            password: 'ChangeMe_123456!',
+            roleIds: ['role-1'],
+            grantedBy: 'admin-1',
+            comment: 'created from admin panel'
+        })
+
+        expect(supabaseAdmin.auth.admin.createUser).toHaveBeenCalledWith({
+            email: 'neo@example.com',
+            password: 'ChangeMe_123456!',
+            email_confirm: true
+        })
+        expect(mockGetOrCreateProfile).toHaveBeenCalledWith('user-1', 'neo@example.com')
+        expect(globalAccessService.setUserRoles).toHaveBeenCalledWith('user-1', ['role-1'], 'admin-1', 'created from admin panel')
+        expect(result).toEqual(
+            expect.objectContaining({
+                userId: 'user-1',
+                email: 'Neo@Example.com',
+                createdAuthUser: true,
+                profileEnsured: true
+            })
+        )
+    })
+
+    it('invites a user by email when no password is provided and still repairs profile and roles', async () => {
+        const executor = createMockExecutor()
+        const globalAccessService = {
+            findUserIdByEmail: jest.fn(),
+            getGlobalAccessInfo: jest.fn(),
+            setUserRoles: jest
+                .fn()
+                .mockResolvedValue([
+                    { id: 'role-1', codename: 'editor', isSuperuser: false, isSystem: false, name: null, color: '#111111' }
+                ])
+        }
+        const supabaseAdmin = {
+            auth: {
+                admin: {
+                    createUser: jest.fn(),
+                    inviteUserByEmail: jest.fn().mockResolvedValue({
+                        data: { user: { id: 'user-invite', email: 'invitee@example.com' } },
+                        error: null
+                    }),
+                    deleteUser: jest.fn()
+                }
+            }
+        }
+
+        const service = createAuthUserProvisioningService({
+            getDbExecutor: () => executor as never,
+            globalAccessService: globalAccessService as never,
+            supabaseAdmin: supabaseAdmin as never
+        })
+
+        const result = await service.provisionAuthUserWithRoleIds({
+            email: ' Invitee@Example.com ',
+            roleIds: ['role-1'],
+            grantedBy: 'admin-1',
+            comment: 'invited from admin panel'
+        })
+
+        expect(supabaseAdmin.auth.admin.createUser).not.toHaveBeenCalled()
+        expect(supabaseAdmin.auth.admin.inviteUserByEmail).toHaveBeenCalledWith('invitee@example.com')
+        expect(mockGetOrCreateProfile).toHaveBeenCalledWith('user-invite', 'invitee@example.com')
+        expect(globalAccessService.setUserRoles).toHaveBeenCalledWith('user-invite', ['role-1'], 'admin-1', 'invited from admin panel')
+        expect(result).toEqual(
+            expect.objectContaining({
+                userId: 'user-invite',
+                email: 'invitee@example.com',
+                createdAuthUser: true,
+                profileEnsured: true
+            })
+        )
+    })
+
+    it('rolls back the new auth user when role synchronization fails', async () => {
+        const executor = createMockExecutor()
+        executor.query.mockResolvedValue([])
+
+        const globalAccessService = {
+            findUserIdByEmail: jest.fn(),
+            getGlobalAccessInfo: jest.fn(),
+            setUserRoles: jest.fn().mockRejectedValue(new Error('role sync failed'))
+        }
+        const deleteUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+        const supabaseAdmin = {
+            auth: {
+                admin: {
+                    createUser: jest.fn().mockResolvedValue({
+                        data: { user: { id: 'user-1', email: 'neo@example.com' } },
+                        error: null
+                    }),
+                    deleteUser
+                }
+            }
+        }
+
+        const service = createAuthUserProvisioningService({
+            getDbExecutor: () => executor as never,
+            globalAccessService: globalAccessService as never,
+            supabaseAdmin: supabaseAdmin as never
+        })
+
+        await expect(
+            service.provisionAuthUserWithRoleIds({
+                email: 'neo@example.com',
+                password: 'ChangeMe_123456!',
+                roleIds: ['role-1'],
+                grantedBy: 'admin-1'
+            })
+        ).rejects.toThrow('Failed to assign roles to the newly created user. Newly created auth account was rolled back.')
+
+        expect(executor.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE profiles.cat_profiles'), ['user-1', null])
+        expect(deleteUser).toHaveBeenCalledWith('user-1')
+    })
+
+    it('returns noop for an existing bootstrap superuser and ensures the profile exists', async () => {
+        const executor = createMockExecutor()
+        const globalAccessService = {
+            findUserIdByEmail: jest.fn().mockResolvedValue('user-existing'),
+            getGlobalAccessInfo: jest.fn().mockResolvedValue({
+                isSuperuser: true,
+                canAccessAdmin: true,
+                globalRoles: []
+            }),
+            setUserRoles: jest.fn()
+        }
+        const supabaseAdmin = {
+            auth: {
+                admin: {
+                    createUser: jest.fn(),
+                    deleteUser: jest.fn()
+                }
+            }
+        }
+
+        const service = createAuthUserProvisioningService({
+            getDbExecutor: () => executor as never,
+            globalAccessService: globalAccessService as never,
+            supabaseAdmin: supabaseAdmin as never
+        })
+
+        const result = await service.ensureBootstrapSuperuser({
+            email: 'root@example.com',
+            password: 'ChangeMe_123456!'
+        })
+
+        expect(supabaseAdmin.auth.admin.createUser).not.toHaveBeenCalled()
+        expect(mockGetOrCreateProfile).toHaveBeenCalledWith('user-existing', 'root@example.com')
+        expect(result).toEqual({
+            userId: 'user-existing',
+            email: 'root@example.com',
+            createdAuthUser: false,
+            profileEnsured: true,
+            status: 'noop_existing_superuser'
+        })
+    })
+
+    it('refuses bootstrap privilege escalation for an existing non-superuser account', async () => {
+        const executor = createMockExecutor()
+        const globalAccessService = {
+            findUserIdByEmail: jest.fn().mockResolvedValue('user-existing'),
+            getGlobalAccessInfo: jest.fn().mockResolvedValue({
+                isSuperuser: false,
+                canAccessAdmin: false,
+                globalRoles: []
+            }),
+            setUserRoles: jest.fn()
+        }
+        const supabaseAdmin = {
+            auth: {
+                admin: {
+                    createUser: jest.fn(),
+                    deleteUser: jest.fn()
+                }
+            }
+        }
+
+        const service = createAuthUserProvisioningService({
+            getDbExecutor: () => executor as never,
+            globalAccessService: globalAccessService as never,
+            supabaseAdmin: supabaseAdmin as never
+        })
+
+        await expect(
+            service.ensureBootstrapSuperuser({
+                email: 'root@example.com',
+                password: 'ChangeMe_123456!'
+            })
+        ).rejects.toThrow('Refusing automatic privilege escalation.')
+
+        expect(supabaseAdmin.auth.admin.createUser).not.toHaveBeenCalled()
+        expect(mockGetOrCreateProfile).not.toHaveBeenCalled()
+    })
+
+    it('creates a new bootstrap superuser with exclusive role synchronization', async () => {
+        const executor = createMockExecutor()
+        executor.query.mockResolvedValue([{ id: 'role-super', codename: 'superuser' }])
+
+        const globalAccessService = {
+            findUserIdByEmail: jest.fn().mockResolvedValue(null),
+            getGlobalAccessInfo: jest.fn(),
+            setUserRoles: jest.fn().mockResolvedValue([
+                {
+                    id: 'role-super',
+                    codename: 'superuser',
+                    isSuperuser: true,
+                    isSystem: true,
+                    name: null,
+                    color: '#111111'
+                }
+            ])
+        }
+        const supabaseAdmin = {
+            auth: {
+                admin: {
+                    createUser: jest.fn().mockResolvedValue({
+                        data: { user: { id: 'user-created', email: 'root@example.com' } },
+                        error: null
+                    }),
+                    deleteUser: jest.fn()
+                }
+            }
+        }
+
+        const service = createAuthUserProvisioningService({
+            getDbExecutor: () => executor as never,
+            globalAccessService: globalAccessService as never,
+            supabaseAdmin: supabaseAdmin as never
+        })
+
+        const result = await service.ensureBootstrapSuperuser({
+            email: 'root@example.com',
+            password: 'ChangeMe_123456!'
+        })
+
+        expect(executor.query).toHaveBeenCalledWith(expect.stringContaining('FROM admin.cat_roles'), [['superuser']])
+        expect(globalAccessService.setUserRoles).toHaveBeenCalledWith('user-created', ['role-super'], null, 'startup bootstrap superuser')
+        expect(result).toEqual({
+            userId: 'user-created',
+            email: 'root@example.com',
+            createdAuthUser: true,
+            profileEnsured: true,
+            status: 'created'
+        })
+    })
+})

--- a/packages/admin-backend/base/src/tests/services/globalAccessService.test.ts
+++ b/packages/admin-backend/base/src/tests/services/globalAccessService.test.ts
@@ -63,19 +63,45 @@ describe('createGlobalAccessService', () => {
     })
 
     it('updates an existing role assignment instead of inserting a duplicate', async () => {
-        const exec = createMockExecutor([
-            [{ id: 'role-1', name: { _schema: '1', _primary: 'en', locales: {} }, color: '#222222', is_superuser: false }],
-            [],
-            [{ id: 'assignment-1' }],
-            [],
-            [{ id: 'user-1', email: 'neo@example.com' }],
-            [{ user_id: 'user-1', nickname: 'neo' }]
-        ])
+        const txQuery = jest
+            .fn()
+            .mockResolvedValueOnce([{ is_super: false }])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([{ id: 'assignment-1' }])
+            .mockResolvedValueOnce([])
+
+        const exec = {
+            query: jest
+                .fn()
+                .mockResolvedValueOnce([
+                    {
+                        id: 'role-1',
+                        name: { _schema: '1', _primary: 'en', locales: {} },
+                        color: '#222222',
+                        is_superuser: false,
+                        is_system: false
+                    }
+                ])
+                .mockResolvedValueOnce([{ id: 'user-1', email: 'neo@example.com' }])
+                .mockResolvedValueOnce([
+                    {
+                        user_id: 'user-1',
+                        nickname: 'neo',
+                        onboarding_completed: false,
+                        _upl_created_at: new Date('2026-03-18T00:00:00.000Z')
+                    }
+                ]),
+            transaction: jest.fn(async (callback: (trx: MockTransaction) => Promise<unknown>) =>
+                callback({ query: txQuery, transaction: jest.fn(), isReleased: jest.fn(() => false) })
+            ),
+            isReleased: jest.fn(() => false)
+        }
         const service = createGlobalAccessService({ getDbExecutor: () => exec as never })
 
         const result = await service.grantRole('user-1', 'editor', 'admin-1', 'keep current assignment')
 
-        const executedSql = exec.query.mock.calls.map(([sql]) => String(sql))
+        const executedSql = [...txQuery.mock.calls, ...exec.query.mock.calls].map(([sql]) => String(sql))
 
         expect(result).toEqual(
             expect.objectContaining({
@@ -174,6 +200,7 @@ describe('createGlobalAccessService', () => {
                     is_system: false
                 }
             ])
+            .mockResolvedValueOnce([{ is_super: true }])
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([
@@ -199,12 +226,74 @@ describe('createGlobalAccessService', () => {
         const result = await service.setUserRoles('user-1', ['role-super', 'role-editor'], 'admin-1', 'exclusive assignment')
 
         expect(result).toEqual([expect.objectContaining({ codename: 'superuser', isSuperuser: true })])
-        expect(txQuery).toHaveBeenNthCalledWith(3, expect.stringContaining('INSERT INTO admin.rel_user_roles'), [
+        expect(txQuery).toHaveBeenNthCalledWith(4, expect.stringContaining('INSERT INTO admin.rel_user_roles'), [
             'user-1',
             ['role-super'],
             'admin-1',
             'exclusive assignment'
         ])
+    })
+
+    it('blocks non-superusers from assigning protected roles through setUserRoles', async () => {
+        const txQuery = jest
+            .fn()
+            .mockResolvedValueOnce([
+                {
+                    id: 'role-super',
+                    codename: 'superuser',
+                    name: { _schema: '1', _primary: 'en', locales: {} },
+                    color: '#d32f2f',
+                    is_superuser: true,
+                    is_system: true
+                }
+            ])
+            .mockResolvedValueOnce([{ is_super: false }])
+            .mockResolvedValueOnce([])
+
+        const exec = {
+            query: jest.fn(),
+            transaction: jest.fn(async (callback: (trx: MockTransaction) => Promise<unknown>) =>
+                callback({ query: txQuery, transaction: jest.fn(), isReleased: jest.fn(() => false) })
+            ),
+            isReleased: jest.fn(() => false)
+        }
+
+        const service = createGlobalAccessService({ getDbExecutor: () => exec as never })
+
+        await expect(service.setUserRoles('user-1', ['role-super'], 'admin-editor', 'unauthorized promotion')).rejects.toThrow(
+            'Only superusers can modify superuser or system-role assignments'
+        )
+
+        expect(txQuery).not.toHaveBeenCalledWith(expect.stringContaining('UPDATE admin.rel_user_roles'), expect.anything())
+        expect(txQuery).not.toHaveBeenCalledWith(expect.stringContaining('INSERT INTO admin.rel_user_roles'), expect.anything())
+    })
+
+    it('blocks non-superusers from revoking an existing protected role assignment', async () => {
+        const txQuery = jest
+            .fn()
+            .mockResolvedValueOnce([{ is_super: false }])
+            .mockResolvedValueOnce([
+                {
+                    id: 'role-super',
+                    codename: 'superuser',
+                    is_superuser: true,
+                    is_system: true
+                }
+            ])
+
+        const exec = {
+            query: jest.fn(),
+            transaction: jest.fn(async (callback: (trx: MockTransaction) => Promise<unknown>) =>
+                callback({ query: txQuery, transaction: jest.fn(), isReleased: jest.fn(() => false) })
+            ),
+            isReleased: jest.fn(() => false)
+        }
+
+        const service = createGlobalAccessService({ getDbExecutor: () => exec as never })
+
+        await expect(service.revokeGlobalAccess('user-1', 'admin-editor')).rejects.toThrow(
+            'Only superusers can modify superuser or system-role assignments'
+        )
     })
 
     it('keeps registered-only users outside shared workspace access even if they still retain profile visibility', async () => {
@@ -222,13 +311,18 @@ describe('createGlobalAccessService', () => {
     })
 
     it('soft-deletes role assignments when revoking access', async () => {
-        const exec = createMockExecutor([[{ id: 'assignment-1' }], [{ id: 'assignment-2' }]])
+        const exec = createMockExecutor([
+            [{ id: 'assignment-1' }],
+            [{ user_id: 'user-1', role_id: 'role-1' }],
+            [{ id: 'role-1', codename: 'editor', is_superuser: false, is_system: false }],
+            [{ id: 'assignment-2' }]
+        ])
         const service = createGlobalAccessService({ getDbExecutor: () => exec as never })
 
         await service.revokeGlobalAccess('user-1')
         await service.revokeAssignment('assignment-2')
 
-        const [[revokeAllSql, revokeAllParams], [revokeOneSql, revokeOneParams]] = exec.query.mock.calls
+        const [[revokeAllSql, revokeAllParams], , , [revokeOneSql, revokeOneParams]] = exec.query.mock.calls
 
         expect(String(revokeAllSql)).toContain('UPDATE admin.rel_user_roles')
         expect(String(revokeAllSql)).toContain('_upl_deleted = true')
@@ -246,6 +340,7 @@ describe('createGlobalAccessService', () => {
     it('replaces existing roles when legacy grant assigns superuser', async () => {
         const txQuery = jest
             .fn()
+            .mockResolvedValueOnce([{ is_super: true }])
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([{ id: 'assignment-super' }])
 
@@ -253,7 +348,13 @@ describe('createGlobalAccessService', () => {
             query: jest
                 .fn()
                 .mockResolvedValueOnce([
-                    { id: 'role-super', name: { _schema: '1', _primary: 'en', locales: {} }, color: '#111111', is_superuser: true }
+                    {
+                        id: 'role-super',
+                        name: { _schema: '1', _primary: 'en', locales: {} },
+                        color: '#111111',
+                        is_superuser: true,
+                        is_system: true
+                    }
                 ])
                 .mockResolvedValueOnce([{ id: 'user-1', email: 'neo@example.com' }])
                 .mockResolvedValueOnce([
@@ -274,12 +375,42 @@ describe('createGlobalAccessService', () => {
         const result = await service.grantRole('user-1', 'superuser', 'admin-1', 'promoted')
 
         expect(result.roleCodename).toBe('superuser')
-        expect(txQuery).toHaveBeenNthCalledWith(1, expect.stringContaining('UPDATE admin.rel_user_roles'), ['user-1', 'admin-1'])
-        expect(txQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO admin.rel_user_roles'), [
+        expect(result.roles[0]).toEqual(expect.objectContaining({ isSuperuser: true, isSystem: true }))
+        expect(txQuery).toHaveBeenNthCalledWith(2, expect.stringContaining('UPDATE admin.rel_user_roles'), ['user-1', 'admin-1'])
+        expect(txQuery).toHaveBeenNthCalledWith(3, expect.stringContaining('INSERT INTO admin.rel_user_roles'), [
             'user-1',
             'role-super',
             'admin-1',
             'promoted'
         ])
+    })
+
+    it('blocks non-superusers from granting superuser through the legacy grant route', async () => {
+        const txQuery = jest
+            .fn()
+            .mockResolvedValueOnce([{ is_super: false }])
+            .mockResolvedValueOnce([])
+
+        const exec = {
+            query: jest.fn().mockResolvedValueOnce([
+                {
+                    id: 'role-super',
+                    name: { _schema: '1', _primary: 'en', locales: {} },
+                    color: '#111111',
+                    is_superuser: true,
+                    is_system: true
+                }
+            ]),
+            transaction: jest.fn(async (callback: (trx: MockTransaction) => Promise<unknown>) =>
+                callback({ query: txQuery, transaction: jest.fn(), isReleased: jest.fn(() => false) })
+            ),
+            isReleased: jest.fn(() => false)
+        }
+
+        const service = createGlobalAccessService({ getDbExecutor: () => exec as never })
+
+        await expect(service.grantRole('user-1', 'superuser', 'admin-editor', 'unauthorized')).rejects.toThrow(
+            'Only superusers can modify superuser or system-role assignments'
+        )
     })
 })

--- a/packages/universo-core-backend/base/.env.example
+++ b/packages/universo-core-backend/base/.env.example
@@ -155,11 +155,11 @@ BOOTSTRAP_SUPERUSER_ENABLED=true
 
 # BOOTSTRAP_SUPERUSER_EMAIL: Demo bootstrap superuser email for local/dev installs.
 # Change this before any real deployment.
-BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+BOOTSTRAP_SUPERUSER_EMAIL=stalin@kremlin.ru
 
 # BOOTSTRAP_SUPERUSER_PASSWORD: Demo bootstrap superuser password for local/dev installs.
 # Change this before any real deployment.
-BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_PutiN-KgB!
 
 # AUTH_RLS_DEBUG: Enable verbose RLS context debug logging (auth-backend)
 # Default: false

--- a/packages/universo-core-backend/base/.env.example
+++ b/packages/universo-core-backend/base/.env.example
@@ -125,6 +125,7 @@ DATABASE_POOL_MAX=5
 
 # SUPABASE_URL=
 # SUPABASE_ANON_KEY=
+# SERVICE_ROLE_KEY=
 # SUPABASE_JWT_SECRET=
 
 
@@ -147,6 +148,18 @@ DATABASE_POOL_MAX=5
 # AUTO_ROLE_AFTER_ONBOARDING: Automatically grant the global `user` role after onboarding completion.
 # Default: true (set to false to keep users on `/start` until an admin assigns `user` manually)
 # AUTO_ROLE_AFTER_ONBOARDING=true
+
+# BOOTSTRAP_SUPERUSER_ENABLED: Automatically create or confirm the startup superuser after migrations complete.
+# Default: true
+BOOTSTRAP_SUPERUSER_ENABLED=true
+
+# BOOTSTRAP_SUPERUSER_EMAIL: Demo bootstrap superuser email for local/dev installs.
+# Change this before any real deployment.
+BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+
+# BOOTSTRAP_SUPERUSER_PASSWORD: Demo bootstrap superuser password for local/dev installs.
+# Change this before any real deployment.
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
 
 # AUTH_RLS_DEBUG: Enable verbose RLS context debug logging (auth-backend)
 # Default: false

--- a/packages/universo-core-backend/base/README-RU.md
+++ b/packages/universo-core-backend/base/README-RU.md
@@ -30,9 +30,10 @@ packages/universo-core-backend/base/
 1. Проверить обязательную auth-конфигурацию, например `SUPABASE_JWT_SECRET`.
 2. Инициализировать shared Knex singleton из `@universo/database`.
 3. Провалидировать и выполнить registered platform migrations через `@universo/migrations-platform`.
-4. Настроить sessions, CSRF, CORS, JWT auth, sanitization и request logging.
-5. Инициализировать rate limiters для downstream service packages.
-6. Смонтировать роутеры `/api/v1` и отдать frontend bundle из `@universo/core-frontend`.
+4. Если `BOOTSTRAP_SUPERUSER_ENABLED=true`, создать или подтвердить стартового суперпользователя через Supabase Admin API, при необходимости восстановить profile row и обеспечить эксклюзивную глобальную роль `superuser`.
+5. Настроить sessions, CSRF, CORS, JWT auth, sanitization и request logging.
+6. Инициализировать rate limiters для downstream service packages.
+7. Смонтировать роутеры `/api/v1` и отдать frontend bundle из `@universo/core-frontend`.
 
 ## Key Integrations
 
@@ -57,6 +58,29 @@ Request-scoped database access строится от shared Knex runtime и requ
 pnpm --filter @universo/core-backend build
 pnpm --filter @universo/core-backend test
 ```
+
+## Bootstrap Superuser
+
+Core backend умеет автоматически поднимать первого суперпользователя платформы во время старта.
+Этот поток рассчитан на первичный bootstrap платформы и использует реальный Supabase auth account, а не прямые SQL-вставки в `auth.users`.
+
+Обязательный backend env-контракт, если bootstrap включён:
+
+```env
+SUPABASE_URL=https://your-project.supabase.co
+SERVICE_ROLE_KEY=your_server_only_service_role_key
+BOOTSTRAP_SUPERUSER_ENABLED=true
+BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
+```
+
+Примечания:
+
+- `BOOTSTRAP_SUPERUSER_ENABLED` по умолчанию равен `true`.
+- `BOOTSTRAP_SUPERUSER_EMAIL` и `BOOTSTRAP_SUPERUSER_PASSWORD` поставляются как demo credentials только для local/dev bootstrap.
+- Перед любым реальным развёртыванием обязательно замените demo email и пароль.
+- Если bootstrap email уже принадлежит существующему non-superuser аккаунту, старт сервера завершится явной ошибкой вместо молчаливого повышения привилегий.
+- Если аккаунт уже существует и уже является superuser, старт становится безопасным no-op и при необходимости только восстанавливает отсутствующий profile row.
 
 ## Migration Commands
 

--- a/packages/universo-core-backend/base/README.md
+++ b/packages/universo-core-backend/base/README.md
@@ -30,9 +30,10 @@ packages/universo-core-backend/base/
 1. Validate required auth configuration such as `SUPABASE_JWT_SECRET`.
 2. Initialize the shared Knex singleton from `@universo/database`.
 3. Validate and run registered platform migrations through `@universo/migrations-platform`.
-4. Configure sessions, CSRF, CORS, JWT auth, sanitization, and request logging.
-5. Initialize rate limiters for downstream service packages.
-6. Mount `/api/v1` routers and serve the frontend bundle from `@universo/core-frontend`.
+4. If `BOOTSTRAP_SUPERUSER_ENABLED=true`, create or confirm the startup superuser through the Supabase Admin API, repair the profile row if needed, and enforce the exclusive global `superuser` role.
+5. Configure sessions, CSRF, CORS, JWT auth, sanitization, and request logging.
+6. Initialize rate limiters for downstream service packages.
+7. Mount `/api/v1` routers and serve the frontend bundle from `@universo/core-frontend`.
 
 ## Key Integrations
 
@@ -57,6 +58,29 @@ Request-scoped database access is derived from the shared Knex runtime and reque
 pnpm --filter @universo/core-backend build
 pnpm --filter @universo/core-backend test
 ```
+
+## Bootstrap Superuser
+
+The core backend can provision the first platform superuser automatically during startup.
+This flow is intended for a fresh platform bootstrap and uses a real Supabase auth account instead of direct SQL writes into `auth.users`.
+
+Required backend env contract when bootstrap is enabled:
+
+```env
+SUPABASE_URL=https://your-project.supabase.co
+SERVICE_ROLE_KEY=your_server_only_service_role_key
+BOOTSTRAP_SUPERUSER_ENABLED=true
+BOOTSTRAP_SUPERUSER_EMAIL=demo-admin@example.com
+BOOTSTRAP_SUPERUSER_PASSWORD=ChangeMe_123456!
+```
+
+Notes:
+
+- `BOOTSTRAP_SUPERUSER_ENABLED` defaults to `true`.
+- `BOOTSTRAP_SUPERUSER_EMAIL` and `BOOTSTRAP_SUPERUSER_PASSWORD` ship as demo credentials for local/dev bootstrap only.
+- Change the demo email and password before any real deployment.
+- If the bootstrap email already belongs to an existing non-superuser account, startup fails fast instead of silently elevating that account.
+- If the account already exists and is already a superuser, startup becomes a safe no-op and only repairs the missing profile row if necessary.
 
 ## Migration Commands
 

--- a/packages/universo-core-backend/base/src/__tests__/App.initDatabase.test.ts
+++ b/packages/universo-core-backend/base/src/__tests__/App.initDatabase.test.ts
@@ -71,6 +71,10 @@ const mockSyncRegisteredPlatformDefinitionsToCatalog = jest.fn().mockResolvedVal
     }
 })
 const mockIsGlobalMigrationCatalogEnabled = jest.fn(() => true)
+const mockBootstrapStartupSuperuser = jest.fn().mockResolvedValue({
+    enabled: false,
+    status: 'disabled'
+})
 const mockKnex = { tag: 'knex' }
 const mockGetKnex = jest.fn(() => mockKnex)
 const mockDestroyKnex = jest.fn().mockResolvedValue(undefined)
@@ -94,6 +98,10 @@ jest.mock('../utils', () => ({
 jest.mock('../routes', () => ({
     __esModule: true,
     default: express.Router()
+}))
+
+jest.mock('../bootstrap/bootstrapSuperuser', () => ({
+    bootstrapStartupSuperuser: (...args: unknown[]) => mockBootstrapStartupSuperuser(...args)
 }))
 
 jest.mock('../middlewares/errors', () => ({
@@ -244,6 +252,10 @@ describe('App.initDatabase', () => {
                 orderedKeys: ['platform_migration.platform_schema.metahubs.PrepareMetahubsSchemaSupport1766351182000::custom']
             }
         })
+        mockBootstrapStartupSuperuser.mockResolvedValue({
+            enabled: false,
+            status: 'disabled'
+        })
     })
 
     it('initializes database and runs unified platform migrations', async () => {
@@ -286,6 +298,10 @@ describe('App.initDatabase', () => {
                 source: 'core-backend-initDatabase'
             })
         )
+        expect(mockBootstrapStartupSuperuser).toHaveBeenCalledTimes(1)
+        expect(mockBootstrapStartupSuperuser.mock.invocationCallOrder[0]).toBeGreaterThan(
+            mockSyncRegisteredPlatformDefinitionsToCatalog.mock.invocationCallOrder[0]
+        )
         expect(mockDestroyKnex).not.toHaveBeenCalled()
     })
 
@@ -302,6 +318,7 @@ describe('App.initDatabase', () => {
         expect(mockEnsureRegisteredSystemAppSchemaGenerationPlans).not.toHaveBeenCalled()
         expect(mockRunRegisteredPlatformPostSchemaMigrations).not.toHaveBeenCalled()
         expect(mockSyncRegisteredPlatformDefinitionsToCatalog).not.toHaveBeenCalled()
+        expect(mockBootstrapStartupSuperuser).not.toHaveBeenCalled()
         expect(mockDestroyKnex).toHaveBeenCalledTimes(1)
         expect(mockLogger.error).toHaveBeenCalledWith('❌ [server]: Error during database initialization:', expect.any(Error))
     })

--- a/packages/universo-core-backend/base/src/__tests__/bootstrapSuperuser.test.ts
+++ b/packages/universo-core-backend/base/src/__tests__/bootstrapSuperuser.test.ts
@@ -1,0 +1,172 @@
+const mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+}
+
+const mockEnsureBootstrapSuperuser = jest.fn()
+const mockCreateGlobalAccessService = jest.fn()
+const mockCreateAuthUserProvisioningService = jest.fn(() => ({
+    ensureBootstrapSuperuser: mockEnsureBootstrapSuperuser
+}))
+const mockGetPoolExecutor = jest.fn(() => ({ tag: 'pool-executor' }))
+const mockWithAdvisoryLock = jest.fn(async (_executor, _key, work) => work({ tag: 'tx-executor' }))
+const mockCreateSupabaseAdminClient = jest.fn(() => ({ tag: 'supabase-admin' }))
+
+jest.mock('../utils/logger', () => ({
+    __esModule: true,
+    default: mockLogger
+}))
+
+jest.mock(
+    '@universo/admin-backend',
+    () => ({
+        createGlobalAccessService: (...args: unknown[]) => mockCreateGlobalAccessService(...args),
+        createAuthUserProvisioningService: (...args: unknown[]) => mockCreateAuthUserProvisioningService(...args)
+    }),
+    { virtual: true }
+)
+
+jest.mock(
+    '@universo/database',
+    () => ({
+        getPoolExecutor: (...args: unknown[]) => mockGetPoolExecutor(...args)
+    }),
+    { virtual: true }
+)
+
+jest.mock(
+    '@universo/utils/database',
+    () => ({
+        withAdvisoryLock: (...args: unknown[]) => mockWithAdvisoryLock(...args)
+    }),
+    { virtual: true }
+)
+
+jest.mock('../utils/supabaseAdmin', () => ({
+    createSupabaseAdminClient: (...args: unknown[]) => mockCreateSupabaseAdminClient(...args)
+}))
+
+import { bootstrapStartupSuperuser, getBootstrapSuperuserConfig } from '../bootstrap/bootstrapSuperuser'
+
+const ORIGINAL_ENV = process.env
+
+describe('bootstrapStartupSuperuser', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        process.env = { ...ORIGINAL_ENV }
+        delete process.env.BOOTSTRAP_SUPERUSER_ENABLED
+        delete process.env.BOOTSTRAP_SUPERUSER_EMAIL
+        delete process.env.BOOTSTRAP_SUPERUSER_PASSWORD
+        delete process.env.SERVICE_ROLE_KEY
+        delete process.env.SUPABASE_URL
+
+        mockCreateGlobalAccessService.mockReturnValue({ tag: 'global-access-service' })
+        mockEnsureBootstrapSuperuser.mockResolvedValue({
+            userId: 'user-1',
+            email: 'root@example.com',
+            createdAuthUser: true,
+            profileEnsured: true,
+            status: 'created'
+        })
+    })
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV
+    })
+
+    it('returns disabled when BOOTSTRAP_SUPERUSER_ENABLED=false', async () => {
+        process.env.BOOTSTRAP_SUPERUSER_ENABLED = 'false'
+
+        expect(getBootstrapSuperuserConfig()).toEqual({ enabled: false })
+
+        const result = await bootstrapStartupSuperuser()
+
+        expect(result).toEqual({ enabled: false, status: 'disabled' })
+        expect(mockWithAdvisoryLock).not.toHaveBeenCalled()
+        expect(mockCreateSupabaseAdminClient).not.toHaveBeenCalled()
+    })
+
+    it('fails fast when bootstrap is enabled but SERVICE_ROLE_KEY is missing', () => {
+        process.env.BOOTSTRAP_SUPERUSER_ENABLED = 'true'
+        process.env.SUPABASE_URL = 'https://example.supabase.co'
+        process.env.BOOTSTRAP_SUPERUSER_EMAIL = 'root@example.com'
+        process.env.BOOTSTRAP_SUPERUSER_PASSWORD = 'ChangeMe_123456!'
+
+        expect(() => getBootstrapSuperuserConfig()).toThrow(
+            'Bootstrap superuser requires SERVICE_ROLE_KEY when BOOTSTRAP_SUPERUSER_ENABLED=true'
+        )
+    })
+
+    it('fails fast when bootstrap email is invalid', () => {
+        process.env.BOOTSTRAP_SUPERUSER_ENABLED = 'true'
+        process.env.SUPABASE_URL = 'https://example.supabase.co'
+        process.env.SERVICE_ROLE_KEY = 'service-role'
+        process.env.BOOTSTRAP_SUPERUSER_EMAIL = 'not-an-email'
+        process.env.BOOTSTRAP_SUPERUSER_PASSWORD = 'ChangeMe_123456!'
+
+        expect(() => getBootstrapSuperuserConfig()).toThrow('Bootstrap superuser email must be a valid email address')
+    })
+
+    it('fails fast when bootstrap password is too weak', () => {
+        process.env.BOOTSTRAP_SUPERUSER_ENABLED = 'true'
+        process.env.SUPABASE_URL = 'https://example.supabase.co'
+        process.env.SERVICE_ROLE_KEY = 'service-role'
+        process.env.BOOTSTRAP_SUPERUSER_EMAIL = 'root@example.com'
+        process.env.BOOTSTRAP_SUPERUSER_PASSWORD = 'short123'
+
+        expect(() => getBootstrapSuperuserConfig()).toThrow('Bootstrap superuser password must be at least 12 characters long')
+    })
+
+    it('creates or confirms the bootstrap superuser inside an advisory lock', async () => {
+        process.env.BOOTSTRAP_SUPERUSER_ENABLED = 'true'
+        process.env.SUPABASE_URL = 'https://example.supabase.co'
+        process.env.SERVICE_ROLE_KEY = 'service-role'
+        process.env.BOOTSTRAP_SUPERUSER_EMAIL = ' Root@example.com '
+        process.env.BOOTSTRAP_SUPERUSER_PASSWORD = 'ChangeMe_123456!'
+
+        const result = await bootstrapStartupSuperuser()
+
+        expect(mockCreateSupabaseAdminClient).toHaveBeenCalledWith('https://example.supabase.co', 'service-role')
+        expect(mockWithAdvisoryLock).toHaveBeenCalledWith(
+            { tag: 'pool-executor' },
+            'core-bootstrap-superuser:root@example.com',
+            expect.any(Function),
+            { timeoutMs: 15000 }
+        )
+        expect(mockCreateGlobalAccessService).toHaveBeenCalledWith({
+            getDbExecutor: expect.any(Function)
+        })
+        expect(mockCreateAuthUserProvisioningService).toHaveBeenCalledWith({
+            getDbExecutor: expect.any(Function),
+            globalAccessService: { tag: 'global-access-service' },
+            supabaseAdmin: { tag: 'supabase-admin' }
+        })
+        expect(mockEnsureBootstrapSuperuser).toHaveBeenCalledWith({
+            email: 'root@example.com',
+            password: 'ChangeMe_123456!'
+        })
+        expect(result).toEqual({
+            enabled: true,
+            userId: 'user-1',
+            email: 'root@example.com',
+            createdAuthUser: true,
+            profileEnsured: true,
+            status: 'created'
+        })
+    })
+
+    it('warns when bootstrap is running with the public demo credentials', async () => {
+        process.env.BOOTSTRAP_SUPERUSER_ENABLED = 'true'
+        process.env.SUPABASE_URL = 'https://example.supabase.co'
+        process.env.SERVICE_ROLE_KEY = 'service-role'
+        process.env.BOOTSTRAP_SUPERUSER_EMAIL = 'demo-admin@example.com'
+        process.env.BOOTSTRAP_SUPERUSER_PASSWORD = 'ChangeMe_123456!'
+
+        await bootstrapStartupSuperuser()
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            '[server]: Bootstrap superuser is using demo credentials. Change BOOTSTRAP_SUPERUSER_EMAIL and BOOTSTRAP_SUPERUSER_PASSWORD before real deployment.'
+        )
+    })
+})

--- a/packages/universo-core-backend/base/src/__tests__/routes.publicationApplicationSyncFlow.test.ts
+++ b/packages/universo-core-backend/base/src/__tests__/routes.publicationApplicationSyncFlow.test.ts
@@ -32,6 +32,7 @@ jest.mock('@universo/auth-backend', () => {
 jest.mock('@universo/database', () => ({
     __esModule: true,
     getKnex: jest.fn(() => ({})),
+    getPoolExecutor: jest.fn(() => mockExecutor),
     createKnexExecutor: jest.fn(() => mockExecutor)
 }))
 
@@ -170,6 +171,7 @@ jest.mock('@universo/admin-backend', () => {
     return {
         __esModule: true,
         createGlobalAccessService: jest.fn(() => ({})),
+        createDashboardRoutes: jest.fn(emptyRouter),
         createGlobalUsersRoutes: jest.fn(emptyRouter),
         createInstancesRoutes: jest.fn(emptyRouter),
         createRolesRoutes: jest.fn(emptyRouter),

--- a/packages/universo-core-backend/base/src/bootstrap/bootstrapSuperuser.ts
+++ b/packages/universo-core-backend/base/src/bootstrap/bootstrapSuperuser.ts
@@ -1,0 +1,139 @@
+import { createAuthUserProvisioningService, createGlobalAccessService, type EnsureBootstrapSuperuserResult } from '@universo/admin-backend'
+import { getPoolExecutor } from '@universo/database'
+import { withAdvisoryLock } from '@universo/utils/database'
+import logger from '../utils/logger'
+import { createSupabaseAdminClient } from '../utils/supabaseAdmin'
+
+const BOOTSTRAP_SUPERUSER_LOCK_TIMEOUT_MS = 15_000
+const BOOTSTRAP_SUPERUSER_LOCK_PREFIX = 'core-bootstrap-superuser'
+const DEMO_BOOTSTRAP_SUPERUSER_EMAIL = 'demo-admin@example.com'
+const DEMO_BOOTSTRAP_SUPERUSER_PASSWORD = 'ChangeMe_123456!'
+
+interface BootstrapSuperuserDisabledConfig {
+    enabled: false
+}
+
+interface BootstrapSuperuserEnabledConfig {
+    enabled: true
+    supabaseUrl: string
+    serviceRoleKey: string
+    email: string
+    password: string
+}
+
+type BootstrapSuperuserConfig = BootstrapSuperuserDisabledConfig | BootstrapSuperuserEnabledConfig
+
+export interface BootstrapSuperuserStartupResult extends EnsureBootstrapSuperuserResult {
+    enabled: true
+}
+
+const parseEnvBoolean = (value: string | undefined, defaultValue: boolean): boolean => {
+    if (value === undefined || value === '') {
+        return defaultValue
+    }
+
+    const normalized = value.trim().toLowerCase()
+    return normalized === 'true' || normalized === '1'
+}
+
+const normalizeEmail = (value: string): string => value.trim().toLowerCase()
+
+const assertPresent = (value: string | undefined, envName: string): string => {
+    const normalized = value?.trim()
+    if (!normalized) {
+        throw new Error(`Bootstrap superuser requires ${envName} when BOOTSTRAP_SUPERUSER_ENABLED=true`)
+    }
+
+    return normalized
+}
+
+const assertBootstrapEmail = (value: string): string => {
+    const normalized = normalizeEmail(value)
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+    if (!emailPattern.test(normalized)) {
+        throw new Error('Bootstrap superuser email must be a valid email address')
+    }
+
+    return normalized
+}
+
+const assertBootstrapPassword = (value: string): string => {
+    if (value.length < 12) {
+        throw new Error('Bootstrap superuser password must be at least 12 characters long')
+    }
+
+    if (/\s/.test(value)) {
+        throw new Error('Bootstrap superuser password must not contain whitespace')
+    }
+
+    return value
+}
+
+export const getBootstrapSuperuserConfig = (): BootstrapSuperuserConfig => {
+    const enabled = parseEnvBoolean(process.env.BOOTSTRAP_SUPERUSER_ENABLED, true)
+
+    if (!enabled) {
+        return { enabled: false }
+    }
+
+    return {
+        enabled: true,
+        supabaseUrl: assertPresent(process.env.SUPABASE_URL, 'SUPABASE_URL'),
+        serviceRoleKey: assertPresent(process.env.SERVICE_ROLE_KEY, 'SERVICE_ROLE_KEY'),
+        email: assertBootstrapEmail(assertPresent(process.env.BOOTSTRAP_SUPERUSER_EMAIL, 'BOOTSTRAP_SUPERUSER_EMAIL')),
+        password: assertBootstrapPassword(assertPresent(process.env.BOOTSTRAP_SUPERUSER_PASSWORD, 'BOOTSTRAP_SUPERUSER_PASSWORD'))
+    }
+}
+
+export async function bootstrapStartupSuperuser(): Promise<BootstrapSuperuserStartupResult | { enabled: false; status: 'disabled' }> {
+    const config = getBootstrapSuperuserConfig()
+
+    if (!config.enabled) {
+        logger.info('[server]: Bootstrap superuser is disabled')
+        return {
+            enabled: false,
+            status: 'disabled'
+        }
+    }
+
+    if (config.email === DEMO_BOOTSTRAP_SUPERUSER_EMAIL && config.password === DEMO_BOOTSTRAP_SUPERUSER_PASSWORD) {
+        logger.warn(
+            '[server]: Bootstrap superuser is using demo credentials. Change BOOTSTRAP_SUPERUSER_EMAIL and BOOTSTRAP_SUPERUSER_PASSWORD before real deployment.'
+        )
+    }
+
+    logger.info('[server]: Bootstrap superuser is enabled', { email: config.email })
+
+    const supabaseAdmin = createSupabaseAdminClient(config.supabaseUrl, config.serviceRoleKey)
+
+    const result = await withAdvisoryLock(
+        getPoolExecutor(),
+        `${BOOTSTRAP_SUPERUSER_LOCK_PREFIX}:${config.email}`,
+        async (tx) => {
+            const globalAccessService = createGlobalAccessService({ getDbExecutor: () => tx })
+            const provisioningService = createAuthUserProvisioningService({
+                getDbExecutor: () => tx,
+                globalAccessService,
+                supabaseAdmin
+            })
+
+            return provisioningService.ensureBootstrapSuperuser({
+                email: config.email,
+                password: config.password
+            })
+        },
+        { timeoutMs: BOOTSTRAP_SUPERUSER_LOCK_TIMEOUT_MS }
+    )
+
+    logger.info('[server]: Bootstrap superuser completed', {
+        email: result.email,
+        status: result.status,
+        createdAuthUser: result.createdAuthUser
+    })
+
+    return {
+        enabled: true,
+        ...result
+    }
+}

--- a/packages/universo-core-backend/base/src/commands/base.ts
+++ b/packages/universo-core-backend/base/src/commands/base.ts
@@ -17,7 +17,11 @@ export abstract class BaseCommand extends Command {
         SESSION_SECRET: Flags.string(),
         SUPABASE_URL: Flags.string(),
         SUPABASE_ANON_KEY: Flags.string(),
+        SERVICE_ROLE_KEY: Flags.string(),
         SUPABASE_JWT_SECRET: Flags.string(),
+        BOOTSTRAP_SUPERUSER_ENABLED: Flags.string(),
+        BOOTSTRAP_SUPERUSER_EMAIL: Flags.string(),
+        BOOTSTRAP_SUPERUSER_PASSWORD: Flags.string(),
         SESSION_COOKIE_NAME: Flags.string(),
         SESSION_COOKIE_MAXAGE: Flags.string(),
         SESSION_COOKIE_SAMESITE: Flags.string(),
@@ -102,7 +106,11 @@ export abstract class BaseCommand extends Command {
         if (flags.SESSION_SECRET) process.env.SESSION_SECRET = flags.SESSION_SECRET
         if (flags.SUPABASE_URL) process.env.SUPABASE_URL = flags.SUPABASE_URL
         if (flags.SUPABASE_ANON_KEY) process.env.SUPABASE_ANON_KEY = flags.SUPABASE_ANON_KEY
+        if (flags.SERVICE_ROLE_KEY) process.env.SERVICE_ROLE_KEY = flags.SERVICE_ROLE_KEY
         if (flags.SUPABASE_JWT_SECRET) process.env.SUPABASE_JWT_SECRET = flags.SUPABASE_JWT_SECRET
+        if (flags.BOOTSTRAP_SUPERUSER_ENABLED) process.env.BOOTSTRAP_SUPERUSER_ENABLED = flags.BOOTSTRAP_SUPERUSER_ENABLED
+        if (flags.BOOTSTRAP_SUPERUSER_EMAIL) process.env.BOOTSTRAP_SUPERUSER_EMAIL = flags.BOOTSTRAP_SUPERUSER_EMAIL
+        if (flags.BOOTSTRAP_SUPERUSER_PASSWORD) process.env.BOOTSTRAP_SUPERUSER_PASSWORD = flags.BOOTSTRAP_SUPERUSER_PASSWORD
         if (flags.SESSION_COOKIE_NAME) process.env.SESSION_COOKIE_NAME = flags.SESSION_COOKIE_NAME
         if (flags.SESSION_COOKIE_MAXAGE) process.env.SESSION_COOKIE_MAXAGE = flags.SESSION_COOKIE_MAXAGE
         if (flags.SESSION_COOKIE_SAMESITE) process.env.SESSION_COOKIE_SAMESITE = flags.SESSION_COOKIE_SAMESITE

--- a/packages/universo-core-backend/base/src/index.ts
+++ b/packages/universo-core-backend/base/src/index.ts
@@ -3,7 +3,6 @@ import { Request, Response, NextFunction, type RequestHandler } from 'express'
 import path from 'path'
 import cors from 'cors'
 import http from 'http'
-import { createClient } from '@supabase/supabase-js'
 import session from 'express-session'
 import csurf from 'csurf'
 import rateLimit from 'express-rate-limit'
@@ -35,6 +34,8 @@ import { initializeRateLimiters as initializeStartRateLimiters } from '@universo
 import errorHandlerMiddleware from './middlewares/errors'
 import { API_WHITELIST_URLS, isGlobalMigrationCatalogEnabled } from '@universo/utils'
 import 'global-agent/bootstrap'
+import { bootstrapStartupSuperuser } from './bootstrap/bootstrapSuperuser'
+import { createSupabaseAdminClient } from './utils/supabaseAdmin'
 
 const parseSameSite = (value?: string): boolean | 'lax' | 'strict' | 'none' => {
     if (!value) return 'lax'
@@ -151,6 +152,8 @@ export class App {
                 logger.info('[server]: Global migration catalog is disabled; skipping catalog definition sync')
             }
 
+            await bootstrapStartupSuperuser()
+
             logger.info('📦 [server]: Database has been initialized!')
         } catch (error) {
             logger.error('❌ [server]: Error during database initialization:', error)
@@ -222,12 +225,7 @@ export class App {
         const globalAccessService = createGlobalAccessService({ getDbExecutor: getPoolExecutor })
         const supabaseAdmin =
             process.env.SUPABASE_URL && process.env.SERVICE_ROLE_KEY
-                ? createClient(process.env.SUPABASE_URL, process.env.SERVICE_ROLE_KEY, {
-                      auth: {
-                          persistSession: false,
-                          autoRefreshToken: false
-                      }
-                  })
+                ? createSupabaseAdminClient(process.env.SUPABASE_URL, process.env.SERVICE_ROLE_KEY)
                 : undefined
 
         // Allow access from specified domains

--- a/packages/universo-core-backend/base/src/routes/index.ts
+++ b/packages/universo-core-backend/base/src/routes/index.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import type { Router as ExpressRouter, Request, Response, NextFunction } from 'express'
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import pingRouter from './ping'
 // Universo Platformo | Logger
 import logger from '../utils/logger'
@@ -18,6 +18,7 @@ import { createApplicationsServiceRoutes } from '@universo/applications-backend'
 import { createStartServiceRoutes } from '@universo/start-backend'
 // Universo Platformo | Admin
 import {
+    createAuthUserProvisioningService,
     createDashboardRoutes,
     createGlobalUsersRoutes,
     createGlobalAccessService,
@@ -32,6 +33,7 @@ import { createProfileRoutes } from '@universo/profile-backend'
 import { getKnex, getPoolExecutor } from '@universo/database'
 import { OptimisticLockError, lookupUserEmail, isDatabaseConnectTimeoutError, getRequestDbExecutor } from '@universo/utils'
 import helmet from 'helmet'
+import { createSupabaseAdminClient } from '../utils/supabaseAdmin'
 
 const router: ExpressRouter = express.Router()
 
@@ -89,11 +91,7 @@ router.use((req: Request, res: Response, next: NextFunction) => {
 let applicationsRouter: ExpressRouter | null = null
 router.use((req: Request, res: Response, next: NextFunction) => {
     if (!applicationsRouter) {
-        applicationsRouter = createApplicationsServiceRoutes(
-            ensureAuthWithRls,
-            getPoolExecutor,
-            loadPublishedPublicationRuntimeSource
-        )
+        applicationsRouter = createApplicationsServiceRoutes(ensureAuthWithRls, getPoolExecutor, loadPublishedPublicationRuntimeSource)
     }
     if (applicationsRouter) {
         applicationsRouter(req, res, next)
@@ -127,15 +125,22 @@ const permissionService = createPermissionService({ getDbExecutor: getPoolExecut
 
 const supabaseAdmin: SupabaseClient | undefined =
     process.env.SUPABASE_URL && process.env.SERVICE_ROLE_KEY
-        ? createClient(process.env.SUPABASE_URL, process.env.SERVICE_ROLE_KEY, {
-              auth: {
-                  persistSession: false,
-                  autoRefreshToken: false
-              }
-          })
+        ? createSupabaseAdminClient(process.env.SUPABASE_URL, process.env.SERVICE_ROLE_KEY)
         : undefined
 
-const globalUsersRouter = createGlobalUsersRoutes({ globalAccessService, permissionService, supabaseAdmin })
+const provisioningService = supabaseAdmin
+    ? createAuthUserProvisioningService({
+          getDbExecutor: getPoolExecutor,
+          globalAccessService,
+          supabaseAdmin
+      })
+    : undefined
+
+const globalUsersRouter = createGlobalUsersRoutes({
+    globalAccessService,
+    permissionService,
+    provisioningService
+})
 router.use('/admin/global-users', ensureAuthWithRls, globalUsersRouter)
 
 const dashboardRouter = createDashboardRoutes({ globalAccessService })

--- a/packages/universo-core-backend/base/src/utils/supabaseAdmin.ts
+++ b/packages/universo-core-backend/base/src/utils/supabaseAdmin.ts
@@ -1,0 +1,9 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+export const createSupabaseAdminClient = (supabaseUrl: string, serviceRoleKey: string): SupabaseClient =>
+    createClient(supabaseUrl, serviceRoleKey, {
+        auth: {
+            persistSession: false,
+            autoRefreshToken: false
+        }
+    })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ importers:
       '@universo/migrations-core':
         specifier: workspace:*
         version: link:../../universo-migrations-core/base
+      '@universo/profile-backend':
+        specifier: workspace:*
+        version: link:../../profile-backend/base
       '@universo/types':
         specifier: workspace:*
         version: link:../../universo-types/base
@@ -382,6 +385,9 @@ importers:
       '@types/node':
         specifier: 20.12.12
         version: 20.12.12
+      '@universo/database':
+        specifier: workspace:*
+        version: link:../../universo-database/base
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -4982,6 +4988,7 @@ packages:
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.43':
     resolution: {integrity: sha512-BgynXKMjeaX4AfWLARhOKDetBOOghnSiVRjAHVvhiAaDXgdQN8e65mSmXRiVoVtD3cHXx/cfU8Gw0p0K+qYKVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [linux]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.43':


### PR DESCRIPTION
Fixes #732

# Description

This PR implements automatic provisioning of the first platform superuser during server startup, eliminating the need for manual SQL steps when deploying a new instance. The feature uses Supabase Admin API for real auth account creation with advisory lock serialization, idempotent behavior, and fail-closed privilege escalation prevention.

## Changes Made

### Bootstrap Orchestrator
- Added bootstrap orchestrator that runs after migrations and system-app seeding in `App.initDatabase()`
- Validates configuration at startup: email format, password length (>=12 chars), required env vars
- Uses advisory lock to serialize concurrent bootstrap attempts across server instances
- Idempotent: no-op if superuser already exists, fail-closed if email belongs to non-superuser
- Runtime warning emitted when demo credentials are detected

### Auth User Provisioning Service
- Created shared `AuthUserProvisioningService` used by both startup bootstrap and admin panel user creation
- Full provisioning pipeline: Supabase auth user creation, profile repair, role synchronization
- Rollback compensation: cleanup auth user and profile on failure during creation
- Centralized provisioning logic previously scattered across route handlers
- Exported from `@universo/admin-backend` for cross-package use

### Protected Role Guards
- Added privilege escalation prevention in `GlobalAccessService`
- Non-superusers blocked from assigning/revoking `superuser` and `is_system=true` roles
- Added actor parameter to role mutation and revocation endpoints

### Environment Variables
- `BOOTSTRAP_SUPERUSER_ENABLED` (default: `true`) — enable/disable feature
- `BOOTSTRAP_SUPERUSER_EMAIL` — bootstrap account email
- `BOOTSTRAP_SUPERUSER_PASSWORD` — bootstrap account password
- `SERVICE_ROLE_KEY` — Supabase server-only admin key
- All forwarded through CLI flags for CI/CD support

## Additional Work

- Updated `.env.example` with new variables and demo defaults
- Added comprehensive unit tests (`authUserProvisioningService.test.ts`)
- Added integration tests (`authUserProvisioningService.integration.test.ts`)
- Added startup tests (`bootstrapSuperuser.test.ts`)
- Updated architecture documentation (EN/RU): auth.md with bootstrap flow section
- Updated getting-started configuration docs (EN/RU)
- Updated README files (root, admin-backend, universo-core-backend) in EN/RU
- Updated memory-bank progress and tasks
- Added implementation plan document

## Testing

- [ ] Manual testing completed
- [ ] Automated tests pass
- [ ] No breaking changes introduced

<details>
<summary>In Russian</summary>

Исправляет #732

# Описание

Данный PR реализует автоматическое создание первого суперпользователя платформы при запуске сервера, исключая необходимость ручных SQL-операций при развёртывании нового экземпляра. Использует Supabase Admin API для создания реального auth-аккаунта с сериализацией через advisory lock, идемпотентным поведением и защитой от эскалации привилегий.

## Внесённые изменения

### Оркестратор Bootstrap
- Добавлен оркестратор bootstrap, запускаемый после миграций и сидинга системных приложений в `App.initDatabase()`
- Валидация конфигурации при запуске: формат email, длина пароля (>=12 символов), обязательные переменные
- Advisory lock для сериализации параллельных попыток bootstrap между экземплярами сервера
- Идемпотентность: no-op если суперпользователь уже существует, ошибка если email принадлежит не-суперпользователю
- Предупреждение в runtime при обнаружении демо-учётных данных

### Сервис провизионинга Auth User
- Создан общий `AuthUserProvisioningService`, используемый как bootstrap-процессом, так и панелью администрирования
- Полный конвейер: создание Supabase auth-пользователя, восстановление профиля, синхронизация ролей
- Компенсация отката: очистка auth-пользователя и профиля при ошибке
- Централизация логики, ранее разбросанной по обработчикам маршрутов
- Экспорт из `@universo/admin-backend` для кросс-пакетного использования

### Защита привилегированных ролей
- Добавлена защита от эскалации привилегий в `GlobalAccessService`
- Не-суперпользователям заблокировано назначение/отзыв ролей `superuser` и `is_system=true`
- Добавлен параметр актора в эндпоинты мутации и отзыва ролей

### Переменные окружения
- `BOOTSTRAP_SUPERUSER_ENABLED` (по умолчанию: `true`) — включение/отключение функции
- `BOOTSTRAP_SUPERUSER_EMAIL` — email bootstrap-аккаунта
- `BOOTSTRAP_SUPERUSER_PASSWORD` — пароль bootstrap-аккаунта
- `SERVICE_ROLE_KEY` — серверный ключ Supabase Admin
- Все проброшены через CLI-флаги для поддержки CI/CD

## Дополнительная работа

- Обновлён `.env.example` с новыми переменными и демо-значениями
- Добавлены комплексные юнит-тесты (`authUserProvisioningService.test.ts`)
- Добавлены интеграционные тесты (`authUserProvisioningService.integration.test.ts`)
- Добавлены startup-тесты (`bootstrapSuperuser.test.ts`)
- Обновлена документация по архитектуре (EN/RU): auth.md с разделом bootstrap
- Обновлена документация по конфигурации getting-started (EN/RU)
- Обновлены файлы README (корневые, admin-backend, universo-core-backend) на EN/RU
- Обновлён memory-bank: progress и tasks
- Добавлен документ плана реализации

## Тестирование

- [ ] Ручное тестирование завершено
- [ ] Автоматические тесты проходят
- [ ] Не внесено критических изменений

</details>