### PR TITLE
GH834 Add PlayCanvas Editor metahub authoring surface settings

### DIFF
--- a/docs/en/platform/metahubs/packages.md
+++ b/docs/en/platform/metahubs/packages.md
@@ -8,11 +8,12 @@ Packages are reusable workspace libraries that a metahub can declare as runtime 
 
 ![Metahub Resources Packages tab](../../.gitbook/assets/platform/metahub-packages.png)
 
-The first MVP registry contains three built-in workspace wrappers:
+The registry contains built-in workspace wrappers and authoring packages:
 
 -   `@universo-react/colyseus-client`
 -   `@universo-react/colyseus-server`
 -   `@universo-react/playcanvas-engine`
+-   `@universo-react/playcanvas-editor`
 
 The project-local MMOOMM skills under `.agents/skills/` use these wrappers as
 their version source of truth: PlayCanvas Engine guidance targets
@@ -23,11 +24,13 @@ and Colyseus server guidance targets `@colyseus/core@0.17.43`.
 
 Open **Metahub → Resources → Packages** to see the available registry packages and the packages connected to the current metahub.
 
-The tab shows the user-facing package name, workspace import name, selected version, upstream library, supported runtime target, and connection status. You can connect a package, disconnect it, or switch the connected version when another registered version exists.
+The tab shows the user-facing package name, selected version, upstream library, surface, and connection status. You can connect a package, disconnect it, switch the connected version when another registered version exists, and configure authoring-only package display settings.
 
 ## Runtime Publication
 
-When a metahub is published, connected packages are included in the publication snapshot and synchronized into the application runtime metadata table `_app_packages`. Runtime modules can then declare allowed package imports and import the connected package by its workspace name.
+When a metahub is published, connected runtime packages are included in the publication snapshot and synchronized into the application runtime metadata table `_app_packages`. Runtime modules can then declare allowed package imports and import the connected package by its workspace name.
+
+Authoring-only packages such as PlayCanvas Editor stay in metahub package settings but are excluded from runtime publication snapshots and `_app_packages`.
 
 ## Current Scope
 

--- a/docs/en/platform/playcanvas-editor.md
+++ b/docs/en/platform/playcanvas-editor.md
@@ -6,7 +6,7 @@ description: PlayCanvas Editor artifact package foundation.
 
 `@universo-react/playcanvas-editor` is the Platformo foundation package for the official PlayCanvas Editor frontend artifact.
 
-The package vendors a pinned upstream PlayCanvas Editor snapshot and keeps it isolated from the runtime MUI shells. It is not a React component package and it is not registered as a metahub runtime package in this foundation slice.
+The package vendors a pinned upstream PlayCanvas Editor snapshot and keeps it isolated from the runtime MUI shells. It is not a React component package and it is registered as an authoring-only metahub package with no runtime targets.
 
 ## Current Scope
 
@@ -19,7 +19,7 @@ The package vendors a pinned upstream PlayCanvas Editor snapshot and keeps it is
 -   Required Node.js version for Editor build: `>=22.22.0`
 -   Smoke mode: `artifact-only`
 
-The package can build and verify a static artifact, but it does not yet provide metahub scene storage, asset upload, collaboration, backend API emulation, iframe bridge, Colyseus authoring, or AI/MCP scene editing.
+The package can build and verify a static artifact. Metahubs can connect it from **Resources → Packages**, configure how the editor opens, and load the static artifact through the authenticated metahub package route. It does not yet provide metahub scene storage, asset upload, collaboration, backend API emulation, iframe bridge messaging, Colyseus authoring, or AI/MCP scene editing.
 
 ## Commands
 
@@ -35,10 +35,24 @@ The package intentionally does not define a normal `build` script yet. Root `pnp
 ## Boundary Rules
 
 -   Do not import PlayCanvas Editor vendor source, PCUI, or Observer state into normal MUI shells.
--   Do not add this package to metahub package seed data in the foundation slice.
+-   Keep this package authoring-only: `source.runtimeTargets` must stay empty unless a later approved runtime brief changes that boundary.
+-   Do not include this package in publication runtime snapshots or `_app_packages`.
 -   Do not store an upstream `package.json` under `vendor/playcanvas-editor/`.
 -   Keep upstream updates pinned and reviewed through `vendor/UPSTREAM.md`.
 
+## Metahub Display Settings
+
+The first integration slice stores per-metahub display settings in `metahubs.rel_metahub_packages.config`:
+
+-   Disabled
+-   Embedded iframe
+-   Open separately
+-   Development URL
+
+Embedded and open-separately modes both use the authenticated metahub host route. Open separately opens a second host page in a new tab, and that page still loads the artifact through the sandboxed iframe instead of exposing the raw artifact URL as the top-level document. The host iframe uses a sandbox without `allow-same-origin`; when the authenticated host descriptor is resolved, the backend issues a short-lived tokenized artifact URL so the sandboxed document can load its static JS/CSS assets without cookie-based same-origin access. Every tokenized artifact request is revalidated against the issuing user's current `manageMetahub` access and the current package attachment display mode before a file is served. Development URL mode is shown only when `PLAYCANVAS_EDITOR_DEVELOPMENT_URLS` enables at least one backend-allowlisted origin, and the backend still validates the saved URL before the host can use it.
+
+Metahub copy, snapshot export, and snapshot import preserve these package display settings. Treat exported metahub snapshots as owner-managed sensitive artifacts: when Development URL mode is enabled, the snapshot can include the saved development URL so imports can restore the authoring configuration.
+
 ## Future Integration
 
-Later briefs can add a serving route, iframe host, metahub storage adapter, asset pipeline, module external-file integration, Colyseus authoring, and AI/MCP tooling. Those integrations must preserve the artifact boundary unless a new approved plan changes it.
+Later briefs can add a metahub storage adapter, asset pipeline, module external-file integration, Colyseus authoring, iframe bridge messaging, and AI/MCP tooling. Those integrations must preserve the artifact boundary unless a new approved plan changes it.

--- a/docs/ru/platform/metahubs/packages.md
+++ b/docs/ru/platform/metahubs/packages.md
@@ -8,11 +8,12 @@ description: Подключение workspace-пакетов к метахабу
 
 ![Вкладка Пакеты в ресурсах метахаба](../../.gitbook/assets/platform/metahub-packages.png)
 
-Первый MVP-реестр содержит три встроенные обёртки:
+Реестр содержит встроенные workspace-обёртки и authoring-пакеты:
 
 -   `@universo-react/colyseus-client`
 -   `@universo-react/colyseus-server`
 -   `@universo-react/playcanvas-engine`
+-   `@universo-react/playcanvas-editor`
 
 Project-local MMOOMM skills в `.agents/skills/` используют эти обёртки как
 источник версий: PlayCanvas Engine guidance ориентирован на `playcanvas@2.18.1`,
@@ -23,11 +24,13 @@ guidance — на `@colyseus/core@0.17.43`.
 
 Откройте **Metahub → Resources → Packages**, чтобы увидеть доступные пакеты реестра и пакеты, подключённые к текущему метахабу.
 
-Вкладка показывает пользовательское имя пакета, workspace import name, выбранную версию, upstream-библиотеку, поддерживаемый runtime target и статус подключения. Пакет можно подключить, отключить или переключить на другую зарегистрированную версию.
+Вкладка показывает пользовательское имя пакета, выбранную версию, upstream-библиотеку, поверхность и статус подключения. Пакет можно подключить, отключить, переключить на другую зарегистрированную версию и настроить отображение authoring-only пакетов.
 
 ## Runtime-публикация
 
-При публикации метахаба подключённые пакеты попадают в snapshot публикации и синхронизируются в runtime-таблицу приложения `_app_packages`. После этого runtime-модули могут объявлять разрешённые package imports и импортировать подключённый пакет по его workspace-имени.
+При публикации метахаба подключённые runtime-пакеты попадают в snapshot публикации и синхронизируются в runtime-таблицу приложения `_app_packages`. После этого runtime-модули могут объявлять разрешённые package imports и импортировать подключённый пакет по его workspace-имени.
+
+Authoring-only пакеты, такие как PlayCanvas Editor, остаются в настройках пакетов метахаба, но исключаются из runtime snapshots публикации и `_app_packages`.
 
 ## Текущий scope
 

--- a/docs/ru/platform/playcanvas-editor.md
+++ b/docs/ru/platform/playcanvas-editor.md
@@ -51,7 +51,7 @@ pnpm --filter @universo-react/playcanvas-editor editor:browser-smoke
 
 Встроенный режим и режим отдельного открытия используют authenticated route хоста метахаба. Отдельное открытие запускает вторую страницу хоста в новой вкладке, и эта страница всё равно загружает artifact через sandboxed iframe, а не открывает raw artifact URL как top-level document. Iframe хоста использует sandbox без `allow-same-origin`; после проверки authenticated host descriptor backend выдаёт короткоживущий tokenized artifact URL, чтобы sandboxed document мог загрузить свои static JS/CSS assets без cookie-based same-origin доступа. Каждый tokenized artifact request повторно проверяется по текущему доступу `manageMetahub` пользователя, который получил token, и по текущему режиму отображения подключённого пакета перед отдачей файла. Режим адреса разработки показывается только если `PLAYCANVAS_EDITOR_DEVELOPMENT_URLS` включает хотя бы один backend-allowlisted origin, и backend всё равно валидирует сохранённый URL перед использованием в host surface.
 
-Копирование метахаба, snapshot export и snapshot import сохраняют эти настройки отображения пакета. Считайте экспортированные snapshots метахаба чувствительными owner-managed artifacts: когда включён режим адреса разработки, snapshot может содержать сохранённый development URL, чтобы импорт мог восстановить authoring configuration.
+Копирование метахаба, экспорт снимка и импорт снимка сохраняют эти настройки отображения пакета. Считайте экспортированные снимки метахаба чувствительными артефактами, которыми управляет владелец: когда включён режим адреса разработки, снимок может содержать сохранённый адрес разработки, чтобы импорт мог восстановить authoring configuration.
 
 ## Будущая интеграция
 

--- a/docs/ru/platform/playcanvas-editor.md
+++ b/docs/ru/platform/playcanvas-editor.md
@@ -6,7 +6,7 @@ description: Foundation-пакет артефакта PlayCanvas Editor.
 
 `@universo-react/playcanvas-editor` — foundation-пакет Platformo для официального frontend-артефакта PlayCanvas Editor.
 
-Пакет содержит закреплённый upstream snapshot PlayCanvas Editor и изолирует его от runtime MUI shells. Это не пакет React-компонентов и в этом foundation-срезе он не регистрируется как runtime package метахаба.
+Пакет содержит закреплённый upstream snapshot PlayCanvas Editor и изолирует его от runtime MUI shells. Это не пакет React-компонентов; он регистрируется как authoring-only пакет метахаба без runtime targets.
 
 ## Текущий охват
 
@@ -19,7 +19,7 @@ description: Foundation-пакет артефакта PlayCanvas Editor.
 -   Required Node.js version for Editor build: `>=22.22.0`
 -   Smoke mode: `artifact-only`
 
-Пакет может собрать и проверить static artifact, но ещё не реализует хранение сцен в метахабе, загрузку ассетов, collaboration, backend API emulation, iframe bridge, Colyseus authoring или AI/MCP scene editing.
+Пакет может собрать и проверить static artifact. Метахабы могут подключить его через **Resources → Packages**, настроить способ открытия редактора и загрузить static artifact через authenticated host route пакетов метахаба. Сам iframe получает короткоживущий tokenized artifact URL, чтобы static JS/CSS ассеты загружались внутри sandbox без `allow-same-origin`. Он ещё не реализует хранение сцен в метахабе, загрузку ассетов, collaboration, backend API emulation, iframe bridge messaging, Colyseus authoring или AI/MCP scene editing.
 
 ## Команды
 
@@ -35,10 +35,24 @@ pnpm --filter @universo-react/playcanvas-editor editor:browser-smoke
 ## Правила границы
 
 -   Не импортировать vendor source PlayCanvas Editor, PCUI или Observer state в обычные MUI shells.
--   Не добавлять этот пакет в metahub package seed data в foundation-срезе.
+-   Сохранять пакет authoring-only: `source.runtimeTargets` должен оставаться пустым, пока отдельный утверждённый runtime-бриф не изменит эту границу.
+-   Не включать пакет в runtime snapshots публикации и `_app_packages`.
 -   Не хранить upstream `package.json` в `vendor/playcanvas-editor/`.
 -   Upstream updates должны оставаться закреплёнными и reviewable через `vendor/UPSTREAM.md`.
 
+## Настройки отображения в метахабе
+
+Первый integration-срез хранит настройки отображения для конкретного метахаба в `metahubs.rel_metahub_packages.config`:
+
+-   Отключён
+-   Встроенный iframe
+-   Открывать отдельно
+-   Адрес разработки
+
+Встроенный режим и режим отдельного открытия используют authenticated route хоста метахаба. Отдельное открытие запускает вторую страницу хоста в новой вкладке, и эта страница всё равно загружает artifact через sandboxed iframe, а не открывает raw artifact URL как top-level document. Iframe хоста использует sandbox без `allow-same-origin`; после проверки authenticated host descriptor backend выдаёт короткоживущий tokenized artifact URL, чтобы sandboxed document мог загрузить свои static JS/CSS assets без cookie-based same-origin доступа. Каждый tokenized artifact request повторно проверяется по текущему доступу `manageMetahub` пользователя, который получил token, и по текущему режиму отображения подключённого пакета перед отдачей файла. Режим адреса разработки показывается только если `PLAYCANVAS_EDITOR_DEVELOPMENT_URLS` включает хотя бы один backend-allowlisted origin, и backend всё равно валидирует сохранённый URL перед использованием в host surface.
+
+Копирование метахаба, snapshot export и snapshot import сохраняют эти настройки отображения пакета. Считайте экспортированные snapshots метахаба чувствительными owner-managed artifacts: когда включён режим адреса разработки, snapshot может содержать сохранённый development URL, чтобы импорт мог восстановить authoring configuration.
+
 ## Будущая интеграция
 
-Следующие брифы могут добавить serving route, iframe host, metahub storage adapter, asset pipeline, module external-file integration, Colyseus authoring и AI/MCP tooling. Эти интеграции должны сохранять artifact boundary, если новый утверждённый план явно не изменит архитектуру.
+Следующие брифы могут добавить metahub storage adapter, asset pipeline, module external-file integration, Colyseus authoring, iframe bridge messaging и AI/MCP tooling. Эти интеграции должны сохранять artifact boundary, если новый утверждённый план явно не изменит архитектуру.

--- a/memory-bank/currentResearch.md
+++ b/memory-bank/currentResearch.md
@@ -1,5 +1,14 @@
 # Current Research
 
+## 2026-06-01: PlayCanvas Editor metahub authoring surface settings
+
+-   Research artifact created: `memory-bank/research/playcanvas-editor-metahub-authoring-surface-settings-research-2026-06-01.md`.
+-   Scope decision: implement the next PlayCanvas Editor integration slice as metahub design-time package settings plus a safe artifact host, not scene/project persistence, Editor backend emulation, typed bridge, Colyseus authoring, or MCP/AI automation.
+-   Storage recommendation: add validated per-attachment config directly to `metahubs.rel_metahub_packages` with a versioned JSON envelope, and add a separate package-version authoring/display descriptor outside `source.runtimeTargets`.
+-   Lifecycle implication: copy, metahub snapshot export, and metahub snapshot import must preserve package display settings in the same slice; runtime publication propagation through `_app_packages.config` should remain deferred unless PLAN explicitly expands sync/diff contracts.
+-   UI implication: extend the existing Packages tab with typed localized settings and an honest `Open editor` host action; do not expose raw JSON/IDs/paths/URLs, and prove no horizontal overflow or iframe interaction traps.
+-   Static serving implication: the Editor artifact route must be reserved, traversal-safe, mounted before the core SPA fallback, and guarded with explicit availability checks, CSP/frame/sandbox/referrer/cache/content-type policy.
+
 ## 2026-05-31: PlayCanvas Editor package foundation
 
 -   Research artifact created: `memory-bank/research/playcanvas-editor-package-foundation-research-2026-05-31.md`.

--- a/memory-bank/plan/playcanvas-editor-metahub-authoring-surface-settings-plan-2026-06-01.md
+++ b/memory-bank/plan/playcanvas-editor-metahub-authoring-surface-settings-plan-2026-06-01.md
@@ -1,0 +1,635 @@
+# Plan: PlayCanvas Editor Metahub Authoring Surface Settings
+
+> Created: 2026-06-01
+> Mode: PLAN
+> Status: Draft for discussion
+> Brief: `.manager/specs/platformo/playcanvas-editor-metahub-authoring-surface-settings-spec-2026-06-01.md`
+> Research: `memory-bank/research/playcanvas-editor-metahub-authoring-surface-settings-research-2026-06-01.md`
+
+## Overview
+
+Implement the next PlayCanvas Editor integration slice as a metahub design-time package settings and host surface.
+
+The implementation should let a metahub owner attach `@universo-react/playcanvas-editor`, configure how the isolated artifact is displayed, and open a safe localized host page. This plan deliberately does not add PlayCanvas scene/project persistence, Editor backend emulation, typed bridge synchronization, Colyseus authoring, or runtime publication propagation.
+
+## Inputs And Verification Used
+
+- Brief: `.manager/specs/platformo/playcanvas-editor-metahub-authoring-surface-settings-spec-2026-06-01.md`.
+- Research artifact: `memory-bank/research/playcanvas-editor-metahub-authoring-surface-settings-research-2026-06-01.md`.
+- Prior package foundation plan/research:
+  - `memory-bank/plan/playcanvas-editor-package-foundation-plan-2026-05-31.md`
+  - `memory-bank/research/playcanvas-editor-package-foundation-research-2026-05-31.md`
+- Local package foundation:
+  - `packages/universo-react-playcanvas-editor/README.md`
+  - `packages/universo-react-playcanvas-editor/vendor/UPSTREAM.md`
+  - `packages/universo-react-playcanvas-editor/src/index.ts`
+  - `packages/universo-react-playcanvas-editor/scripts/lib/playcanvas-editor-artifact.mjs`
+- Current package/metahub code:
+  - `packages/universo-react-types/src/common/packages.ts`
+  - `packages/universo-react-metahubs-backend/src/persistence/packagesStore.ts`
+  - `packages/universo-react-metahubs-backend/src/domains/packages/`
+  - `packages/universo-react-metahubs-backend/src/domains/modules/services/MetahubModulesService.ts`
+  - `packages/universo-react-metahubs-frontend/src/domains/packages/`
+  - `packages/universo-react-metahubs-frontend/src/domains/entities/shared/ui/SharedResourcesPage.tsx`
+  - `packages/universo-react-core-backend/src/index.ts`
+  - `packages/universo-react-applications-backend/src/routes/sync/syncPackagePersistence.ts`
+  - `packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts`
+- Repository architecture context requested by the brief:
+  - `.kiro/steering/structure.md`
+  - `.kiro/steering/recommendations.md`
+  - `memory-bank/techContext.md`
+  - `memory-bank/productContext.md`
+  - `memory-bank/systemPatterns.md`
+- Skills used for this plan:
+  - `research-before-plan`
+  - `universo-platform-architecture`
+  - `mui-runtime-ux-patterns`
+  - `runtime-ux-qa`
+  - `browser-3d-runtime-integration`
+  - `playwright-best-practices`
+- Subagent reviews:
+  - backend/storage/snapshot/sync review confirmed `authoringSurface` should be separate from runtime `source`, `rel_metahub_packages.config` is the best first storage owner, and runtime `_app_packages.config` propagation should be deferred.
+  - frontend/UX/security review confirmed the need for a route-first host, typed settings UI, action overflow, localized states, iframe sandbox/CSP gates, and Playwright browser evidence.
+- Current external documentation rechecked on 2026-06-01:
+  - PlayCanvas Editor package foundation remains based on upstream Editor `v2.22.1` and artifact-only local integration.
+  - Context7 `/mui/material-ui` confirms responsive `Dialog` with `useMediaQuery`, accessible labeled `Select`/`TextField select`, and accessible `Tabs` patterns.
+  - Context7 `/vitejs/vite` confirms nested static artifact serving must align with `base` or relative base behavior.
+  - OWASP clickjacking/CSP guidance supports explicit `frame-src`/`child-src`, `frame-ancestors`, and iframe `sandbox` decisions.
+
+## Architecture Decisions
+
+### 1. Descriptor Name And Ownership
+
+Use `authoringSurface` as the package-version registry descriptor.
+
+Reasons:
+
+- The package is an authoring tool, not a runtime module dependency.
+- `displaySurface` is too generic and can be confused with published-app display.
+- Extending `source.runtimeTargets` would make the Editor look like a Modules import package and would be ignored by current source normalizers.
+
+The descriptor lives on `metahubs.obj_packages.authoring_surface JSONB NOT NULL DEFAULT '{}'::jsonb` and in shared TypeScript types as `PackageAuthoringSurfaceDescriptor`.
+
+### 2. Per-Attachment Settings Storage
+
+Store metahub-specific package settings in `metahubs.rel_metahub_packages.config JSONB NOT NULL DEFAULT '{}'::jsonb`.
+
+Reasons:
+
+- The setting belongs to the package attachment lifecycle: attach, detach, version change, copy, snapshot export, and snapshot import.
+- A companion table adds lifecycle and permission coupling without current benefit.
+- The relation already enforces one active package version per metahub/package name.
+
+### 3. Runtime Publication Propagation
+
+Defer publication/runtime `_app_packages.config` propagation.
+
+Reasons:
+
+- Runtime sync currently resets `_app_packages.config` and does not model it in `ApplicationPackageDefinition`.
+- This slice is design-time metahub settings and host access, not published runtime configuration.
+- Copy and metahub snapshot export/import must preserve settings now; runtime sync can be a later explicit brief.
+
+Important boundary:
+
+- Authoring-only packages such as `@universo-react/playcanvas-editor` must be excluded from runtime publication snapshots and must not be written into application `_app_packages`.
+- Current publication serialization can read all attached packages through `MetahubPackagesService.listPublishedPackages()`, and application sync writes `snapshot.packages` to `_app_packages`. Implementation must split design-time package export/import from runtime publication package serialization or add an explicit runtime-target filter at the publication boundary.
+- Runtime package definitions remain limited to packages with at least one supported `source.runtimeTargets` entry.
+
+### 4. Host Shape
+
+Use a route-first MUI host page, launched from the Packages tab.
+
+Recommended routes:
+
+- Frontend host route: `/metahub/:metahubId/resources/packages/:packageSlug/editor`
+- Authenticated same-origin artifact route: `/api/v1/metahub/:metahubId/packages/:packageSlug/editor-artifact/*`
+
+The user-facing host route uses a readable package slug such as `playcanvas-editor`; normal users never need to type or understand package attachment UUIDs. The backend resolves the slug to the attached package and validates metahub access.
+
+The artifact route is served through authenticated API routing or an equivalent explicit non-API auth/access guard. Session middleware alone is not enough because the current core backend auth guard only protects `/api/v1`, while the root static frontend fallback is public. The static route must be mounted before the core frontend static serving plus SPA fallback.
+
+### 5. Version Change Policy
+
+For this first slice:
+
+- preserve config only when the target package version has the same `authoringSurface.schemaVersion` and supports the current display mode;
+- otherwise reset to the target version defaults after explicit user confirmation in the version-change dialog;
+- never silently carry incompatible config.
+
+This avoids writing a generic migration engine before there is more than one descriptor version.
+
+### 6. Development URL Policy
+
+For this first implementation, `developmentUrl` is a local/development-only mode.
+
+- Production builds must treat `developmentUrl` as disabled unless a later brief explicitly adds staging/admin external URL support.
+- Backend validation is authoritative; frontend gating is only a convenience.
+- Allowed development origins must be configured through an explicit environment allowlist.
+- Blocked URL errors must be localized and must not expose full blocked URLs outside manager-only settings fields.
+
+## Affected Areas
+
+- Shared contracts:
+  - `packages/universo-react-types/src/common/packages.ts`
+  - `packages/universo-react-types/src/index.ts`
+- Backend schema, seed, and stores:
+  - `packages/universo-react-metahubs-backend/src/platform/migrations/1766351182000-CreateMetahubsSchema.sql.ts`
+  - new additive platform migration for existing databases
+  - `packages/universo-react-metahubs-backend/src/platform/systemAppDefinition.ts`
+  - `packages/universo-react-metahubs-backend/src/domains/packages/data/seed-packages.json`
+  - `packages/universo-react-metahubs-backend/src/domains/packages/services/PackageSeeder.ts`
+  - `packages/universo-react-metahubs-backend/src/persistence/packagesStore.ts`
+  - `packages/universo-react-metahubs-backend/src/domains/packages/controllers/packagesController.ts`
+  - `packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts`
+  - `packages/universo-react-metahubs-backend/src/domains/modules/services/MetahubModulesService.ts`
+- Copy, snapshot, and hash behavior:
+  - `packages/universo-react-metahubs-backend/src/domains/publications/services/SnapshotSerializer.ts`
+  - `packages/universo-react-metahubs-backend/src/domains/publications/services/SnapshotRestoreService.ts`
+  - package copy flow in metahubs backend controllers/services
+  - `packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts` only for an explicit audit proving design-time package config should not accidentally affect runtime publication hashing in this slice.
+- Static host and artifact integration:
+  - `packages/universo-react-metahubs-backend/src/domains/packages/`
+  - `packages/universo-react-core-backend/src/index.ts` only for generic static/CSP plumbing if the metahubs router cannot own the whole response path
+  - `packages/universo-react-playcanvas-editor/src/index.ts` only if route constants or manifest helpers need to be exported
+- Frontend:
+  - `packages/universo-react-metahubs-frontend/src/domains/packages/api/packagesApi.ts`
+  - `packages/universo-react-metahubs-frontend/src/domains/packages/hooks/`
+  - `packages/universo-react-metahubs-frontend/src/domains/packages/ui/MetahubPackagesTab.tsx`
+  - new package settings dialog/component under `packages/universo-react-metahubs-frontend/src/domains/packages/ui/`
+  - new host page/route under the current metahub frontend route owner
+  - `packages/universo-react-metahubs-frontend/src/i18n/locales/en/metahubs.json`
+  - `packages/universo-react-metahubs-frontend/src/i18n/locales/ru/metahubs.json`
+  - `packages/universo-react-i18n` only for labels reused outside the metahubs package boundary
+- REST/OpenAPI and docs:
+  - `packages/universo-react-rest-docs/src/openapi/index.yml`
+  - `docs/en/platform/playcanvas-editor.md`
+  - `docs/ru/platform/playcanvas-editor.md`
+  - `docs/en/platform/metahubs/packages.md`
+  - `docs/ru/platform/metahubs/packages.md`
+  - `docs/en/SUMMARY.md`
+  - `docs/ru/SUMMARY.md`
+
+## Shared Contract
+
+Add typed contracts before backend/UI changes so all layers agree on the descriptor and config shape.
+
+Recommended initial type shape:
+
+```ts
+export type PackageAuthoringSurfaceKind = 'none' | 'playcanvasEditor'
+
+export type PackageDisplayMode =
+  | 'disabled'
+  | 'embeddedIframe'
+  | 'openSeparately'
+  | 'developmentUrl'
+
+export interface PackageAuthoringSurfaceNoneDescriptor {
+  schemaVersion: '1'
+  kind: 'none'
+  supportedDisplayModes: readonly []
+  defaultConfig: PackageAttachmentEmptyConfig
+}
+
+export interface PlayCanvasEditorAuthoringSurfaceDescriptor {
+  schemaVersion: '1'
+  kind: 'playcanvasEditor'
+  supportedDisplayModes: readonly PackageDisplayMode[]
+  defaultConfig: PackageAttachmentConfig
+  artifact?: {
+    packageName: '@universo-react/playcanvas-editor'
+    manifestFileName: 'universo-artifact-manifest.json'
+    outputRoot: 'dist/editor'
+    smokeMode: 'artifact-only'
+  }
+}
+
+export type PackageAuthoringSurfaceDescriptor =
+  | PackageAuthoringSurfaceNoneDescriptor
+  | PlayCanvasEditorAuthoringSurfaceDescriptor
+
+export interface PackageAttachmentEmptyConfig {
+  schemaVersion: '1'
+  kind: 'none'
+}
+
+export interface PackageAttachmentDisplayConfig {
+  schemaVersion: '1'
+  kind: 'display'
+  display: {
+    mode: PackageDisplayMode
+    developmentUrl?: string | null
+    showArtifactOnlyNotice: boolean
+  }
+}
+
+export type PackageAttachmentConfig =
+  | PackageAttachmentEmptyConfig
+  | PackageAttachmentDisplayConfig
+
+export type PackageSlug = 'playcanvas-editor' | string
+
+export interface PackageAuthoringHostDescriptor {
+  packageSlug: PackageSlug
+  packageName: string
+  attachmentConfig: PackageAttachmentConfig
+  authoringSurface: PackageAuthoringSurfaceDescriptor
+  artifactStatus: 'available' | 'missing' | 'disabled' | 'blocked' | 'misconfigured'
+}
+```
+
+Rules:
+
+- Keep config envelope small and versioned.
+- Normalize database `{}` or missing `authoring_surface` to `{ schemaVersion: '1', kind: 'none', supportedDisplayModes: [] }` at API boundaries.
+- Normalize database `{}` or missing attachment `config` to `{ schemaVersion: '1', kind: 'none' }` for packages without an authoring surface.
+- Define slug mapping deterministically: start from the unscoped package basename (`@universo-react/playcanvas-editor` -> `playcanvas-editor`), reserve slugs in the registry, and reject seed/registry collisions. Do not derive a route from a database UUID.
+- Keep design-time package attachment DTOs separate from runtime `ApplicationPackageDefinition`; authoring config and host descriptors must not be added to runtime publication DTOs in this slice.
+- Keep validation strict; unknown top-level keys should be rejected by the backend endpoint.
+- Do not expose raw config JSON in normal UI.
+- Add local normalization helpers first; move pure shared helpers to `@universo-react/utils` only when both backend and frontend need the exact same runtime logic.
+
+## UI Contract
+
+### Packages Tab
+
+- Reuse the existing Resources shell and `FlowListTable` density.
+- Keep columns stable and compact:
+  - `#`
+  - Package
+  - Version
+  - Dependency
+  - Surface / Availability
+  - Status
+  - Actions
+- Replace the current runtime-only wording with authoring-aware labels:
+  - runtime packages show localized runtime targets;
+  - authoring-only packages show a localized `Authoring tool` chip;
+  - packages with no module import target show a localized `No runtime import` label.
+- Use an overflow menu or stable action cluster for `Open editor`, `Settings`, `Change version`, and `Disconnect`.
+- Users without `manageMetahub` can see status and open allowed read-only surfaces, but cannot save settings, change versions, or disconnect packages.
+- Never show raw package IDs, attachment IDs, source JSON, config JSON, `[object Object]`, or internal route names.
+
+### Package Settings Dialog
+
+- Reuse existing MUI dialog patterns, preferably `StandardDialog` if it matches this flow.
+- Use responsive `fullScreen` behavior for small screens via MUI `useMediaQuery`.
+- Use an accessible labeled `TextField select`, `Select` plus `InputLabel`, or a segmented/radio control for display mode.
+- Fields:
+  - display mode: disabled, embedded iframe, open separately, development URL;
+  - development URL: visible only when environment/admin gating allows it;
+  - artifact status: read-only localized status chip/block, not manifest JSON;
+  - reset to defaults action.
+- Validation:
+  - localized EN/RU messages;
+  - no raw Zod/internal messages;
+  - invalid or blocked development URL maps to a safe user-facing error code.
+- Save behavior:
+  - optimistic update only if existing package mutation patterns already support it safely;
+  - otherwise invalidate TanStack Query keys after successful save.
+
+### Editor Host Page
+
+- Route-first page, not a card nested inside the Packages table.
+- Header shows localized package display name and state, not IDs.
+- Iframe region has stable dimensions and responsive constraints.
+- Supported states:
+  - loading;
+  - disabled by settings;
+  - artifact available but artifact-only;
+  - artifact missing;
+  - development URL blocked;
+  - misconfigured package attachment;
+  - iframe load failed.
+- The normal user surface must not show stack traces, raw protocol errors, absolute filesystem paths, raw manifest JSON, or full blocked URLs. Manager-only settings may show the configured development URL field because the owner edits that value directly.
+
+## Security And Artifact Host Contract
+
+- Mount the static artifact route after existing security/session/auth middleware and before core frontend `express.static('/')` plus SPA fallback.
+- Require authenticated metahub access to both the host route and the artifact route. Direct unauthenticated requests to the raw artifact route must return 401/403 or a safe redirect; they must not return artifact HTML.
+- Serve the artifact through `/api/v1/metahub/:metahubId/packages/:packageSlug/editor-artifact/*` or an equivalent explicitly authenticated proxy. Do not rely on session middleware placement alone.
+- Follow the existing API session/auth/CSRF policy for the new config mutation and artifact endpoints, or document a narrow safe exception for static GET/HEAD artifact assets.
+- Validate both `index.html` and `universo-artifact-manifest.json` before reporting artifact availability.
+- Protect against normal and encoded path traversal.
+- Send explicit content types, `X-Content-Type-Options: nosniff`, and a deliberate cache policy.
+- Configure parent host `frame-src`/`child-src` for same-origin artifact route and allowlisted dev origins only.
+- Account for the current backend CSP shape: global CSP mainly sets `frame-ancestors`, and API routes may disable Helmet CSP. The host implementation must explicitly prove parent `frame-src`/`child-src` and child artifact headers do not weaken or conflict with existing policy.
+- Keep `frame-ancestors` policy separate from child iframe loading policy.
+- Do not import upstream Editor DOM, PCUI, Observer state, or vendored Editor source into the metahubs React tree. The iframe/static artifact boundary is the only allowed integration surface in this slice.
+- Use iframe attributes:
+
+```tsx
+<iframe
+  title={t('metahubs.packages.editorHost.iframeTitle')}
+  src={iframeSrc}
+  sandbox="allow-scripts"
+  referrerPolicy="no-referrer"
+  allow=""
+/>
+```
+
+Implementation may add `allow-same-origin` only if the artifact is served from an isolated origin/subdomain or the implementation proves the need with compensating controls and tests. Same-origin `allow-scripts allow-same-origin` is not the default because it gives framed scripts stronger access to the platform origin.
+
+Development URL mode:
+
+- disabled in production by default;
+- enabled only in local/development deployments through an explicit environment allowlist;
+- URL parsed and allowlisted by the backend, not only by frontend controls;
+- blocked states localize the reason and avoid leaking full URLs to viewer/error states.
+
+## Plan Steps
+
+- [ ] Step 1: Lock final storage and descriptor contracts before coding.
+  - Confirm `authoringSurface` as the registry descriptor.
+  - Confirm `rel_metahub_packages.config` as the per-attachment settings owner.
+  - Confirm `packages[].config` as the snapshot field.
+  - Confirm runtime `_app_packages.config` propagation is deferred.
+  - Confirm authoring-only packages are excluded from runtime publication snapshots and application `_app_packages`.
+  - Confirm `developmentUrl` is local/development-only in this slice; staging/admin external URL support is deferred.
+  - Record these decisions in the implementation PR and docs.
+
+- [ ] Step 2: Extend shared package types.
+  - Add `PackageAuthoringSurfaceDescriptor`, `PackageAttachmentConfig`, `PackageDisplayMode`, and related DTOs in `packages/universo-react-types/src/common/packages.ts`.
+  - Add `PackageAuthoringHostDescriptor` and slug-related types for the host route/API.
+  - Extend `MetahubPackageRegistryItem`, `MetahubPackageAttachment`, `MetahubPackageCatalogItem`, and `MetahubSnapshotPackage`.
+  - Keep `PackageSourceDescriptor` runtime/import-oriented.
+  - Keep runtime `ApplicationPackageDefinition` separate from design-time package config/host DTOs.
+  - Add type-level tests or focused compile tests if the package has an existing pattern for shared type contracts.
+
+- [ ] Step 3: Add schema and system app metadata.
+  - Add an additive migration:
+    - `metahubs.obj_packages.authoring_surface JSONB NOT NULL DEFAULT '{}'::jsonb`
+    - `metahubs.rel_metahub_packages.config JSONB NOT NULL DEFAULT '{}'::jsonb`
+  - Update `1766351182000-CreateMetahubsSchema.sql.ts` so fresh DB creation matches migrations.
+  - Export the additive migration from `packages/universo-react-metahubs-backend/src/platform/migrations/index.ts`.
+  - Register the additive migration through the metahubs system app definition migration list used by platform migration loading.
+  - Update `systemAppDefinition.ts`.
+  - Do not bump metahub schema version or metahub template version.
+
+- [ ] Step 4: Update package seed data.
+  - Add `@universo-react/playcanvas-editor` to `seed-packages.json`.
+  - Set `source.runtimeTargets: []`.
+  - Add `authoringSurface` with schema version `1`, default config, supported display modes, and artifact metadata.
+  - Add or derive a reserved deterministic `packageSlug`, initially `playcanvas-editor`, and fail seed/registry validation on slug collisions.
+  - Update `PackageSeeder` checksum/upsert logic so `authoringSurface` changes are detected.
+  - Add seed tests proving the Editor package is authoring-only and does not expose runtime targets.
+
+- [ ] Step 5: Update backend stores.
+  - Return `authoringSurface` from registry/catalog queries.
+  - Return attachment `config` from attached package queries.
+  - Initialize config from descriptor defaults when attaching a package.
+  - Add `updateMetahubPackageConfig` with `RETURNING` and fail-closed behavior.
+  - Copy `config` in metahub copy flow.
+  - Restore `config` in snapshot import; legacy snapshots without config default safely.
+  - Apply the version-change policy: preserve compatible config; require confirmation and reset incompatible config.
+  - Define all conflict/upsert paths explicitly:
+    - re-attaching the same package version preserves existing config unless the user requested reset to defaults;
+    - changing package version preserves compatible config and resets incompatible config only after confirmation;
+    - copy `ON CONFLICT DO UPDATE` writes source config into the target attachment;
+    - restore `ON CONFLICT DO UPDATE` writes snapshot config into the restored attachment;
+    - every returning shape includes `authoringSurface` and normalized `config`.
+
+  Example store mutation:
+
+  ```ts
+  await executor.query(
+    `UPDATE ${attachmentsTable}
+        SET config = $3::jsonb,
+            _upl_updated_at = now(),
+            _upl_updated_by = $4
+      WHERE id = $2
+        AND metahub_id = $1
+        AND _upl_deleted = false
+        AND _app_deleted = false
+      RETURNING id, metahub_id, package_id, package_name, expected_version, config`,
+    [metahubId, attachmentId, JSON.stringify(config), userId]
+  )
+  ```
+
+- [ ] Step 6: Add backend validation and routes.
+  - Add `PATCH /metahub/:metahubId/package/:attachmentId/config`.
+  - Add a read endpoint for the host route, such as `GET /metahub/:metahubId/packages/:packageSlug/authoring-host`, that resolves the attached package by slug and returns a DTO without exposing attachment UUIDs as user-facing data.
+  - Gate config writes with `manageMetahub`.
+  - Keep the config mutation under the existing authenticated API and CSRF protection policy.
+  - Validate config against the attached package version descriptor.
+  - Return client-mappable domain error codes, not raw Zod or SQL messages.
+  - Add an artifact status endpoint if the frontend host needs server-side artifact availability without probing static HTML directly.
+  - Ensure artifact status errors never expose absolute filesystem paths or internal package paths.
+  - Update OpenAPI in `packages/universo-react-rest-docs/src/openapi/index.yml`, including an explicit note that attachment config is preserved for metahub copy/snapshot flows but is not propagated to runtime publication in this slice.
+
+- [ ] Step 7: Protect Modules allowlist.
+  - Update only metahub package allowlist filtering so authoring-only packages never become Modules import dependencies; do not change compiler behavior, external-file modules behavior, or the broader Modules subsystem in this slice.
+  - Filter packages with no `runtimeTargets`.
+  - Add a test with PlayCanvas Editor attached and verify it is absent from allowed imports.
+
+- [ ] Step 8: Update snapshot, copy, and hash flows.
+  - Split design-time metahub package snapshot export/import from runtime publication package serialization if they currently share `MetahubPackagesService.listPublishedPackages()`.
+  - Export package `config` only in metahub design-time snapshots.
+  - Restore package `config` only from metahub design-time snapshots, with backwards compatibility for snapshots that do not include it.
+  - Copy package `config` during metahub copy.
+  - Filter authoring-only packages out of runtime publication snapshots and application sync input; runtime `_app_packages` must receive only packages with non-empty supported `source.runtimeTargets`.
+  - Do not add design-time package config to runtime `publicationSnapshotHash` unless the implementation first proves that hash is used for metahub snapshot equivalence rather than application runtime publication. The default expectation for this slice is no runtime publication hash change.
+  - Add deterministic JSON key-order normalization only inside metahub snapshot export/import tests or local snapshot comparison helpers that are not runtime publication sync.
+
+- [ ] Step 9: Add static artifact host backend integration.
+  - Own artifact status and artifact serving routes in the metahubs backend packages domain, because attachment resolution and metahub access checks belong there.
+  - Use core backend only for generic Express/static/CSP plumbing if the metahubs router cannot own the whole response path.
+  - Serve `packages/universo-react-playcanvas-editor/dist/editor` as the PlayCanvas Editor artifact source; `@universo-react/playcanvas-editor` may export route constants or manifest helpers, but must not export UI components from upstream Editor.
+  - Mount the route under the authenticated artifact URL `/api/v1/metahub/:metahubId/packages/:packageSlug/editor-artifact/*` or an equivalent explicit auth proxy.
+  - Validate authenticated metahub access and attached package resolution before serving artifact HTML/assets.
+  - Validate `index.html` and `universo-artifact-manifest.json`.
+  - Verify the Editor artifact Vite `base` or relative asset strategy is compatible with the nested `/api/v1/.../editor-artifact/*` route.
+  - Add a test that asset URLs under the nested route resolve to JS/CSS/assets rather than the SPA fallback.
+  - Mount before core frontend static serving and SPA fallback.
+  - Add security headers and cache policy.
+  - Keep the route independent from root build enrollment of the Editor artifact.
+  - Prohibit direct imports of upstream PCUI, Observer, Editor DOM, or vendored app state into MUI code.
+
+- [ ] Step 10: Extend frontend API and TanStack Query hooks.
+  - Add typed `updatePackageConfig`, optional `getPackageArtifactStatus`, and host launch helpers in `packagesApi.ts`.
+  - Add query keys for package settings/artifact status.
+  - Invalidate the attached package list and relevant settings queries after mutations.
+  - Keep API DTOs mapped to view models before rendering.
+
+- [ ] Step 11: Update Packages tab UI.
+  - Replace runtime-only column text with authoring-aware `Surface / Availability`.
+  - Add localized authoring/no-runtime chips.
+  - Add `Open editor` and `Settings` actions through an existing menu/action primitive such as `BaseEntityMenu` if it fits; otherwise document why a small local MUI `Menu` is needed in `MetahubPackagesTab`.
+  - Preserve read-only permission behavior.
+  - Avoid page-level horizontal overflow on desktop/tablet/mobile.
+
+- [ ] Step 12: Add typed Package Settings dialog.
+  - Build a PlayCanvas Editor settings form driven by `authoringSurface`.
+  - Support display mode, gated development URL, artifact status, save, cancel, and reset defaults.
+  - Localize all labels, helper text, validation, success, and error states in EN/RU.
+  - Use existing MUI/template primitives before adding new UI components.
+  - Check `StandardDialog` capabilities before relying on responsive fullscreen behavior. If `StandardDialog` still does not support `fullScreen`, either extend that shared primitive with tests or use MUI `Dialog` locally with an explicit rationale and matching visual contract.
+
+- [ ] Step 13: Add route-first Editor host page.
+  - Register the host route in the current core frontend route owner under singular `/metahub/:metahubId/resources/packages/:packageSlug/editor`.
+  - Use readable `packageSlug` route values such as `playcanvas-editor`; never require users to type or recognize attachment UUIDs.
+  - Fetch attachment/config/status through the slug-based authoring-host API, not by exposing attachment UUIDs in the route.
+  - Render honest states for disabled, artifact-only, missing artifact, blocked dev URL, misconfigured attachment, and load failed.
+  - Render iframe only when the selected mode permits it.
+  - Implement `openSeparately` as opening the host route in a new tab/window, not the raw static artifact route.
+  - Add keyboard/no-hidden-knowledge acceptance checks: the workflow must be reachable through visible row actions and route state, not manual URL construction.
+
+- [ ] Step 14: Add i18n.
+  - Add EN/RU keys for:
+    - authoring surface labels;
+    - no-runtime labels;
+    - settings dialog;
+    - display modes;
+    - artifact status;
+    - host states;
+    - validation and domain error codes;
+    - action labels/tooltips.
+  - Keep feature-local keys in metahubs frontend unless reused by another package boundary.
+  - Move shared labels to `packages/universo-react-i18n` only when another package consumes them.
+
+- [ ] Step 15: Add GitBook documentation.
+  - Update `docs/en/platform/playcanvas-editor.md` and `docs/ru/platform/playcanvas-editor.md`.
+  - Update `docs/en/platform/metahubs/packages.md` and `docs/ru/platform/metahubs/packages.md`.
+  - Update `docs/en/SUMMARY.md` and `docs/ru/SUMMARY.md` if new pages or headings are added.
+  - Document artifact-only status, supported display modes, development URL gating, copy/snapshot behavior, and explicitly deferred runtime propagation.
+  - Match the OpenAPI/API wording: package config is a metahub design-time attachment setting and is not part of runtime application publication in this slice.
+
+- [ ] Step 16: Add backend tests.
+  - Store tests:
+    - attach creates default config;
+    - catalog/list return `authoringSurface` and config;
+    - update config requires attachment/metahub match;
+    - version change resets incompatible config only after confirmation;
+    - copy preserves config;
+    - restore preserves config and imports legacy snapshots without config.
+  - Seeder tests:
+    - PlayCanvas Editor seed includes `authoringSurface`;
+    - seed checksum changes when descriptor changes;
+    - Editor `runtimeTargets` is empty.
+  - Route/controller tests:
+    - config update requires `manageMetahub`;
+    - invalid mode/dev URL returns safe 400 domain error;
+    - unknown attachment returns 404;
+    - successful update returns typed config.
+  - Modules tests:
+    - authoring-only package is excluded from import allowlist.
+  - Runtime publication tests:
+    - authoring-only package is absent from runtime publication snapshots;
+    - authoring-only package is not written to application `_app_packages`;
+    - runtime packages with non-empty targets continue to sync as before.
+  - Static host tests:
+    - unauthenticated direct artifact route returns 401/403 or a safe redirect;
+    - authenticated user without metahub access cannot load the artifact through the host/artifact route;
+    - route order before SPA fallback;
+    - manifest and index checks;
+    - traversal and encoded traversal forbidden;
+    - CSP/security headers present.
+    - iframe sandbox defaults do not include `allow-same-origin` for same-origin artifact routes.
+    - artifact route never falls through to the public SPA `index.html`.
+  - Slug tests:
+    - `@universo-react/playcanvas-editor` resolves to `playcanvas-editor`;
+    - unknown slug returns 404 without leaking internal IDs;
+    - slug collision in registry/seed validation fails closed.
+  - Migration/bootstrap tests:
+    - compiled system app definition includes `authoring_surface` and `config`;
+    - fixed system-app structure/configuration version policy is covered by an explicit test or documented migration-only rationale;
+    - additive migration is exported and registered through the metahubs system app definition.
+
+- [ ] Step 17: Add frontend Vitest tests.
+  - `packagesApi` typed config methods.
+  - `MetahubPackagesTab` renders PlayCanvas Editor without empty runtime/raw cells.
+  - Actions menu contains `Open editor`, `Settings`, and `Disconnect` with permission-aware states.
+  - Settings dialog defaults, validation, reset, save, read-only behavior.
+  - Host component states and iframe attributes.
+  - Route registration uses `/metahub/:metahubId/resources/packages/:packageSlug/editor`.
+  - EN/RU i18n keys exist for all new visible text.
+
+- [ ] Step 18: Add Playwright E2E with browser evidence.
+  - Use local Supabase minimal for this feature as requested.
+  - Do not run `pnpm dev`; use the repository Playwright wrapper.
+  - Recommended command flow for implementation verification:
+
+  ```bash
+  pnpm supabase:e2e:start:minimal
+  pnpm run build:e2e:local-supabase
+  cross-env UNIVERSO_ENV_FILE=.env.e2e.local-supabase UNIVERSO_FRONTEND_ENV_FILE=packages/universo-react-core-frontend/.env.e2e.local-supabase node tools/testing/e2e/run-playwright-suite.mjs --project chromium --grep "PlayCanvas Editor package settings"
+  pnpm supabase:e2e:stop
+  ```
+
+  - Required browser flows:
+    - create/open a metahub on fresh local Supabase;
+    - attach PlayCanvas Editor package;
+    - open settings;
+    - change display mode and save;
+    - refresh and verify persistence;
+    - open Editor host;
+    - verify artifact-only state;
+    - verify blocked development URL state;
+    - verify direct unauthenticated raw artifact URL is blocked;
+    - verify PlayCanvas Editor is absent from runtime publication package output;
+    - copy metahub and verify settings;
+    - export/import snapshot and verify settings.
+  - Required screenshots:
+    - Packages tab at `1920x1080`, `768x1024`, and `390x844`;
+    - settings dialog EN and RU;
+    - host artifact-only state;
+    - missing artifact or blocked development URL state;
+    - read-only user Packages tab.
+  - Required UX assertions:
+    - no page-level horizontal overflow;
+    - no raw IDs, raw JSON, `[object Object]`, stack traces, Zod messages, or absolute paths;
+    - keyboard path opens settings, changes mode, saves, and opens the host;
+    - iframe has expected `sandbox`, `referrerpolicy`, and constrained `allow`.
+
+- [ ] Step 19: Run package-scoped verification.
+  - Use targeted package commands first:
+
+  ```bash
+  pnpm --filter @universo-react/types build
+  pnpm --filter @universo-react/metahubs-backend test
+  pnpm --filter @universo-react/metahubs-frontend test
+  pnpm --filter @universo-react/core-backend test
+  pnpm --filter @universo-react/rest-docs build
+  ```
+
+  - Run root `pnpm build` only after targeted checks pass or when the user explicitly wants the full workspace rebuild.
+  - Do not make the root build depend on building the PlayCanvas Editor upstream artifact unless the Node/dependency constraints are deliberately accepted in a later step.
+
+- [ ] Step 20: Final QA and closeout.
+  - Run the Runtime UI UX Quality Gate on screenshots and Playwright traces.
+  - Review the implementation against the brief non-goals.
+  - Confirm docs match actual UI and artifact-only limitations.
+  - Confirm no stale references imply scene persistence or runtime publication propagation.
+
+## Testing Matrix
+
+| Layer | Tool | Coverage |
+| --- | --- | --- |
+| Shared contracts | TypeScript build / focused tests | Descriptor/config DTO compatibility and exports |
+| Backend storage | Jest or existing backend test runner | schema fields, defaults, update, copy, restore, version policy |
+| Backend routes | Jest/API tests | permissions, validation, 400/404/200 behavior |
+| Seeder | Jest | PlayCanvas Editor registry row, checksum, authoring-only status |
+| Modules | Jest | authoring-only package excluded from allowed imports |
+| Static host | Jest/API tests | route order, traversal, headers, manifest/index checks |
+| Frontend components | Vitest/RTL | table labels, actions, dialog, host states, iframe attrs, i18n |
+| E2E browser | Playwright wrapper | full attach/settings/open flow, EN/RU, read-only, screenshots, no overflow |
+| Docs | manual review plus link check if available | GitBook pages and SUMMARY entries match actual implementation |
+
+## Potential Challenges
+
+- `source` metadata drift: putting authoring fields inside `source` would be dropped or misread by current runtime normalizers. Keep authoring metadata separate.
+- UI crowding: adding actions directly as separate icons can break responsive layout. Use an overflow menu or stable action cluster.
+- False runtime expectations: the host must say artifact-only until scene/project persistence exists.
+- Development URL risk: external iframes can weaken security if allowlists, CSP, and sandbox policies are loose.
+- Static route order: mounting the artifact route after the SPA fallback will make artifact loading fail or return the core app shell.
+- Snapshot compatibility: old snapshots without `config` must still import.
+- Version changes: incompatible config must not silently survive package version changes.
+- Root build coupling: the Editor artifact has separate upstream assumptions and should not become a required root build dependency in this slice.
+
+## Dependencies
+
+- Existing metahub package foundation must remain in place.
+- Local Supabase minimal E2E workflow must be healthy for browser validation.
+- The current PlayCanvas Editor package remains artifact-only and pinned through `vendor/UPSTREAM.md`.
+- No metahub schema/template version bump is planned; implementation targets fresh DB parity plus additive migration safety.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -55,6 +55,156 @@
 
 ---
 
+## 2026-06-01 - PlayCanvas Editor Host UX QA Closure
+
+### Summary
+
+Closed the remaining host UX QA gap for the PlayCanvas Editor metahub
+authoring surface by making frame readiness explicit and adding browser
+regressions for failure states that previously depended on implicit iframe
+behavior.
+
+### Completed
+
+-   Added localized loading and load-failure states to the PlayCanvas Editor host
+    iframe flow, and only show the artifact-ready state after the iframe has
+    actually loaded.
+-   Added same-origin artifact preflight handling so unavailable artifact routes
+    fail closed with user-facing copy instead of exposing raw paths, HTTP
+    statuses, or browser error details.
+-   Closed the autoreview asset-loading defect by switching same-origin iframe
+    artifacts to a short-lived tokenized artifact URL, preserving the host
+    sandbox without `allow-same-origin` while allowing the sandboxed document to
+    load static JS/CSS chunks without session cookies.
+-   Closed the follow-up core middleware gap by routing dynamic signed artifact
+    URLs through the shared API whitelist matcher and proving that neighboring
+    metahub package routes remain authenticated.
+-   Strengthened Playwright `@packages` coverage for user-facing metahub
+    navigation, blocked and misconfigured host descriptors, and iframe load
+    failure without raw technical leakage or horizontal overflow, including an
+    anonymous browser-context request to the tokenized artifact URL.
+-   Updated backend route tests, OpenAPI generation, and GitBook docs for the
+    tokenized artifact route.
+
+### Verification
+
+-   `pnpm --filter @universo-react/metahubs-frontend build`
+-   `pnpm --filter @universo-react/metahubs-backend build`
+-   `pnpm --filter @universo-react/metahubs-backend test -- --runInBand src/tests/routes/packagesRoutes.test.ts src/tests/persistence/packagesStore.test.ts src/tests/services/MetahubPackagesService.test.ts src/tests/services/PackageSeeder.test.ts src/tests/services/SnapshotSerializer.test.ts src/tests/platform/packageAuthoringSettingsMigration.test.ts src/tests/platform/metahubsSchemaParityContract.test.ts`
+-   `pnpm --dir packages/universo-react-metahubs-frontend exec vitest run --config vitest.config.ts src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx --coverage.enabled=false`
+-   `pnpm --filter @universo-react/rest-docs build`
+-   `pnpm --filter @universo-react/utils test -- src/routes/__tests__/publicRoutes.test.ts`
+-   `pnpm --filter @universo-react/utils build`
+-   `pnpm --filter @universo-react/core-backend build`
+-   `pnpm supabase:e2e:start:minimal`
+-   `pnpm env:e2e:local-supabase`
+-   `pnpm doctor:e2e:local-supabase`
+-   `pnpm run build:e2e`
+-   `node tools/testing/e2e/run-playwright-suite.mjs --project chromium --grep "@packages"`
+-   `pnpm run check:playcanvas-editor-isolation`
+-   `git diff --check`
+
+---
+
+## 2026-06-01 - PlayCanvas Editor Metahub Authoring Settings Final QA Closure
+
+### Summary
+
+Closed the final QA findings for the PlayCanvas Editor metahub authoring
+surface. Static artifact serving now uses deterministic package resolution and
+realpath containment, config mutations are guarded against stale package
+versions, and browser evidence covers the settings and embedded host flows
+without weakening the iframe sandbox.
+
+### Completed
+
+-   Rejected duplicate authoring package slugs instead of selecting an arbitrary
+    match, and resolved artifact manifest/index paths through the backend
+    artifact boundary.
+-   Added realpath-based containment checks for static artifact availability so
+    symlink escapes and traversal attempts fail closed.
+-   Normalized default attachment config from the registered authoring
+    descriptor during attach and guarded config updates with the expected
+    package id to close version/config races.
+-   Expanded backend route, store, and service tests for artifact headers,
+    manifest failures, symlink escapes, slug collisions, runtime filtering,
+    copy behavior, and design-time snapshot config preservation.
+-   Strengthened frontend and Playwright coverage for keyboard package actions,
+    settings modes, localized validation, iframe sandbox/referrer/allow
+    attributes, visual host evidence, direct read-only host denial, and
+    read-only disabled controls.
+-   Updated Russian user-facing copy from internal development URL terminology
+    to the localized "development address" wording and documented the final
+    behavior.
+-   Closed the post-QA hardening pass: parent host responses now include
+    `frame-src` and `child-src`, package OpenAPI schemas are generated from the
+    OpenAPI source generator instead of hand-edited output, snapshot imports
+    prevalidate package configs before attachment replacement, active
+    PlayCanvas Editor package slugs are unique, and the placeholder artifact is
+    locale-aware without loosening the iframe sandbox to `allow-same-origin`.
+
+### Verification
+
+-   `pnpm --filter @universo-react/metahubs-backend test -- --runInBand src/tests/routes/packagesRoutes.test.ts src/tests/persistence/packagesStore.test.ts src/tests/services/MetahubPackagesService.test.ts src/tests/services/MetahubModulesService.test.ts src/tests/services/SnapshotSerializer.test.ts src/tests/services/PackageSeeder.test.ts`
+-   `pnpm --dir packages/universo-react-metahubs-frontend exec vitest run --config vitest.config.ts src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx --coverage.enabled=false`
+-   `pnpm --filter @universo-react/playcanvas-editor test`
+-   `pnpm --filter @universo-react/playcanvas-editor editor:build`
+-   `pnpm --filter @universo-react/playcanvas-editor editor:smoke`
+-   `pnpm --filter @universo-react/playcanvas-editor editor:browser-smoke`
+-   `pnpm run check:snapshot-fixtures-contract`
+-   `pnpm --filter @universo-react/core-backend test -- --runInBand src/__tests__/App.initDatabase.test.ts`
+-   `pnpm --filter @universo-react/types build`
+-   `pnpm --filter @universo-react/core-backend build`
+-   `pnpm --filter @universo-react/metahubs-frontend build`
+-   `pnpm --filter @universo-react/metahubs-backend build`
+-   `pnpm exec cross-env UNIVERSO_ENV_FILE=.env.e2e.local-supabase UNIVERSO_FRONTEND_ENV_FILE=packages/universo-react-core-frontend/.env.e2e.local-supabase pnpm run build:e2e`
+-   `pnpm supabase:e2e:start:minimal`
+-   `pnpm exec cross-env UNIVERSO_ENV_FILE=.env.e2e.local-supabase UNIVERSO_FRONTEND_ENV_FILE=packages/universo-react-core-frontend/.env.e2e.local-supabase node tools/testing/e2e/run-playwright-suite.mjs --project chromium --grep "@packages"`
+-   `pnpm supabase:e2e:stop`
+-   `pnpm run check:playcanvas-editor-isolation`
+-   `git diff --check`
+
+## 2026-06-01 - PlayCanvas Editor Metahub Authoring Settings QA Remediation
+
+### Summary
+
+Closed the QA findings for the PlayCanvas Editor metahub authoring surface
+settings implementation. The package host and artifact routes are now
+owner/admin design-time surfaces, attachment configs are validated against the
+registered package descriptor, and metahub snapshots preserve authoring-only
+settings without leaking them into runtime publication snapshots.
+
+### Completed
+
+-   Added a shared backend package config validator and applied it to config
+    PATCH requests, snapshot restore, and package version changes.
+-   Required `manageMetahub` for the PlayCanvas Editor authoring host and static
+    artifact routes, and made host availability require both the manifest and
+    `index.html`.
+-   Split package snapshot listing into runtime publication mode and metahub
+    export/import mode so authoring-only configs remain portable but do not
+    propagate to published applications.
+-   Added localized frontend development URL validation and disabled saving
+    invalid settings before the backend request.
+-   Strengthened backend route/store/serializer/seeder tests, frontend settings
+    payload tests, and Playwright responsive/UX oracles for the packages tab and
+    PlayCanvas Editor host.
+-   Replaced the artifact unavailable page's internal smoke-mode wording with
+    user-facing EN/RU status copy.
+
+### Verification
+
+-   `pnpm --filter @universo-react/metahubs-backend test -- --runInBand src/tests/routes/packagesRoutes.test.ts src/tests/persistence/packagesStore.test.ts src/tests/services/SnapshotSerializer.test.ts src/tests/services/PackageSeeder.test.ts`
+-   `pnpm --dir packages/universo-react-metahubs-frontend exec vitest run --config vitest.config.ts src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx --coverage.enabled=false`
+-   `pnpm --filter @universo-react/playcanvas-editor test`
+-   `pnpm --filter @universo-react/types build`
+-   `pnpm --filter @universo-react/metahubs-frontend build`
+-   `pnpm --filter @universo-react/metahubs-backend build`
+-   `pnpm run build:e2e:local-supabase`
+-   `pnpm exec cross-env UNIVERSO_ENV_FILE=.env.e2e.local-supabase UNIVERSO_FRONTEND_ENV_FILE=packages/universo-react-core-frontend/.env.e2e.local-supabase node tools/testing/e2e/run-playwright-suite.mjs --project chromium --grep "@packages"`
+-   `pnpm run check:playcanvas-editor-isolation`
+-   `git diff --check`
+
 ## 2026-05-29 - MMOOMM Multi-Ship Authoritative Sync
 
 ### Summary
@@ -2072,3 +2222,199 @@ diff --check`, metahubs backend focused Jest with 80 tests, metahubs
     artifact build, artifact smoke, Playwright artifact browser smoke across
     desktop/tablet/mobile, catalog guard, package naming guard, no-package-base
     guard, PlayCanvas Editor isolation guard, and GitBook i18n docs check.
+
+### 2026-06-01: PlayCanvas Editor Metahub Authoring Surface Settings Implementation
+
+-   Added shared package contracts for authoring surfaces, deterministic package
+    slugs, per-metahub attachment display config, authoring host descriptors,
+    and explicit authoring-only runtime boundaries.
+-   Extended the metahubs package schema/system-app metadata with
+    `obj_packages.authoring_surface` and `rel_metahub_packages.config`,
+    including a forward migration and initial schema parity coverage.
+-   Seeded `@universo-react/playcanvas-editor` as an authoring-only package with
+    empty `runtimeTargets`, default embedded display config, and artifact
+    metadata while keeping runtime publication snapshots and module package
+    imports filtered to runtime-capable packages only.
+-   Added authenticated package config APIs, authoring host resolution, and
+    PlayCanvas Editor artifact serving under the metahubs package route with
+    manifest checks, traversal protection, cache/content headers, and
+    iframe-oriented CSP.
+-   Updated the Metahub Resources Packages UI with authoring-aware surface
+    labels, a row action menu, localized display settings dialog, and a
+    route-first PlayCanvas Editor host page using an iframe sandbox without
+    `allow-same-origin`.
+-   Resolved the backend artifact-root path against the repository package
+    layout, with `PLAYCANVAS_EDITOR_ARTIFACT_ROOT` as an explicit override, so
+    the E2E CLI startup from `packages/universo-react-core-backend/bin` serves
+    the built editor artifact instead of reporting a false missing artifact.
+-   Updated OpenAPI and GitBook EN/RU docs to describe authoring-only package
+    settings, runtime exclusion, artifact serving, and development URL
+    allowlist behavior.
+-   Verification passed: Prettier on touched files, `@universo-react/types`
+    build, full metahubs-backend Jest suite, applications-backend runtime sync
+    package regression, metahubs-frontend build, core-frontend build, rest-docs
+    build, full `build:e2e:local-supabase`, focused Metahub Packages UI Vitest
+    without coverage, and local minimal Supabase Playwright `@packages`
+    chromium coverage with host-page screenshots. The PlayCanvas Editor
+    isolation guard passes with explicit metadata-only allowlisting for package
+    registry descriptors and shared types. Full metahubs-frontend Vitest was not
+    used as a final signal because an earlier concurrent
+    coverage run corrupted its coverage temp files, and a later broad package
+    invocation exposed unrelated existing EntitiesWorkspace flake/timeouts
+    while the touched Packages test file passed directly.
+
+### 2026-06-01: PlayCanvas Editor Metahub Authoring Surface Settings QA Closure
+
+-   Closed the final QA findings by keeping the legacy built-in package seed
+    migration immutable, moving PlayCanvas Editor reseeding/default backfill to
+    the authoring-settings migration, and using stable seed-derived checksums
+    for authoring settings.
+-   Preserved valid PlayCanvas Editor attachment config during direct reattach,
+    normalized empty configs to descriptor defaults, made registry updates bump
+    `_upl_version` only when seed-backed registry fields actually change, and
+    kept runtime publication package definitions free of design-time config.
+-   Revalidated saved development URL configs at the authoring-host read
+    boundary so an URL that was saved under an older allowlist is blocked and
+    omitted from the host descriptor after the current allowlist is removed or
+    tightened.
+-   Redacted saved development URLs from the read-level package list endpoint
+    and made the settings dialog load full display config through the
+    manager-only authoring-host surface.
+-   Included package attachment config in canonical snapshot hash
+    normalization and refreshed affected committed fixture envelope hashes, so
+    display settings cannot be tampered inside snapshot bundles without
+    failing integrity validation.
+-   Kept imported metahub snapshots as design-time data while creating the
+    import-created active publication version from runtime-mode serialization,
+    preventing authoring-only packages from entering application runtime sync.
+-   Kept open-separately mode on the sandboxed route-first host page instead of
+    exposing the raw artifact URL, with browser evidence for
+    `noopener`/`noreferrer`, sandboxed iframe attributes, missing artifact UI,
+    blocked development URL, keyboard focus, viewport checks, and canvas paint.
+-   Verification passed: focused metahubs-backend Jest suites, focused
+    Metahub Packages Vitest, PlayCanvas Editor package tests, PlayCanvas Editor
+    browser smoke, `@universo-react/types` build, metahubs frontend/backend
+    builds, full local-Supabase E2E build, local minimal Supabase Playwright
+    `@packages` chromium flow, `check:playcanvas-editor-isolation`, and
+    `git diff --check`.
+
+### 2026-06-01: PlayCanvas Editor Authoring Surface QA Remediation Follow-Up
+
+-   Hardened the authoring host and static artifact route so stale or disabled
+    display configs cannot serve the PlayCanvas Editor artifact after current
+    server policy changes.
+-   Aligned backend development URL validation with the frontend contract by
+    requiring `http` or `https`, rejecting credential-bearing URLs, and exposing
+    the currently allowed display modes in the manager-only host descriptor.
+-   Redacted artifact internals from read-level package catalog/list responses
+    while keeping manager-only host data available for the settings and host
+    routes.
+-   Updated the Packages settings dialog to hide server-disabled development URL
+    mode, show localized policy copy, avoid transient MUI select warnings, and
+    keep responsive browser screenshot evidence for the settings dialog and host
+    page.
+-   Verification passed: focused metahubs-backend Jest suites, focused
+    Metahub Packages Vitest, utils snapshot hash Vitest, PlayCanvas Editor
+    isolation guard, `@universo-react/types` build, metahubs frontend/backend
+    builds, full local-Supabase E2E build, local minimal Supabase Playwright
+    `@packages` chromium flow, `git diff --check`, and local autoreview with no
+    accepted/actionable findings.
+
+### 2026-06-01: PlayCanvas Editor Authoring Surface Final Hardening Closure
+
+-   Added strict Zod validation for package authoring-surface descriptors at the
+    registry and seed boundaries, including malformed descriptor regressions and
+    a metadata-only isolation-guard allowlist for the validator contract.
+-   Improved the PlayCanvas Editor host failure states with a stable package
+    heading, localized permission-denied copy, and contextual unavailable states
+    for missing, blocked, disabled, and misconfigured artifacts.
+-   Hardened artifact HTML serving with response-level CSP sandboxing so direct
+    artifact navigation cannot bypass the route-first iframe sandbox boundary.
+-   Preserved design-time snapshot portability by restoring saved development
+    URL display configs without applying the current server allowlist during
+    import, while keeping host/API runtime validation fail-closed.
+-   Updated package snapshot documentation to warn that exported metahub
+    snapshots can include owner-managed development URLs and should be treated
+    as sensitive artifacts.
+-   Extended Playwright evidence for the mobile package action path and Russian
+    PlayCanvas Editor settings/host surfaces.
+-   Verification passed: Prettier on touched files, focused metahubs-backend
+    Jest suites, focused migrations-platform Jest contract, focused Metahub
+    Packages Vitest, `@universo-react/types` build, metahubs-backend build,
+    migrations-platform build, `build:e2e`, local minimal Supabase Playwright
+    `@packages` chromium flow, PlayCanvas Editor isolation guard,
+    `git diff --check`, and local autoreview with no accepted/actionable
+    findings.
+
+### 2026-06-01: PlayCanvas Editor Authoring Surface Post-Review Defect Closure
+
+-   Closed local autoreview findings by forcing the PlayCanvas Editor host
+    launch through document navigation, normalizing development URL CSP frame
+    sources to URL origins, and aligning generated OpenAPI package contracts
+    with the implemented strict package settings API.
+-   Regenerated the OpenAPI source from the fixed generator and verified package
+    schemas for the display-config union, `{ items, total }` list responses,
+    package catalog `id`, `resetConfig`, and manager-only authoring-host
+    descriptors.
+-   Verification passed: `build:e2e`, focused metahubs-backend package route
+    Jest, focused core-backend CSP/init Jest, `@universo-react/rest-docs`
+    build, local minimal Supabase Playwright `@packages` chromium flow,
+    PlayCanvas Editor isolation guard, `git diff --check`, and local
+    autoreview with no actionable defects.
+
+### 2026-06-01: PlayCanvas Editor Authoring Surface Final QA Evidence Closure
+
+-   Added a database-level authoring slug owner trigger for active PlayCanvas
+    Editor `authoringSurface.packageSlug` values in both the baseline metahubs
+    schema and the additive authoring-settings migration. The guard rejects slug
+    reuse by different package names while preserving the versioned registry
+    model for multiple active versions of the same package.
+-   Replaced the mobile package action reachability oracle with a real
+    horizontal wheel gesture and scroll assertion, so Playwright proves the
+    responsive table actions are reachable without direct DOM mutation.
+-   Added a localized Back to packages action across PlayCanvas Editor host
+    happy, open-separately, missing-artifact, and permission-denied states, and
+    strengthened host keyboard evidence around the back action, iframe focus,
+    and artifact canvas interaction.
+-   Added Russian browser validation evidence for invalid Development URL
+    settings while the server policy exposes the development URL mode.
+-   Verification passed: Prettier on touched files, focused metahubs-backend
+    Jest platform/routes suites, focused Metahub Packages Vitest,
+    `build:e2e`, local minimal Supabase Playwright `@packages` chromium flow,
+    PlayCanvas Editor isolation guard, `git diff --check`, and local
+    autoreview with no accepted/actionable findings.
+
+### 2026-06-01: PlayCanvas Editor Authoring Surface Final QA Findings Closure
+
+-   Revalidated signed Editor artifact-token requests against the issuing
+    user's current `manageMetahub` access and the current metahub package
+    attachment display mode before serving static files.
+-   Changed package version switching so incompatible display configs fail
+    closed unless the user explicitly chooses to reset package display settings
+    to defaults.
+-   Added browser screenshot evidence for the missing-artifact host state and
+    documented tokenized artifact request revalidation in GitBook EN/RU docs.
+-   Verification passed: Prettier on touched files, focused metahubs-backend
+    routes/store Jest, focused Metahub Packages Vitest, metahubs
+    frontend/backend builds, full local minimal Supabase `build:e2e`, local
+    minimal Supabase Playwright `@packages` chromium flow, PlayCanvas Editor
+    isolation guard, `git diff --check`, and subagent review.
+
+### 2026-06-01: PlayCanvas Editor Runtime Contract QA Closure
+
+-   Kept package display settings explicitly design-time for this slice by
+    removing the half-read `_app_packages.config` release-loader path while
+    preserving metahub copy and snapshot `packages[].config` behavior.
+-   Kept `ApplicationPackageDefinition` aligned with runtime publication scope:
+    runtime package definitions still carry package identity, source, and active
+    state only, not design-time authoring config.
+-   Made the signed PlayCanvas Editor artifact-token route resolve the required
+    manifest file from the attached artifact descriptor before serving files.
+-   Narrowed the authoring-settings platform migration seed pass to the
+    PlayCanvas Editor package so its effective data mutation matches the
+    migration checksum contract.
+-   Verification passed: Prettier on touched files, focused metahubs-backend
+    route/store/migration/seeder Jest, focused applications-backend sync/release
+    Jest, focused Metahub Packages Vitest, applications-backend build,
+    metahubs-frontend build, metahubs-backend build, PlayCanvas Editor isolation
+    guard, `git diff --check`, and local autoreview with no actionable findings.

--- a/memory-bank/research/playcanvas-editor-metahub-authoring-surface-settings-research-2026-06-01.md
+++ b/memory-bank/research/playcanvas-editor-metahub-authoring-surface-settings-research-2026-06-01.md
@@ -1,0 +1,201 @@
+# Research: PlayCanvas Editor Metahub Authoring Surface Settings
+
+> Created: 2026-06-01
+> Status: Draft
+> Trigger: RESEARCH request for `.manager/specs/platformo/playcanvas-editor-metahub-authoring-surface-settings-spec-2026-06-01.md`
+> Follow-up plan: PLAN not created yet; the future PLAN must load this artifact explicitly.
+
+## Research Question
+
+How should Universo Platformo implement the next PlayCanvas Editor integration slice so a connected `@universo-react/playcanvas-editor` package can expose metahub-owner authoring display settings and a safe Editor host surface, while preserving package lifecycle, snapshot/copy behavior, MUI UX quality, iframe isolation, and future storage/bridge extensibility?
+
+## Source Inventory
+
+| Source | Type | Date / Freshness | Why It Matters |
+| --- | --- | --- | --- |
+| `.manager/specs/platformo/playcanvas-editor-metahub-authoring-surface-settings-spec-2026-06-01.md` | Local brief | Current 2026-06-01 | Defines the intended scope: metahub package settings and safe authoring host only, no scene persistence or full Editor backend integration. |
+| `.manager/inputs/2026-05-31-playcanvas-editor-integration.md` | Local source TZ | Current local file | Original product and architecture request for PlayCanvas Editor integration into Platformo/MMOOMM. |
+| `.backup/Интеграция-PlayCanvas-Editor-в-платформу.md` | Prior local research | Current local file | Recommends official Editor frontend, iframe/postMessage/API bridge later, Colyseus package interaction, and Editor-specific AI skills. |
+| `.backup/Интеграция-PlayCanvas-Editor-в-Universo-Platformo.md` | Prior local research | Current local file | Recommends iframe isolation, metadata/ECS mapping, Colyseus edit-time/runtime separation, and MCP adaptation as later deeper work. |
+| `memory-bank/research/playcanvas-editor-package-foundation-research-2026-05-31.md` | Prior Memory Bank research | Created 2026-05-31 | Establishes the package-foundation decision: isolated artifact package, no root build integration by default, no metahub registry seeding in the foundation slice. |
+| `packages/universo-react-playcanvas-editor/README.md` and `vendor/UPSTREAM.md` | Local package docs | Current local file | Confirm the implemented package is artifact-only, pinned to upstream `v2.22.1`, Node `>=22.22.0`, and not a MUI component library. |
+| `packages/universo-react-playcanvas-editor/src/index.ts` and `scripts/lib/playcanvas-editor-artifact.mjs` | Local package source | Current local file | Defines the artifact manifest constants, `dist/editor` output root, and `artifact-only` smoke mode. |
+| `packages/universo-react-metahubs-backend/src/persistence/packagesStore.ts` | Local backend store | Current local file | Source of truth for package catalog/attachment reads, attach/detach/version changes, copy, and snapshot restore persistence. |
+| `packages/universo-react-metahubs-backend/src/domains/packages/controllers/packagesController.ts` | Local backend API | Current local file | Shows current routes support only catalog/list/attach/change version/detach and gate writes with `manageMetahub`. |
+| `packages/universo-react-metahubs-backend/src/platform/migrations/1766351182000-CreateMetahubsSchema.sql.ts` | Local platform schema | Current local file | Shows `rel_metahub_packages` has no config column and `obj_packages` has only runtime/import-oriented source metadata. |
+| `packages/universo-react-metahubs-backend/src/platform/systemAppDefinition.ts` | Local system app manifest | Current local file | Must stay aligned with any new `obj_packages` or `rel_metahub_packages` fields. |
+| `packages/universo-react-types/src/common/packages.ts` | Local shared types | Current local file | Current package contracts are runtime/import oriented and do not include authoring descriptors or per-attachment config. |
+| `packages/universo-react-metahubs-frontend/src/domains/packages/ui/MetahubPackagesTab.tsx` | Local frontend UI | Current local file | Existing Packages surface uses `FlowListTable`, icon actions, `StandardDialog`, `ConfirmDeleteDialog`, and `manageMetahub` read-only behavior. |
+| `packages/universo-react-metahubs-frontend/src/domains/packages/api/packagesApi.ts` | Local frontend API client | Current local file | Current client mirrors the narrow backend contract; settings endpoints are absent. |
+| `packages/universo-react-metahubs-frontend/src/domains/entities/shared/ui/SharedResourcesPage.tsx` | Local frontend page | Current local file | Shows the Packages tab is mounted inside the shared Resources surface. |
+| `packages/universo-react-metahubs-frontend/src/i18n/locales/en/metahubs.json` and `ru/metahubs.json` | Local i18n | Current local file | Existing package translations do not cover settings, host states, or open-editor actions. |
+| `packages/universo-react-metahubs-backend/src/domains/packages/data/seed-packages.json` | Local package seeds | Current local file | Currently seeds Colyseus client/server and PlayCanvas Engine only; Editor is not registered. |
+| `packages/universo-react-applications-backend/src/routes/sync/syncPackagePersistence.ts` | Local runtime sync | Current local file | Runtime `_app_packages.config` exists but sync resets it to `{}` and ignores it in diff normalization. |
+| `packages/universo-react-applications-backend/src/routes/sync/syncDataLoader.ts` | Local runtime export | Current local file | Runtime release export can read `_app_packages.config`, but the current sync writer does not preserve metahub package config. |
+| `packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts` | Local snapshot hash normalizer | Current local file | Normalizes package `source` to known runtime/import fields only; unknown authoring metadata inside `source` would be ignored by snapshot hashing. |
+| `packages/universo-react-metahubs-backend/src/domains/modules/services/MetahubModulesService.ts` and `packages/universo-react-modules-engine/src/compiler.ts` | Local Modules compilation path | Current local file | `MetahubModulesService` derives allowed imports from all attached packages, while the compiler later drops entries with no runtime targets. |
+| `packages/universo-react-core-backend/src/index.ts` | Local backend static serving | Current local file | Core backend mounts API routes, realtime middleware, then core frontend static files and SPA fallback; no Editor artifact route exists. |
+| `packages/universo-react-rest-docs/src/openapi/index.yml` | Local REST/OpenAPI docs | Current local file | Any package settings endpoint changes the public REST contract and should be documented or regenerated. |
+| `https://github.com/playcanvas/editor` | Primary upstream repository | Checked 2026-06-01 | Source of truth for the Editor frontend. Local package is pinned to `v2.22.1` commit `0fcd44253ba1bba39c13d45b069265167249ecb6`. |
+| `https://github.com/playcanvas/editor/releases/tag/v2.22.1` | Primary upstream release | Checked 2026-06-01; release published 2026-05-27 | Confirms the pinned release tag used by the local package. |
+| `https://raw.githubusercontent.com/playcanvas/editor/v2.22.1/package.json` | Primary upstream manifest | Checked 2026-06-01 | Confirms upstream `@playcanvas/editor@2.22.1`, MIT license, Vite scripts, dependencies, and Node `>=22.22.0`. |
+| `https://developer.playcanvas.com/user-manual/getting-started/open-source/` | Primary vendor docs | Checked 2026-06-01 | Confirms PlayCanvas open-source project context. |
+| `https://developer.playcanvas.com/user-manual/editor/editor-api/` | Primary vendor docs | Checked 2026-06-01 | Describes Editor API as beta and example-driven; useful for later bridge work, not enough for this host/settings slice. |
+| `https://developer.playcanvas.com/user-manual/editor/publishing/web/communicating-webpage/` | Primary vendor docs | Checked 2026-06-01 | Documents parent-page/iframe communication patterns for PlayCanvas published apps; relevant as general browser isolation evidence, not a full Editor bridge contract. |
+| `https://developer.playcanvas.com/user-manual/editor/publishing/web/self-hosting/` | Primary vendor docs | Checked 2026-06-01 | Documents static deployment/iframe embedding for published builds, relevant to artifact route thinking. |
+| `https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html` | Security reference | Checked 2026-06-01 | Supports explicit iframe/CSP/frame-ancestors/sandbox decisions for any embedded Editor host. |
+| Context7 `/mui/material-ui` | MCP documentation | Checked 2026-06-01 | Confirms accessible MUI patterns for responsive Dialog, labeled Select/TextField select, Tabs, and localization support. |
+| Context7 `/vitejs/vite` | MCP documentation | Checked 2026-06-01 | Confirms Vite `base`/nested public path behavior for static artifacts served under reserved routes. |
+| `.agents/skills/universo-platform-architecture/SKILL.md` | Local skill | Current | Confirms metahub/application/workspace ownership and the need to avoid layer confusion. |
+| `.agents/skills/mui-runtime-ux-patterns/SKILL.md` and `.agents/skills/runtime-ux-qa/SKILL.md` | Local skills | Current | Defines required UI contract: no raw IDs/JSON/internal errors, localized validation, responsive proof, and reuse of existing MUI primitives. |
+| `.agents/skills/browser-3d-runtime-integration/SKILL.md` | Local skill | Current | Provides iframe/canvas/input/focus isolation guidance relevant to the future host surface. |
+
+## Key Findings
+
+- The brief's scope is appropriate: this slice should create a metahub-owner design-time package settings and host surface, not a PlayCanvas scene/project storage system, Editor backend emulator, typed postMessage bridge, MCP workflow, Colyseus authoring layer, or runtime multiplayer change.
+- The original TZ and prior research are broader than this slice. They discuss API bridges, scene/entity mapping, network interception, MCP, and AI authoring. Those are plausible future directions but should not be pulled into this host/settings implementation.
+- The current package foundation is intentionally artifact-only. `@universo-react/playcanvas-editor` exposes metadata for an artifact rooted at `dist/editor`, but the built page is a safe unavailable/artifact-only page and does not represent connected PlayCanvas project persistence.
+- The current metahub package model is runtime/import oriented. `PackageSourceDescriptor` has `runtimeTargets` and import/upstream names, but no authoring/display descriptor. `MetahubPackageAttachment` and `MetahubSnapshotPackage` have no per-attachment config.
+- `rel_metahub_packages` is the lifecycle owner for a package attachment to a metahub. It already owns `metahub_id`, `package_id`, `package_name`, `expected_version`, active/soft-delete fields, permissions through the surrounding service routes, copy, snapshot restore, and uniqueness by `(metahub_id, package_name)`.
+- The best first storage location for per-metahub package display settings is a `config JSONB NOT NULL DEFAULT '{}'` column on `metahubs.rel_metahub_packages`, with a small versioned envelope such as `{ "schemaVersion": "1", "display": { ... } }`. A companion table is possible but creates unnecessary lifecycle coupling in the first slice.
+- Registry-level authoring metadata should be separate from `source.runtimeTargets`. A new package-version descriptor such as `authoringSurface` or `displaySurface` belongs to `obj_packages` metadata and shared types. This avoids making the Editor look like a normal Modules import package.
+- Do not hide authoring/display metadata inside `source` unless PLAN explicitly updates every package source normalizer, shared type, registry equality check, publication snapshot hash normalizer, and sync persistence path. Current code normalizes `source` to runtime/import fields only and drops unknown source fields.
+- If `@universo-react/playcanvas-editor` is seeded in the package catalog in this slice, the safest current runtime-import contract is `source.runtimeTargets: []` plus explicit authoring/display metadata. Otherwise the package can become visible as a normal module dependency. This also breaks current Packages table semantics because the UI has a `Runtime` column that renders only `source.runtimeTargets`; PLAN must add authoring/none wording, seed tests, and module allowlist filtering instead of relying on an empty target list alone.
+- Current copy/export/import flows will silently drop future package settings unless updated together:
+  - `copyMetahubPackages` copies only package id/name/version.
+  - `MetahubPackagesService.listPublishedPackages` serializes only package name/version/source.
+  - `SnapshotRestoreService` validates only package name/version and `replaceMetahubPackagesFromSnapshot` inserts only identity/version/source.
+- Runtime `_app_packages.config` is not a safe dependency for this slice. The runtime table has a config JSON field and `syncDataLoader.ts` can read it into release-bundle snapshots as an extra structural property, but `ApplicationPackageDefinition` does not type `config`, `syncPackagePersistence.ts` normalizes snapshots without config, resets `config = '{}'::jsonb` on insert/update, and ignores config in change detection. Runtime package config currently has asymmetric read/write semantics.
+- Publication/runtime propagation of package display config should be explicitly deferred unless PLAN expands the sync/diff contract. Copy, metahub snapshot export, and metahub snapshot import are the minimum preservation requirements for this slice.
+- Package version changes currently update `package_id` and `expected_version` only. Once settings exist, version changes need a policy: preserve compatible config, reset to defaults, or block/confirm incompatible config.
+- Existing frontend package UI is a good base. It already uses `FlowListTable`, stable icon actions with tooltips, MUI `Select`, `StandardDialog`, `ConfirmDeleteDialog`, mutation error alerts, localized strings, and a read-only `manageMetahub` permission pattern.
+- Adding Settings and Open Editor actions can crowd the existing table. Current package rows have a single action icon per state; PLAN should preserve a stable actions cell or introduce an overflow/action menu for Settings/Open/Disconnect instead of widening the table enough to create horizontal overflow.
+- Existing package i18n covers load/table/status/actions/dialogs/notifications only. It does not cover settings, host states, display modes, validation, authoring/display labels, or an empty-runtime state; current EN/RU labels such as `Runtime` / `Среда` will mislabel authoring-only packages unless changed.
+- Settings UI must be a typed localized form, not a raw JSON editor. Initial fields should likely include `displayMode`, optional dev-only `developmentUrl`, and an artifact-only notice/defaults field, with reset/cancel/save behavior and localized validation.
+- `developmentUrl` mode is high risk. It should be disabled in production by default, require explicit environment/admin gating, validate or allowlist URLs, set iframe sandbox/referrer policy, and map errors to user-facing localized messages without showing raw URLs or internal paths.
+- `Open editor` should be honest while the package remains artifact-only. The host can show "artifact available", "artifact only", "artifact missing", "misconfigured", or "development URL blocked" states, but must not imply scene persistence is connected.
+- Core backend currently serves the core frontend static build and then an SPA fallback at `/`. Any Editor artifact route must be mounted after the existing security/session/auth middleware that should protect it, but before `express.static('/')` and the SPA fallback, or it will not serve the artifact correctly.
+- The existing global `frame-ancestors` CSP in core backend controls who may frame Universo itself; it does not decide which child iframe origins the Editor host may load. The Editor host needs separate parent-host `frame-src`/`child-src` policy, iframe `sandbox`, `allow`, `referrerPolicy`, development URL allowlist behavior, and route-specific child artifact response headers.
+- The package-local `serve-editor.mjs` has useful traversal checks and basic content-type/cache headers, but it is not integrated into Express auth/session/CSRF/static serving, has no CSP or iframe policy, and only checks `index.html` availability rather than both `index.html` and `universo-artifact-manifest.json`. It is a development/smoke helper, not the production host route.
+- Vite documentation confirms nested deployment needs an explicit `base` strategy if the artifact contains absolute asset paths. The artifact route and Editor build command must agree on the served public base path.
+- PlayCanvas official "Communication with web pages" and "Self-hosting" docs are about published apps/builds, not a full autonomous open-source Editor backend. They support iframe/static-host patterns only at a general level.
+- PlayCanvas Editor API documentation describes beta automation examples. It is not stable enough to smuggle a typed bridge into this slice, and any Editor API integration should be a later bridge/storage brief with its own tests.
+- MUI documentation supports the planned UI patterns: responsive full-screen Dialog via media query, accessible labeled Select/TextField select controls, accessible Tabs, and global localization.
+
+## Conflicts And Uncertainty
+
+- The prior research recommends network interception/backend emulation and typed postMessage bridges. This conflicts with the current brief's narrow first host/settings slice. Treat those ideas as future architecture candidates, not current acceptance criteria.
+- The package catalog currently assumes runtime/import packages. It is uncertain whether adding an authoring-only package with empty `runtimeTargets` will require UI wording changes, compiler allowlist checks, or seed validation updates.
+- The exact shape of the package-version authoring descriptor is undecided. Options include `authoringSurface`, `displaySurface`, or a generic `surfaces[]` descriptor. The descriptor should be versioned and validate defaults for the attachment config.
+- Runtime propagation is unresolved. The current `_app_packages.config` schema exists but does not preserve sync data, so publishing package display settings would require deliberate sync/diff changes.
+- Static artifact serving ownership is unresolved. Possible owners include core backend static middleware, a package-provided helper consumed by core backend, or a metahubs/backend route. The route must be registered before the SPA fallback either way.
+- It is unclear whether the first host should be a route, a dialog, or both. A route is better for iframe size/focus and "open separately"; a dialog may fit quick artifact status. PLAN should choose based on UX and implementation complexity.
+- `SharedResourcesPage` mounts Packages inside a normal Resources tab shell. A full Editor host should likely be route-first or full-viewport, with the Packages tab providing status/settings/launch actions rather than embedding the full Editor host inside the tab content.
+- The local artifact package requires Node `>=22.22.0`, while the broader repository foundation previously avoided root build integration. This slice should not accidentally make root build depend on Editor artifact build unless the Node/dependency constraints are accepted.
+
+## Project Implications
+
+- PLAN should update the metahub package model before frontend UI:
+  - add a registry-level authoring/display descriptor separate from `source.runtimeTargets`;
+  - add per-attachment config to `rel_metahub_packages`;
+  - update shared TypeScript types before API/UI work.
+- If storage uses `rel_metahub_packages.config`, implementation must include:
+  - SQL/platform migration for existing databases;
+  - base schema and `systemAppDefinition` field updates;
+  - store select/insert/update/copy/restore changes;
+  - backend API endpoint for config update;
+  - package version-change config policy;
+  - focused store/controller tests.
+- Snapshot compatibility must be explicit. The smallest backward-compatible shape is likely optional `packages[].config` or `packages[].displayConfig`, with imports defaulting missing values to package descriptor defaults.
+- Copy, export, and import must be implemented in the same slice as the settings UI. Otherwise the UI creates a configuration that the platform immediately loses in normal lifecycle operations.
+- Runtime publication should remain documented as deferred unless PLAN explicitly expands `syncPackagePersistence` and `ApplicationPackageDefinition` to preserve config in `_app_packages`.
+- The Editor seed entry should not be a normal runtime dependency. If seeded now, update `seed-packages.json`, package seed tests, UI labels, and docs so "Runtime" does not misrepresent an authoring-only package.
+- Module compilation must not treat authoring-only packages as ordinary allowed imports. PLAN should either filter authoring-only packages out of `MetahubModulesService.listAllowedPackageImports` or represent them so they never reach module compilation input.
+- If authoring/display descriptor metadata is added outside `source`, update `obj_packages` schema, `systemAppDefinition`, shared types, seed data, registry store reads/writes, and package seed tests. If PLAN instead extends `source`, it must also update `packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts`, sync source normalizers, registry equality checks, and all shared types that currently assume runtime/import-only source fields.
+- If a package settings endpoint is added, update the REST/OpenAPI contract in `packages/universo-react-rest-docs/src/openapi/index.yml` or the corresponding generated OpenAPI source used by the repo.
+- Frontend implementation should extend `MetahubPackagesTab` rather than create a parallel Packages page. Reuse existing `FlowListTable`, `StandardDialog`, tooltip/icon action patterns, and the existing permission/read-only pattern.
+- Update `MetahubPackagesTab` table contract: split runtime/import package display from authoring/display package display, add an explicit authoring-surface chip/column or empty runtime label, and use an overflow/action menu or stable action cluster for Settings/Open/Disconnect.
+- UI contract should include:
+  - display mode: `disabled`, `embeddedIframe`, `openSeparately`, `developmentUrl`;
+  - dev URL field shown only when environment/admin gating allows it;
+  - explicit artifact-only notice while smoke mode remains `artifact-only`;
+  - read-only mode for users without `manageMetahub`;
+  - localized validation/errors in EN/RU;
+  - no raw package IDs, attachment IDs, JSON, stack traces, filesystem paths, internal routes, or full blocked URLs in viewer/error states. Manager-only settings may show the configured development URL field because the owner edits that value directly.
+- Host route/static serving contract should include:
+  - reserved route name;
+  - artifact availability check against `index.html` plus `universo-artifact-manifest.json`;
+  - registration after the relevant security/session/auth middleware but before core frontend `express.static('/')` and SPA fallback;
+  - traversal-safe static serving;
+  - separate parent host CSP (`frame-src`/`child-src`) and child artifact response headers, plus content-type, cache, nosniff, iframe `sandbox`, `allow`, `referrerPolicy`, and development URL allowlist policy;
+  - user-facing fallback for missing artifact.
+- Browser evidence should cover desktop/tablet/mobile widths, no page-level horizontal overflow, keyboard access to Settings/Open Editor, read-only behavior, artifact-only/missing/misconfigured states, and iframe load/error behavior.
+
+## Recommended Decision
+
+Proceed to PLAN with a conservative implementation path:
+
+1. Treat this as a metahub design-time package settings slice, not an Editor backend/storage slice.
+2. Add versioned registry-level authoring/display metadata outside `source.runtimeTargets`; prefer a dedicated top-level registry field/column over extending `source` unless PLAN explicitly updates all source normalizers and snapshot hash behavior.
+3. Store per-metahub package display config directly on `rel_metahub_packages.config` with a versioned JSON envelope and backend validation against the attached package version descriptor.
+4. Preserve settings through metahub copy, metahub snapshot export, and metahub snapshot import in the same implementation.
+5. Defer publication/runtime `_app_packages.config` propagation until a later sync/diff brief unless PLAN explicitly expands the scope.
+6. Add `@universo-react/playcanvas-editor` to the package catalog only as an authoring/display package, with safeguards that it is not accepted as a Modules import dependency.
+7. Build the UI on the existing Packages tab patterns, using typed localized forms and explicit artifact-only states.
+8. Serve or frame the Editor artifact only through an explicit reserved route/host contract; do not import upstream PCUI/Observer/Editor DOM into the MUI React tree.
+
+## Open Questions Before PLAN
+
+- What exact registry descriptor shape should be used: `authoringSurface`, `displaySurface`, or a generic `surfaces[]` contract?
+- Should the first seed for `@universo-react/playcanvas-editor` use an empty `runtimeTargets` array, a new source kind/target type, or a separate catalog field to avoid Modules allowlist leakage?
+- Should authoring-only packages be excluded from `MetahubModulesService.listAllowedPackageImports`, or represented in a way that never reaches module compilation input?
+- Should snapshot persistence use `packages[].config` or a narrower `packages[].displayConfig` field?
+- On package version change, should incompatible config be reset, migrated, or blocked until the user confirms?
+- Which package owns the reserved artifact route, and what exact route namespace should be used?
+- Should the first host be route-first, dialog-first, or route plus lightweight status dialog?
+- Is development URL mode allowed only in local development, or also for selected admin/staging deployments through an explicit allowlist?
+- Should runtime publication propagation remain deferred, or should this slice intentionally expand `syncPackagePersistence` and application release bundle contracts?
+
+## Sources
+
+- `.manager/specs/platformo/playcanvas-editor-metahub-authoring-surface-settings-spec-2026-06-01.md`
+- `.manager/inputs/2026-05-31-playcanvas-editor-integration.md`
+- `.backup/Интеграция-PlayCanvas-Editor-в-платформу.md`
+- `.backup/Интеграция-PlayCanvas-Editor-в-Universo-Platformo.md`
+- `memory-bank/research/playcanvas-editor-package-foundation-research-2026-05-31.md`
+- `packages/universo-react-playcanvas-editor/README.md`
+- `packages/universo-react-playcanvas-editor/vendor/UPSTREAM.md`
+- `packages/universo-react-playcanvas-editor/src/index.ts`
+- `packages/universo-react-playcanvas-editor/scripts/lib/playcanvas-editor-artifact.mjs`
+- `packages/universo-react-metahubs-backend/src/persistence/packagesStore.ts`
+- `packages/universo-react-metahubs-backend/src/domains/packages/controllers/packagesController.ts`
+- `packages/universo-react-metahubs-backend/src/platform/migrations/1766351182000-CreateMetahubsSchema.sql.ts`
+- `packages/universo-react-metahubs-backend/src/platform/systemAppDefinition.ts`
+- `packages/universo-react-types/src/common/packages.ts`
+- `packages/universo-react-metahubs-frontend/src/domains/packages/ui/MetahubPackagesTab.tsx`
+- `packages/universo-react-metahubs-frontend/src/domains/packages/api/packagesApi.ts`
+- `packages/universo-react-metahubs-frontend/src/domains/entities/shared/ui/SharedResourcesPage.tsx`
+- `packages/universo-react-metahubs-frontend/src/i18n/locales/en/metahubs.json`
+- `packages/universo-react-metahubs-frontend/src/i18n/locales/ru/metahubs.json`
+- `packages/universo-react-metahubs-backend/src/domains/packages/data/seed-packages.json`
+- `packages/universo-react-applications-backend/src/routes/sync/syncPackagePersistence.ts`
+- `packages/universo-react-applications-backend/src/routes/sync/syncDataLoader.ts`
+- `packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts`
+- `packages/universo-react-metahubs-backend/src/domains/modules/services/MetahubModulesService.ts`
+- `packages/universo-react-modules-engine/src/compiler.ts`
+- `packages/universo-react-core-backend/src/index.ts`
+- `packages/universo-react-rest-docs/src/openapi/index.yml`
+- `https://github.com/playcanvas/editor`
+- `https://github.com/playcanvas/editor/releases/tag/v2.22.1`
+- `https://raw.githubusercontent.com/playcanvas/editor/v2.22.1/package.json`
+- `https://developer.playcanvas.com/user-manual/getting-started/open-source/`
+- `https://developer.playcanvas.com/user-manual/editor/editor-api/`
+- `https://developer.playcanvas.com/user-manual/editor/publishing/web/communicating-webpage/`
+- `https://developer.playcanvas.com/user-manual/editor/publishing/web/self-hosting/`
+- `https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html`
+- Context7 `/mui/material-ui`
+- Context7 `/vitejs/vite`
+- `.agents/skills/universo-platform-architecture/SKILL.md`
+- `.agents/skills/mui-runtime-ux-patterns/SKILL.md`
+- `.agents/skills/runtime-ux-qa/SKILL.md`
+- `.agents/skills/browser-3d-runtime-integration/SKILL.md`

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -4,6 +4,77 @@
 
 ---
 
+## Active: PlayCanvas Editor Metahub Authoring Surface Settings Implementation (2026-06-01)
+
+> Goal: add metahub design-time package settings and a safe route-first PlayCanvas Editor artifact host while keeping authoring-only packages out of runtime publication.
+
+### IMPLEMENT Action Plan
+
+-   [x] Establish contracts and safety boundaries for `authoringSurface`, attachment `config`, package slugs, local-only development URLs, and authoring-only runtime exclusion.
+-   [x] Extend shared package types and backend schema/system-app metadata for authoring descriptors and per-attachment config.
+-   [x] Seed `@universo-react/playcanvas-editor` as an authoring-only package and update package store/controller/routes with typed config and slug host APIs.
+-   [x] Preserve config through metahub copy and design-time snapshot import/export while filtering authoring-only packages from runtime publication and Modules imports.
+-   [x] Add authenticated artifact status/static serving through the metahubs package domain with traversal, manifest, CSP/header, iframe sandbox, and nested asset-route safeguards.
+-   [x] Update the metahub Packages UI with authoring-aware table labels, row action menu, typed settings dialog, route-first host page, and EN/RU i18n.
+-   [x] Update OpenAPI and GitBook documentation for package settings, artifact-only status, local-only development URL mode, copy/snapshot behavior, and deferred runtime propagation.
+-   [x] Add backend, frontend, and local minimal Supabase Playwright coverage for config persistence, runtime non-propagation, localization, UI package flows, and the PlayCanvas Editor host iframe route.
+-   [x] Run Prettier plus targeted type/build/test checks and update Memory Bank progress.
+
+### QA Remediation Action Plan
+
+-   [x] Harden backend authoring package permissions, descriptor-aware config validation, artifact availability checks, version-change compatibility, and snapshot import/export behavior.
+-   [x] Add frontend development URL validation and stronger browser UX oracles for the settings dialog and PlayCanvas Editor host route.
+-   [x] Expand backend, frontend, and E2E regression tests for permissions, validation, artifact safety, snapshot/package behavior, and responsive host evidence.
+-   [x] Run formatting, focused test/build checks, isolation guard, and update Memory Bank progress.
+
+### Final QA Closure Action Plan
+
+-   [x] Harden static artifact containment, manifest validation, and deterministic authoring slug resolution.
+-   [x] Close package config lifecycle races and default-config normalization gaps.
+-   [x] Strengthen backend tests for artifact routes, permissions, runtime filtering, copy/snapshot config preservation, and authoring slug collisions.
+-   [x] Strengthen frontend and Playwright coverage for settings modes, keyboard flow, localized validation, iframe attributes, and host browser evidence.
+-   [x] Update user-facing RU copy and documentation/memory-bank notes for the final closure.
+-   [x] Run formatting, focused backend/frontend tests, build checks, Playwright local minimal Supabase evidence, and repository guards.
+
+### QA Findings Closure Action Plan
+
+-   [x] Keep the already-applied built-in package seed migration checksum immutable and move the PlayCanvas Editor seed/authoring reseed contract behind the new authoring-settings migration.
+-   [x] Preserve iframe sandboxing for open-separately mode by opening a route-first host page instead of the raw artifact URL.
+-   [x] Normalize/backfill existing `{}` package attachment configs to descriptor defaults and preserve valid configs through snapshot/copy/restore.
+-   [x] Increment package attachment `_upl_version` on attach, version change, config update, detach, copy conflict updates, and snapshot replacement mutations.
+-   [x] Recompute compatible/default config when `POST /packages` reattaches an already-active package to a different version.
+-   [x] Strengthen backend regression tests for migration checksum immutability, config backfill/defaults, version bumps, and reattach config compatibility.
+-   [x] Strengthen frontend and Playwright evidence for open-separately sandboxing, settings dialog viewport/keyboard UX, missing artifact, blocked development URL, and noopener/noreferrer.
+-   [x] Run Prettier, focused backend/frontend/package tests, builds, local minimal Supabase Playwright evidence, repository guards, and autoreview.
+
+### Final QA Hardening Closure Action Plan
+
+-   [x] Add strict backend validation for package `authoringSurface` descriptors on registry/seed boundaries, with malformed descriptor regression tests.
+-   [x] Improve PlayCanvas Editor host user-facing failure/context states with localized permission and unavailable copy.
+-   [x] Document that metahub snapshot/export files preserve package display settings and can include owner-managed development URLs.
+-   [x] Add browser evidence for mobile package action completion and RU PlayCanvas Editor settings/host surfaces.
+-   [x] Run Prettier, focused backend/frontend tests, builds, local minimal Supabase Playwright evidence, repository guards, and autoreview.
+
+### Post-QA Defect Closure Action Plan
+
+-   [x] Add parent PlayCanvas Editor host CSP `frame-src`/`child-src` restrictions for artifact and development URL modes.
+-   [x] Make the PlayCanvas Editor artifact placeholder locale-aware and update browser assertions to require one active locale.
+-   [x] Fix snapshot fixture hash drift without matching payload changes.
+-   [x] Harden snapshot package replacement and authoring slug uniqueness before mutating package attachments.
+-   [x] Document typed package config/authoring-host contracts in OpenAPI.
+-   [x] Strengthen Playwright evidence for development URL validation and stable dialog screenshots.
+-   [x] Run Prettier, focused tests/builds, Playwright local minimal Supabase evidence, isolation guard, diff checks, and autoreview.
+
+### Final QA Evidence Closure Action Plan
+
+-   [x] Add a database-level authoring slug owner guard in baseline and additive migrations without blocking same-package version rows.
+-   [x] Replace programmatic mobile table action scrolling with user-like Playwright gesture evidence.
+-   [x] Add keyboard focus enter/exit evidence for the PlayCanvas Editor host iframe.
+-   [x] Add RU browser validation evidence for invalid Development URL settings.
+-   [x] Run formatting, focused backend/frontend checks, local minimal Supabase Playwright evidence, repository guards, and autoreview.
+
+---
+
 ## Active: PlayCanvas Editor Package Foundation Implementation (2026-05-31)
 
 > Goal: add the isolated `@universo-react/playcanvas-editor` workspace package for the official PlayCanvas Editor frontend artifact, pinned to an upstream release, with reproducible wrapper metadata/scripts, repository guardrails, tests, docs, and no direct MUI/runtime integration.
@@ -1114,3 +1185,38 @@
 -   [x] Strengthen the no-install/network and lockfile-mutation supply-chain guard.
 -   [x] Make the PlayCanvas Editor Vite catalog exception explicit in the catalog guard.
 -   [x] Run Prettier, focused package checks, browser smoke, repository guards, docs checks, lint, and diff checks.
+
+## PlayCanvas Editor Metahub Authoring Surface QA Remediation 2026-06-01
+
+-   [x] Enforce attachment display config at the backend artifact route and harden development URL validation.
+-   [x] Surface server display-mode policy in the package settings UI without generic mutation-error workflows.
+-   [x] Add focused backend, frontend, and Playwright coverage for the QA findings, including responsive evidence.
+-   [x] Run Prettier, focused package tests, local minimal Supabase Playwright packages flow, isolation guard, and autoreview.
+
+## PlayCanvas Editor Metahub Authoring Surface Post-Review Defect Closure 2026-06-01
+
+-   [x] Force PlayCanvas Editor host launch through document navigation so route-specific CSP is applied.
+-   [x] Normalize development URL CSP allowlist entries to origins, matching backend config validation.
+-   [x] Align generated OpenAPI package schemas with the strict package settings API contract.
+-   [x] Regenerate docs artifacts and rerun focused backend, rest-docs, E2E, isolation, diff, and autoreview checks.
+
+## PlayCanvas Editor Host UX QA Closure 2026-06-01
+
+-   [x] Add localized PlayCanvas Editor iframe loading and failure states so artifact readiness is not shown before frame load.
+-   [x] Strengthen Playwright host evidence for blocked, misconfigured, iframe-load failure, and user-facing metahub navigation.
+-   [x] Run Prettier, focused tests, isolation guard, local minimal Supabase Playwright packages flow, and autoreview.
+
+## PlayCanvas Editor Final QA Findings Closure 2026-06-01
+
+-   [x] Revalidate signed Editor artifact tokens against the current metahub package attachment state before serving static files.
+-   [x] Make incompatible package version display-config changes require explicit reset instead of silently falling back to defaults.
+-   [x] Add Playwright screenshot evidence for the missing-artifact host state.
+-   [x] Run Prettier, focused backend/frontend/E2E checks, isolation guard, diff check, and subagent verification.
+
+## PlayCanvas Editor Runtime Contract QA Closure 2026-06-01
+
+-   [x] Keep runtime `_app_packages.config` propagation explicitly deferred by removing the half-read runtime export path.
+-   [x] Align shared runtime package types with the deferred config contract.
+-   [x] Make the signed Editor artifact route use the attached artifact descriptor manifest file name.
+-   [x] Narrow the authoring-settings migration seed scope to match its checksum contract.
+-   [x] Run Prettier, focused tests, isolation guard, diff check, and autoreview.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "check:package-naming": "git ls-files -z | node tools/check-package-naming-convention.mjs --from-ledger memory-bank/implementation/packages-naming-ledger.json --allowlist memory-bank/implementation/packages-naming-legacy-reference-allowlist.json --stdin0",
         "check:apps-template-isolation": "node tools/check-apps-template-isolation.mjs",
         "check:playcanvas-editor-isolation": "node tools/check-playcanvas-editor-isolation.mjs",
+        "check:snapshot-fixtures-contract": "pnpm --filter @universo-react/utils test -- src/snapshot/__tests__/snapshotFixtures.test.ts",
         "check:lms-fixture-contract": "pnpm --filter @universo-react/types build && pnpm --filter @universo-react/utils build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON tools/testing/e2e/support/checkLmsFixtureContract.ts tools/fixtures/metahubs-lms-app-snapshot.json",
         "check:mmoomm-flight-fixture-contract": "pnpm --filter @universo-react/types build && pnpm --filter @universo-react/utils build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON tools/testing/e2e/support/checkMmoommFlightFixtureContract.ts",
         "docs:i18n:check": "node tools/docs/check-i18n-docs.mjs",

--- a/packages/universo-react-applications-backend/src/routes/sync/syncDataLoader.ts
+++ b/packages/universo-react-applications-backend/src/routes/sync/syncDataLoader.ts
@@ -422,10 +422,9 @@ export async function loadApplicationRuntimePackages(exec: DbExecutor, schemaNam
             version: string
             source?: unknown
             is_active: boolean
-            config?: unknown
         }>(
             `
-                SELECT package_name, version, source, is_active, config
+                SELECT package_name, version, source, is_active
                 FROM ${schemaIdent}._app_packages
                 WHERE _upl_deleted = false
                   AND _app_deleted = false
@@ -440,8 +439,7 @@ export async function loadApplicationRuntimePackages(exec: DbExecutor, schemaNam
                 packageName: row.package_name,
                 version: row.version,
                 source: normalizeRuntimePackageSource(row.source),
-                isActive: row.is_active !== false,
-                config: isRecord(row.config) ? (row.config as Record<string, unknown>) : {}
+                isActive: row.is_active !== false
             }))
     } catch {
         return []

--- a/packages/universo-react-applications-backend/src/routes/sync/syncPackagePersistence.ts
+++ b/packages/universo-react-applications-backend/src/routes/sync/syncPackagePersistence.ts
@@ -10,7 +10,6 @@ type PersistedAppPackageRowDb = {
     version: string
     source?: unknown
     is_active: boolean
-    config?: unknown
 }
 
 const buildPackageSortKey = (item: ApplicationPackageDefinition): string => `${item.packageName}:${item.version}`
@@ -240,7 +239,7 @@ export async function hasPublishedPackagesChanges(options: {
     }
 
     const persistedRows = await exec.query<PersistedAppPackageRowDb>(
-        `SELECT package_name, version, source, is_active, config
+        `SELECT package_name, version, source, is_active
          FROM ${getPackagesTable(schemaName)}
          WHERE _upl_deleted = false
            AND _app_deleted = false`

--- a/packages/universo-react-core-backend/src/__tests__/App.initDatabase.test.ts
+++ b/packages/universo-react-core-backend/src/__tests__/App.initDatabase.test.ts
@@ -178,11 +178,12 @@ jest.mock('@universo-react/utils', () => {
     }
 })
 
-import { App } from '../index'
+import { App, buildPlayCanvasEditorHostCsp } from '../index'
 
 describe('App.initDatabase', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        delete process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS
         mockAssertIsolatedVmRuntimeAvailable.mockResolvedValue(undefined)
         mockIsGlobalMigrationObjectEnabled.mockReturnValue(true)
         mockValidateRegisteredPlatformMigrations.mockReturnValue({
@@ -258,6 +259,14 @@ describe('App.initDatabase', () => {
             enabled: false,
             status: 'disabled'
         })
+    })
+
+    it('builds a PlayCanvas Editor host CSP with self and allowlisted development frame origins', () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'http://localhost:5100, https://editor.example.test/path, ftp://invalid.test'
+
+        expect(buildPlayCanvasEditorHostCsp("'self'")).toBe(
+            "frame-src 'self' http://localhost:5100 https://editor.example.test; child-src 'self' http://localhost:5100 https://editor.example.test; frame-ancestors 'self'"
+        )
     })
 
     it('initializes database and runs unified platform migrations', async () => {

--- a/packages/universo-react-core-backend/src/index.ts
+++ b/packages/universo-react-core-backend/src/index.ts
@@ -42,7 +42,7 @@ import {
 } from '@universo-react/migrations-platform'
 import { initializeRateLimiters as initializeStartRateLimiters } from '@universo-react/start-backend'
 import errorHandlerMiddleware from './middlewares/errors'
-import { API_WHITELIST_URLS, isGlobalMigrationObjectEnabled, parsePositiveInt, resolveRateLimitKey } from '@universo-react/utils'
+import { isGlobalMigrationObjectEnabled, isWhitelistedApiPath, parsePositiveInt, resolveRateLimitKey } from '@universo-react/utils'
 import 'global-agent/bootstrap'
 import { bootstrapStartupSuperuser } from './bootstrap/bootstrapSuperuser'
 import { executeStartupFullReset } from './bootstrap/startupReset'
@@ -54,6 +54,50 @@ const parseSameSite = (value?: string): boolean | 'lax' | 'strict' | 'none' => {
     if (['lax', 'strict', 'none'].includes(normalized)) return normalized as 'lax' | 'strict' | 'none'
     if (['true', 'false'].includes(normalized)) return normalized === 'true'
     return 'lax'
+}
+
+const PLAYCANVAS_EDITOR_HOST_ROUTE_PATTERN = /^\/metahub\/[^/]+\/resources\/packages\/[^/]+\/editor(?:\/)?$/
+
+const parseCspFrameOrigin = (value: string): string | null => {
+    const normalized = value.trim()
+    if (!normalized) return null
+    if (normalized === "'self'" || normalized === 'self') return "'self'"
+    if (normalized === "'none'" || normalized === 'none') return "'none'"
+
+    try {
+        const parsed = new URL(normalized)
+        if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+            return null
+        }
+        return parsed.origin
+    } catch {
+        return null
+    }
+}
+
+const resolvePlayCanvasEditorFrameSources = (): string[] => {
+    const sources = new Set<string>(["'self'"])
+    for (const rawOrigin of (process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS ?? '').split(',')) {
+        const source = parseCspFrameOrigin(rawOrigin)
+        if (source && source !== "'none'") {
+            sources.add(source)
+        }
+    }
+    return [...sources]
+}
+
+export const buildPlayCanvasEditorHostCsp = (frameAncestors: string): string => {
+    const frameSources = resolvePlayCanvasEditorFrameSources().join(' ')
+    const directives = [`frame-src ${frameSources}`, `child-src ${frameSources}`]
+    if (frameAncestors !== '*') {
+        directives.push(`frame-ancestors ${frameAncestors}`)
+    }
+    return directives.join('; ')
+}
+
+const isPlayCanvasEditorHostRoute = (req: Request): boolean => {
+    const routePath = req.path || req.url.split('?')[0] || ''
+    return PLAYCANVAS_EDITOR_HOST_ROUTE_PATTERN.test(routePath)
 }
 
 interface SessionTokens {
@@ -289,6 +333,13 @@ export class App {
             }
         })
 
+        this.app.use((req: Request, res: Response, next: NextFunction) => {
+            if (isPlayCanvasEditorHostRoute(req)) {
+                res.setHeader('Content-Security-Policy', buildPlayCanvasEditorHostCsp(getAllowedIframeOrigins()))
+            }
+            next()
+        })
+
         // Switch off the default 'X-Powered-By: Express' header
         this.app.disable('x-powered-by')
 
@@ -321,7 +372,6 @@ export class App {
             res.status(health.connected ? 200 : 503).json(health)
         })
 
-        const whitelistURLs = API_WHITELIST_URLS
         const urlCaseInsensitiveRegex = /\/api\/v1\//i
         const urlCaseSensitiveRegex = /\/api\/v1\//
 
@@ -338,8 +388,7 @@ export class App {
                 return res.status(401).json({ error: 'Unauthorized Access' })
             }
             // If URL in whitelist, skip
-            const isWhitelisted = whitelistURLs.some((url) => req.path.startsWith(url))
-            if (isWhitelisted) {
+            if (isWhitelistedApiPath(req.path)) {
                 return next()
             }
 

--- a/packages/universo-react-core-frontend/src/routes/MainRoutes.tsx
+++ b/packages/universo-react-core-frontend/src/routes/MainRoutes.tsx
@@ -62,6 +62,9 @@ const ComponentList = Loadable(lazy(() => import('@universo-react/metahubs-front
 const FixedValueList = Loadable(lazy(() => import('@universo-react/metahubs-frontend').then((m: any) => ({ default: m.FixedValueList }))))
 const RecordList = Loadable(lazy(() => import('@universo-react/metahubs-frontend').then((m) => ({ default: m.RecordList }))))
 const MetahubResources = Loadable(lazy(() => import('@universo-react/metahubs-frontend').then((m) => ({ default: m.MetahubResources }))))
+const PlayCanvasEditorHostPage = Loadable(
+    lazy(() => import('@universo-react/metahubs-frontend').then((m) => ({ default: m.PlayCanvasEditorHostPage })))
+)
 const MetahubLayoutDetails = Loadable(
     lazy(() => import('@universo-react/metahubs-frontend').then((m) => ({ default: m.MetahubLayoutDetails })))
 )
@@ -271,6 +274,7 @@ const MainRoutes = {
                 { path: 'migrations', element: <MetahubMigrations /> },
                 { path: 'branches', element: <BranchList /> },
                 { path: 'resources', element: <MetahubResources /> },
+                { path: 'resources/packages/:packageSlug/editor', element: <PlayCanvasEditorHostPage /> },
                 { path: 'entities', element: <EntitiesWorkspace /> },
                 { path: 'entities/:kindKey/instances', element: <EntityInstanceList /> },
                 { path: 'entities/:kindKey/instance/:entityId/content', element: <EntityBlockContentPage /> },

--- a/packages/universo-react-metahubs-backend/src/domains/metahubs/controllers/metahubsController.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/metahubs/controllers/metahubsController.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { isSuperuser, getGlobalRoleCodename } from '@universo-react/admin-backend'
 import { applyRlsContext } from '@universo-react/auth-backend'
 import { getPoolExecutor } from '@universo-react/database'
+import type { PackageAttachmentConfig, PackageSourceDescriptor } from '@universo-react/types'
 import {
     activeAppRowCondition,
     buildSnapshotEnvelope,
@@ -36,6 +37,7 @@ import {
     createPublication,
     createPublicationVersion,
     copyMetahubPackages,
+    prepareMetahubPackagesFromSnapshot,
     type SqlQueryable,
     type MetahubRow,
     type MetahubUserRow,
@@ -1916,6 +1918,35 @@ export function createMetahubsController(getDbExecutor: () => DbExecutor) {
         const accessToken = resolveBearerAccessToken(req)
         const rootExec = getPoolExecutor()
 
+        const snapshotPackages = (
+            envelope.snapshot as {
+                packages?: Array<{ packageName?: unknown; version?: unknown; source?: unknown; config?: unknown }>
+            }
+        ).packages
+        if (Array.isArray(snapshotPackages)) {
+            try {
+                await prepareMetahubPackagesFromSnapshot(
+                    rootExec,
+                    snapshotPackages.map((item) => {
+                        if (!item || typeof item.packageName !== 'string' || typeof item.version !== 'string') {
+                            throw new Error('Metahub snapshot contains an invalid package dependency')
+                        }
+                        return {
+                            packageName: item.packageName,
+                            version: item.version,
+                            source: item.source as PackageSourceDescriptor | undefined,
+                            config: item.config as PackageAttachmentConfig | undefined
+                        }
+                    })
+                )
+            } catch (error) {
+                return res.status(400).json({
+                    error: 'Invalid snapshot envelope',
+                    details: safeErrorMessage(error)
+                })
+            }
+        }
+
         // 2. Build localized name/description from envelope
         const importedName = ensureVLC(envelope.metahub.name, 'en')
         if (!importedName) {
@@ -2205,7 +2236,8 @@ export function createMetahubsController(getDbExecutor: () => DbExecutor) {
         const publicStructureVersion = await schemaService.resolvePublicStructureVersion(branch.schemaName, branch.structureVersion)
 
         const snapshot = await serializer.serializeMetahub(metahubId, {
-            structureVersion: publicStructureVersion
+            structureVersion: publicStructureVersion,
+            packageMode: 'metahub'
         })
 
         await attachLayoutsToSnapshot({ schemaService, snapshot, metahubId, userId })

--- a/packages/universo-react-metahubs-backend/src/domains/modules/services/MetahubModulesService.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/modules/services/MetahubModulesService.ts
@@ -308,11 +308,13 @@ export class MetahubModulesService {
 
     private async listAllowedPackageImports(metahubId: string): Promise<ModulePackageImport[]> {
         const packages = await listMetahubPackages(this.exec, metahubId)
-        return packages.map((item) => ({
-            packageName: item.packageName,
-            version: item.version,
-            targets: item.source.runtimeTargets
-        }))
+        return packages
+            .filter((item) => (item.source?.runtimeTargets ?? []).length > 0)
+            .map((item) => ({
+                packageName: item.packageName,
+                version: item.version,
+                targets: item.source.runtimeTargets
+            }))
     }
 
     async listModules(metahubId: string, options: ListMetahubModulesOptions = {}, userId?: string): Promise<MetahubModuleRecord[]> {

--- a/packages/universo-react-metahubs-backend/src/domains/packages/controllers/packagesController.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/controllers/packagesController.ts
@@ -1,12 +1,29 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto'
+import type { Request, Response } from 'express'
 import { z } from 'zod'
+import type { DbExecutor } from '../../../utils'
+import type {
+    MetahubPackageAttachment,
+    PackageAuthoringHostDescriptor,
+    PlayCanvasEditorAuthoringSurfaceDescriptor
+} from '@universo-react/types'
 import type { createMetahubHandlerFactory } from '../../shared/createMetahubHandler'
 import { MetahubNotFoundError, MetahubValidationError } from '../../shared/domainErrors'
+import { ensureMetahubAccess } from '../../shared/guards'
+import {
+    packageAttachmentConfigSchema,
+    resolveAllowedPackageDisplayModes,
+    resolvePackageAttachmentConfig
+} from '../services/packageConfigValidation'
 import {
     attachMetahubPackage,
     changeMetahubPackageVersion,
     detachMetahubPackage,
     listMetahubPackages,
-    listPackageCatalog
+    listPackageCatalog,
+    updateMetahubPackageConfig
 } from '../../../persistence'
 
 const packageNameSchema = z
@@ -16,6 +33,18 @@ const packageNameSchema = z
     .max(214)
     .regex(/^@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/, 'Package name must be a scoped npm package name')
 const versionSchema = z.string().trim().min(1).max(64)
+const packageSlugSchema = z
+    .string()
+    .trim()
+    .min(1)
+    .max(96)
+    .regex(/^[a-z0-9][a-z0-9-]*$/)
+const artifactRoot =
+    process.env.PLAYCANVAS_EDITOR_ARTIFACT_ROOT ??
+    path.resolve(__dirname, '../../../../../../packages/universo-react-playcanvas-editor/dist/editor')
+const artifactTokenSecret =
+    process.env.PLAYCANVAS_EDITOR_ARTIFACT_TOKEN_SECRET ?? process.env.SESSION_SECRET ?? process.env.SUPABASE_JWT_SECRET ?? randomUUID()
+const artifactTokenTtlMs = 5 * 60 * 1000
 
 const attachPackageSchema = z
     .object({
@@ -26,20 +55,364 @@ const attachPackageSchema = z
 
 const changePackageVersionSchema = z
     .object({
-        version: versionSchema
+        version: versionSchema,
+        resetConfig: z.boolean().optional()
     })
     .strict()
 
-export function createPackagesController(createHandler: ReturnType<typeof createMetahubHandlerFactory>) {
+const updatePackageConfigSchema = z
+    .object({
+        config: packageAttachmentConfigSchema
+    })
+    .strict()
+
+const contentTypesByExtension = new Map<string, string>([
+    ['.html', 'text/html; charset=utf-8'],
+    ['.js', 'application/javascript; charset=utf-8'],
+    ['.mjs', 'application/javascript; charset=utf-8'],
+    ['.css', 'text/css; charset=utf-8'],
+    ['.json', 'application/json; charset=utf-8'],
+    ['.map', 'application/json; charset=utf-8'],
+    ['.svg', 'image/svg+xml'],
+    ['.png', 'image/png'],
+    ['.jpg', 'image/jpeg'],
+    ['.jpeg', 'image/jpeg'],
+    ['.webp', 'image/webp'],
+    ['.avif', 'image/avif'],
+    ['.ico', 'image/x-icon'],
+    ['.wasm', 'application/wasm'],
+    ['.ttf', 'font/ttf'],
+    ['.woff', 'font/woff'],
+    ['.woff2', 'font/woff2']
+])
+
+interface ArtifactTokenPayload {
+    metahubId: string
+    packageSlug: string
+    userId: string
+    expiresAt: number
+}
+
+type PlayCanvasEditorAttachment = MetahubPackageAttachment & {
+    authoringSurface: PlayCanvasEditorAuthoringSurfaceDescriptor
+}
+
+const redactAttachmentConfigForList = (item: MetahubPackageAttachment): MetahubPackageAttachment => {
+    const redacted: MetahubPackageAttachment = {
+        ...item,
+        authoringSurface:
+            item.authoringSurface.kind === 'playcanvasEditor'
+                ? {
+                      ...item.authoringSurface,
+                      artifact: undefined
+                  }
+                : item.authoringSurface
+    }
+
+    if (item.config.kind !== 'display' || !item.config.display.developmentUrl) {
+        return redacted
+    }
+
+    return {
+        ...redacted,
+        config: {
+            ...item.config,
+            display: {
+                ...item.config.display,
+                developmentUrl: null
+            }
+        }
+    }
+}
+
+const redactCatalogItemForList = <Item extends { authoringSurface: MetahubPackageAttachment['authoringSurface'] }>(item: Item): Item => ({
+    ...item,
+    authoringSurface:
+        item.authoringSurface.kind === 'playcanvasEditor'
+            ? {
+                  ...item.authoringSurface,
+                  artifact: undefined
+              }
+            : item.authoringSurface
+})
+
+const isPlayCanvasEditorAttachment = (item: MetahubPackageAttachment, packageSlug: string): item is PlayCanvasEditorAttachment =>
+    item.authoringSurface.kind === 'playcanvasEditor' && item.authoringSurface.packageSlug === packageSlug
+
+const getPlayCanvasEditorAttachment = async (
+    exec: Parameters<typeof listMetahubPackages>[0],
+    metahubId: string,
+    packageSlug: string
+): Promise<PlayCanvasEditorAttachment | undefined> => {
+    const packages = await listMetahubPackages(exec, metahubId)
+    const matches = packages.filter((item) => isPlayCanvasEditorAttachment(item, packageSlug))
+    if (matches.length > 1) {
+        throw new MetahubValidationError('Package authoring surface slug is not unique for this metahub')
+    }
+    return matches[0]
+}
+
+const resolveArtifactPath = (relativePath: string): string => {
+    const normalized = relativePath.replace(/^\/+/, '') || 'index.html'
+    if (normalized.includes('\0')) {
+        throw new MetahubValidationError('Invalid package artifact path')
+    }
+
+    const resolved = path.resolve(artifactRoot, normalized)
+    const relative = path.relative(artifactRoot, resolved)
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw new MetahubValidationError('Invalid package artifact path')
+    }
+    return resolved
+}
+
+const isPathInsideArtifactRoot = (resolvedRoot: string, resolvedPath: string): boolean => {
+    const relative = path.relative(resolvedRoot, resolvedPath)
+    return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+const isArtifactFileAvailable = async (filePath: string): Promise<boolean> => {
+    try {
+        await fs.access(filePath)
+        const [realRoot, realFile] = await Promise.all([fs.realpath(artifactRoot), fs.realpath(filePath)])
+        return isPathInsideArtifactRoot(realRoot, realFile)
+    } catch {
+        return false
+    }
+}
+
+const encodeArtifactTokenPart = (value: string): string => Buffer.from(value, 'utf8').toString('base64url')
+
+const signArtifactTokenPayload = (encodedPayload: string): string =>
+    createHmac('sha256', artifactTokenSecret).update(encodedPayload).digest('base64url')
+
+const createArtifactToken = (payload: Omit<ArtifactTokenPayload, 'expiresAt'>): string => {
+    const encodedPayload = encodeArtifactTokenPart(
+        JSON.stringify({
+            ...payload,
+            expiresAt: Date.now() + artifactTokenTtlMs
+        } satisfies ArtifactTokenPayload)
+    )
+    return `${encodedPayload}.${signArtifactTokenPayload(encodedPayload)}`
+}
+
+const readArtifactTokenPayload = (token: string): ArtifactTokenPayload | null => {
+    const [encodedPayload, signature, extra] = token.split('.')
+    if (!encodedPayload || !signature || extra) {
+        return null
+    }
+
+    const expectedSignature = signArtifactTokenPayload(encodedPayload)
+    const provided = Buffer.from(signature)
+    const expected = Buffer.from(expectedSignature)
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+        return null
+    }
+
+    try {
+        const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as Partial<ArtifactTokenPayload>
+        if (
+            typeof payload.metahubId !== 'string' ||
+            typeof payload.packageSlug !== 'string' ||
+            typeof payload.userId !== 'string' ||
+            typeof payload.expiresAt !== 'number' ||
+            payload.expiresAt < Date.now()
+        ) {
+            return null
+        }
+        return payload as ArtifactTokenPayload
+    } catch {
+        return null
+    }
+}
+
+const sendEditorArtifactFile = async (res: Response, filePath: string): Promise<Response | void> => {
+    const extension = path.extname(filePath).toLowerCase()
+    res.setHeader('X-Content-Type-Options', 'nosniff')
+    res.setHeader('Cache-Control', extension === '.html' ? 'no-store' : 'private, max-age=300')
+    res.setHeader(
+        'Content-Security-Policy',
+        "sandbox allow-scripts; default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:; connect-src 'self'; frame-ancestors 'self'"
+    )
+    const contentType = contentTypesByExtension.get(extension)
+    if (contentType) {
+        res.type(contentType)
+    }
+    return res.sendFile(filePath)
+}
+
+export function createPackagesController(createHandler: ReturnType<typeof createMetahubHandlerFactory>, getDbExecutor: () => DbExecutor) {
     const listCatalog = createHandler(async ({ res, metahubId, exec }) => {
-        const items = await listPackageCatalog(exec, metahubId)
+        const items = (await listPackageCatalog(exec, metahubId)).map(redactCatalogItemForList)
         return res.json({ items, total: items.length })
     })
 
     const listAttached = createHandler(async ({ res, metahubId, exec }) => {
-        const items = await listMetahubPackages(exec, metahubId)
+        const items = (await listMetahubPackages(exec, metahubId)).map(redactAttachmentConfigForList)
         return res.json({ items, total: items.length })
     })
+
+    const getAuthoringHost = createHandler(
+        async ({ req, res, metahubId, userId, exec }) => {
+            const slug = packageSlugSchema.safeParse(req.params.packageSlug)
+            if (!slug.success) {
+                throw new MetahubValidationError('Invalid package slug', { details: slug.error.flatten() })
+            }
+
+            const item = await getPlayCanvasEditorAttachment(exec, metahubId, slug.data)
+            if (!item) {
+                throw new MetahubNotFoundError('Metahub package')
+            }
+            if (!item.authoringSurface.artifact) {
+                throw new MetahubValidationError('Package authoring surface artifact is not configured')
+            }
+
+            let attachmentConfig = item.config
+            let isAttachmentConfigBlocked = false
+            try {
+                attachmentConfig = resolvePackageAttachmentConfig(item.config, item.authoringSurface)
+            } catch {
+                attachmentConfig = item.authoringSurface.defaultConfig
+                isAttachmentConfigBlocked = true
+            }
+
+            const manifestPath = resolveArtifactPath(item.authoringSurface.artifact.manifestFileName)
+            const indexPath = resolveArtifactPath('index.html')
+            const [hasManifest, hasIndex] = await Promise.all([isArtifactFileAvailable(manifestPath), isArtifactFileAvailable(indexPath)])
+            const hasArtifact = hasManifest && hasIndex
+            const displayMode = attachmentConfig.kind === 'display' ? attachmentConfig.display.mode : 'disabled'
+            const shouldServeArtifact =
+                !isAttachmentConfigBlocked && hasArtifact && (displayMode === 'embeddedIframe' || displayMode === 'openSeparately')
+            const artifactToken = shouldServeArtifact
+                ? createArtifactToken({
+                      metahubId,
+                      packageSlug: item.authoringSurface.packageSlug,
+                      userId
+                  })
+                : null
+            const descriptor: PackageAuthoringHostDescriptor = {
+                packageSlug: item.authoringSurface.packageSlug,
+                packageName: item.packageName,
+                version: item.version,
+                displayName: item.displayName,
+                description: item.description,
+                attachmentConfig,
+                authoringSurface: item.authoringSurface,
+                allowedDisplayModes: resolveAllowedPackageDisplayModes(item.authoringSurface),
+                artifactStatus: isAttachmentConfigBlocked
+                    ? 'blocked'
+                    : displayMode === 'disabled'
+                    ? 'disabled'
+                    : displayMode === 'developmentUrl'
+                    ? 'available'
+                    : hasArtifact
+                    ? 'available'
+                    : 'missing',
+                artifactUrl: shouldServeArtifact
+                    ? `/api/v1/metahub/${encodeURIComponent(metahubId)}/packages/${encodeURIComponent(
+                          item.authoringSurface.packageSlug
+                      )}/editor-artifact-token/${encodeURIComponent(artifactToken ?? '')}/index.html`
+                    : null
+            }
+
+            return res.json(descriptor)
+        },
+        { permission: 'manageMetahub' }
+    )
+
+    const serveEditorArtifact = createHandler(
+        async ({ req, res, metahubId, exec }) => {
+            const slug = packageSlugSchema.safeParse(req.params.packageSlug)
+            if (!slug.success) {
+                throw new MetahubValidationError('Invalid package slug', { details: slug.error.flatten() })
+            }
+
+            const item = await getPlayCanvasEditorAttachment(exec, metahubId, slug.data)
+            if (!item) {
+                throw new MetahubNotFoundError('Metahub package')
+            }
+            if (!item.authoringSurface.artifact) {
+                throw new MetahubValidationError('Package authoring surface artifact is not configured')
+            }
+
+            const attachmentConfig = resolvePackageAttachmentConfig(item.config, item.authoringSurface)
+            const displayMode = attachmentConfig.kind === 'display' ? attachmentConfig.display.mode : 'disabled'
+            if (displayMode !== 'embeddedIframe' && displayMode !== 'openSeparately') {
+                throw new MetahubNotFoundError('Package artifact')
+            }
+
+            const relativePath = typeof req.params[0] === 'string' ? req.params[0] : 'index.html'
+            const filePath = resolveArtifactPath(relativePath)
+            const manifestPath = resolveArtifactPath(item.authoringSurface.artifact.manifestFileName)
+            const [manifestAvailable, fileAvailable] = await Promise.all([
+                isArtifactFileAvailable(manifestPath),
+                isArtifactFileAvailable(filePath)
+            ])
+
+            if (!manifestAvailable || !fileAvailable) {
+                throw new MetahubNotFoundError('Package artifact')
+            }
+
+            return sendEditorArtifactFile(res, filePath)
+        },
+        { permission: 'manageMetahub' }
+    )
+
+    const serveEditorArtifactWithToken = async (req: Request, res: Response): Promise<Response | void> => {
+        const slug = packageSlugSchema.safeParse(req.params.packageSlug)
+        if (!slug.success) {
+            return res.status(404).json({ error: 'Package artifact' })
+        }
+
+        const token = typeof req.params.artifactToken === 'string' ? req.params.artifactToken : ''
+        const payload = readArtifactTokenPayload(token)
+        if (!payload || payload.metahubId !== req.params.metahubId || payload.packageSlug !== slug.data) {
+            return res.status(404).json({ error: 'Package artifact' })
+        }
+
+        const exec = getDbExecutor()
+        let manifestFileName: string | null = null
+        try {
+            await ensureMetahubAccess(exec, payload.userId, payload.metahubId, 'manageMetahub')
+
+            const item = await getPlayCanvasEditorAttachment(exec, payload.metahubId, slug.data)
+            if (!item?.authoringSurface.artifact) {
+                return res.status(404).json({ error: 'Package artifact' })
+            }
+            manifestFileName = item.authoringSurface.artifact.manifestFileName
+
+            const attachmentConfig = resolvePackageAttachmentConfig(item.config, item.authoringSurface)
+            const displayMode = attachmentConfig.kind === 'display' ? attachmentConfig.display.mode : 'disabled'
+            if (displayMode !== 'embeddedIframe' && displayMode !== 'openSeparately') {
+                return res.status(404).json({ error: 'Package artifact' })
+            }
+        } catch {
+            return res.status(404).json({ error: 'Package artifact' })
+        }
+
+        const relativePath = typeof req.params[0] === 'string' ? req.params[0] : 'index.html'
+        let filePath: string
+        let manifestPath: string
+        try {
+            if (!manifestFileName) {
+                return res.status(404).json({ error: 'Package artifact' })
+            }
+            filePath = resolveArtifactPath(relativePath)
+            manifestPath = resolveArtifactPath(manifestFileName)
+        } catch {
+            return res.status(404).json({ error: 'Package artifact' })
+        }
+
+        const [manifestAvailable, fileAvailable] = await Promise.all([
+            isArtifactFileAvailable(manifestPath),
+            isArtifactFileAvailable(filePath)
+        ])
+        if (!manifestAvailable || !fileAvailable) {
+            return res.status(404).json({ error: 'Package artifact' })
+        }
+
+        return sendEditorArtifactFile(res, filePath)
+    }
 
     const attach = createHandler(
         async ({ req, res, metahubId, userId, exec }) => {
@@ -75,7 +448,38 @@ export function createPackagesController(createHandler: ReturnType<typeof create
                 metahubId,
                 attachmentId: req.params.attachmentId,
                 version: parsed.data.version,
+                resetConfig: parsed.data.resetConfig,
                 userId
+            })
+
+            if (!item) {
+                throw new MetahubNotFoundError('Metahub package', req.params.attachmentId)
+            }
+
+            return res.json(item)
+        },
+        { permission: 'manageMetahub' }
+    )
+
+    const updateConfig = createHandler(
+        async ({ req, res, metahubId, userId, exec }) => {
+            const parsed = updatePackageConfigSchema.safeParse(req.body)
+            if (!parsed.success) {
+                throw new MetahubValidationError('Invalid package config payload', { details: parsed.error.flatten() })
+            }
+            const packages = await listMetahubPackages(exec, metahubId)
+            const attachment = packages.find((item) => item.id === req.params.attachmentId)
+            if (!attachment) {
+                throw new MetahubNotFoundError('Metahub package', req.params.attachmentId)
+            }
+            const config = resolvePackageAttachmentConfig(parsed.data.config, attachment.authoringSurface)
+
+            const item = await updateMetahubPackageConfig(exec, {
+                metahubId,
+                attachmentId: req.params.attachmentId,
+                config,
+                userId,
+                expectedPackageId: attachment.packageId
             })
 
             if (!item) {
@@ -107,8 +511,12 @@ export function createPackagesController(createHandler: ReturnType<typeof create
     return {
         listCatalog,
         listAttached,
+        getAuthoringHost,
+        serveEditorArtifact,
         attach,
         changeVersion,
-        detach
+        updateConfig,
+        detach,
+        serveEditorArtifactWithToken
     }
 }

--- a/packages/universo-react-metahubs-backend/src/domains/packages/data/index.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/data/index.ts
@@ -1,6 +1,7 @@
 import seedPackages from './seed-packages.json'
 import type { MetahubPackageRegistryItem } from '@universo-react/types'
 
-export type BuiltinPackageSeed = Omit<MetahubPackageRegistryItem, 'id' | 'isActive'>
+export type BuiltinPackageSeed = Omit<MetahubPackageRegistryItem, 'id' | 'isActive' | 'authoringSurface'> &
+    Partial<Pick<MetahubPackageRegistryItem, 'authoringSurface'>>
 
 export const builtinPackageSeeds = seedPackages as BuiltinPackageSeed[]

--- a/packages/universo-react-metahubs-backend/src/domains/packages/data/seed-packages.json
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/data/seed-packages.json
@@ -154,5 +154,78 @@
             "upstreamVersion": "2.18.1",
             "runtimeTargets": ["client"]
         }
+    },
+    {
+        "packageName": "@universo-react/playcanvas-editor",
+        "version": "0.1.0",
+        "displayName": {
+            "_schema": "1",
+            "_primary": "en",
+            "locales": {
+                "en": {
+                    "content": "PlayCanvas Editor",
+                    "version": 1,
+                    "isActive": true,
+                    "createdAt": "2026-06-01T00:00:00.000Z",
+                    "updatedAt": "2026-06-01T00:00:00.000Z"
+                },
+                "ru": {
+                    "content": "PlayCanvas Editor",
+                    "version": 1,
+                    "isActive": true,
+                    "createdAt": "2026-06-01T00:00:00.000Z",
+                    "updatedAt": "2026-06-01T00:00:00.000Z"
+                }
+            }
+        },
+        "description": {
+            "_schema": "1",
+            "_primary": "en",
+            "locales": {
+                "en": {
+                    "content": "Authoring-only PlayCanvas Editor package for metahub resources.",
+                    "version": 1,
+                    "isActive": true,
+                    "createdAt": "2026-06-01T00:00:00.000Z",
+                    "updatedAt": "2026-06-01T00:00:00.000Z"
+                },
+                "ru": {
+                    "content": "Authoring-only пакет PlayCanvas Editor для ресурсов метахаба.",
+                    "version": 1,
+                    "isActive": true,
+                    "createdAt": "2026-06-01T00:00:00.000Z",
+                    "updatedAt": "2026-06-01T00:00:00.000Z"
+                }
+            }
+        },
+        "source": {
+            "kind": "workspace",
+            "packageName": "@universo-react/playcanvas-editor",
+            "importName": "@universo-react/playcanvas-editor",
+            "upstreamPackageName": "playcanvas-editor",
+            "upstreamVersion": "2026-05-31-vendor",
+            "runtimeTargets": []
+        },
+        "authoringSurface": {
+            "schemaVersion": "1",
+            "kind": "playcanvasEditor",
+            "packageSlug": "playcanvas-editor",
+            "supportedDisplayModes": ["disabled", "embeddedIframe", "openSeparately", "developmentUrl"],
+            "defaultConfig": {
+                "schemaVersion": "1",
+                "kind": "display",
+                "display": {
+                    "mode": "embeddedIframe",
+                    "developmentUrl": null,
+                    "showArtifactOnlyNotice": true
+                }
+            },
+            "artifact": {
+                "packageName": "@universo-react/playcanvas-editor",
+                "manifestFileName": "universo-artifact-manifest.json",
+                "outputRoot": "dist/editor",
+                "smokeMode": "artifact-only"
+            }
+        }
     }
 ]

--- a/packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts
@@ -12,15 +12,25 @@ export function createPackagesRoutes(
     writeLimiter: RateLimitRequestHandler
 ): Router {
     const router = Router({ mergeParams: true })
-    router.use(ensureAuth)
 
     const createHandler = createMetahubHandlerFactory(getDbExecutor)
-    const ctrl = createPackagesController(createHandler)
+    const ctrl = createPackagesController(createHandler, getDbExecutor)
+
+    router.get(
+        '/metahub/:metahubId/packages/:packageSlug/editor-artifact-token/:artifactToken/*',
+        readLimiter,
+        asyncHandler(ctrl.serveEditorArtifactWithToken)
+    )
+
+    router.use(ensureAuth)
 
     router.get('/metahub/:metahubId/packages/catalog', readLimiter, asyncHandler(ctrl.listCatalog))
     router.get('/metahub/:metahubId/packages', readLimiter, asyncHandler(ctrl.listAttached))
+    router.get('/metahub/:metahubId/packages/:packageSlug/authoring-host', readLimiter, asyncHandler(ctrl.getAuthoringHost))
+    router.get('/metahub/:metahubId/packages/:packageSlug/editor-artifact/*', readLimiter, asyncHandler(ctrl.serveEditorArtifact))
     router.post('/metahub/:metahubId/packages', writeLimiter, asyncHandler(ctrl.attach))
     router.patch('/metahub/:metahubId/package/:attachmentId', writeLimiter, asyncHandler(ctrl.changeVersion))
+    router.patch('/metahub/:metahubId/package/:attachmentId/config', writeLimiter, asyncHandler(ctrl.updateConfig))
     router.delete('/metahub/:metahubId/package/:attachmentId', writeLimiter, asyncHandler(ctrl.detach))
 
     return router

--- a/packages/universo-react-metahubs-backend/src/domains/packages/services/MetahubPackagesService.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/services/MetahubPackagesService.ts
@@ -7,10 +7,22 @@ export class MetahubPackagesService {
 
     async listPublishedPackages(metahubId: string): Promise<MetahubSnapshotPackage[]> {
         const packages = await listMetahubPackages(this.exec, metahubId)
+        return packages
+            .filter((item) => item.source.runtimeTargets.length > 0)
+            .map((item) => ({
+                packageName: item.packageName,
+                version: item.version,
+                source: item.source
+            }))
+    }
+
+    async listMetahubSnapshotPackages(metahubId: string): Promise<MetahubSnapshotPackage[]> {
+        const packages = await listMetahubPackages(this.exec, metahubId)
         return packages.map((item) => ({
             packageName: item.packageName,
             version: item.version,
-            source: item.source
+            source: item.source,
+            config: item.config
         }))
     }
 }

--- a/packages/universo-react-metahubs-backend/src/domains/packages/services/PackageSeeder.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/services/PackageSeeder.ts
@@ -2,6 +2,10 @@ import stableStringify from 'json-stable-stringify'
 import type { DbExecutor } from '@universo-react/utils'
 import { builtinPackageSeeds } from '../data'
 import { upsertPackageRegistryItem } from '../../../persistence'
+import { resolvePackageAuthoringSurface } from './packageConfigValidation'
+
+export const playCanvasEditorPackageName = `@universo-react/${'playcanvas-editor'}`
+type BuiltinPackageSeed = (typeof builtinPackageSeeds)[number]
 
 export interface PackageSeederLogger {
     info(message: string, ...meta: unknown[]): void
@@ -11,6 +15,7 @@ export interface PackageSeederLogger {
 export interface PackageSeederOptions {
     failFast?: boolean
     logger?: PackageSeederLogger
+    packageFilter?: (seed: BuiltinPackageSeed) => boolean
 }
 
 export class PackageSeeder {
@@ -19,11 +24,24 @@ export class PackageSeeder {
     async seed(): Promise<void> {
         const logger = this.options.logger ?? console
         const stats = { upserted: 0, errors: 0 }
+        const packageSlugOwners = new Map<string, string>()
 
-        for (const seed of builtinPackageSeeds) {
+        const seeds = this.options.packageFilter ? builtinPackageSeeds.filter(this.options.packageFilter) : builtinPackageSeeds
+
+        for (const seed of seeds) {
             try {
+                const authoringSurface = resolvePackageAuthoringSurface(seed.authoringSurface)
+                if (authoringSurface.kind === 'playcanvasEditor') {
+                    const owner = packageSlugOwners.get(authoringSurface.packageSlug)
+                    if (owner && owner !== seed.packageName) {
+                        throw new Error(`Package authoring surface slug "${authoringSurface.packageSlug}" is already used by "${owner}"`)
+                    }
+                    packageSlugOwners.set(authoringSurface.packageSlug, seed.packageName)
+                }
+
                 await upsertPackageRegistryItem(this.executor, {
                     ...seed,
+                    authoringSurface,
                     userId: null
                 })
                 stats.upserted++
@@ -45,12 +63,22 @@ export async function seedPackages(executor: DbExecutor, options?: PackageSeeder
     await seeder.seed()
 }
 
-export const builtinPackageSeedChecksumSource =
+export const legacyBuiltinPackageSeedChecksumSource =
     stableStringify({
         kind: 'builtin-metahub-package-seed-migration',
-        packages: builtinPackageSeeds.map((item) => ({
-            packageName: item.packageName,
-            version: item.version,
-            source: item.source
-        }))
+        packages: builtinPackageSeeds
+            .filter((item) => item.packageName !== playCanvasEditorPackageName)
+            .map((item) => ({
+                packageName: item.packageName,
+                version: item.version,
+                source: item.source
+            }))
     }) ?? 'builtin-metahub-package-seed-migration'
+
+export const packageAuthoringSettingsSeedChecksumSource =
+    stableStringify({
+        kind: 'builtin-metahub-package-authoring-settings-seed-migration',
+        package: builtinPackageSeeds.find((item) => item.packageName === playCanvasEditorPackageName)
+    }) ?? 'builtin-metahub-package-authoring-settings-seed-migration'
+
+export const isLegacyBuiltinPackageSeed = (seed: BuiltinPackageSeed): boolean => seed.packageName !== playCanvasEditorPackageName

--- a/packages/universo-react-metahubs-backend/src/domains/packages/services/packageConfigValidation.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/services/packageConfigValidation.ts
@@ -1,0 +1,262 @@
+import { z } from 'zod'
+import type { PackageAttachmentConfig, PackageAuthoringSurfaceDescriptor, PackageDisplayMode } from '@universo-react/types'
+import { MetahubValidationError } from '../../shared/domainErrors'
+
+const displayModes = ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'] as const satisfies readonly PackageDisplayMode[]
+
+const packageAttachmentEmptyConfigSchema = z
+    .object({
+        schemaVersion: z.literal('1'),
+        kind: z.literal('none')
+    })
+    .strict()
+
+const packageAttachmentDisplayConfigSchema = z
+    .object({
+        schemaVersion: z.literal('1'),
+        kind: z.literal('display'),
+        display: z
+            .object({
+                mode: z.enum(displayModes),
+                developmentUrl: z.string().url().max(2048).nullable().optional(),
+                showArtifactOnlyNotice: z.boolean()
+            })
+            .strict()
+    })
+    .strict()
+
+export const packageAttachmentConfigSchema = z.discriminatedUnion('kind', [
+    packageAttachmentEmptyConfigSchema,
+    packageAttachmentDisplayConfigSchema
+])
+
+export const packageAuthoringSurfaceSchema = z
+    .discriminatedUnion('kind', [
+        z
+            .object({
+                schemaVersion: z.literal('1'),
+                kind: z.literal('none'),
+                supportedDisplayModes: z.tuple([]),
+                defaultConfig: z
+                    .object({
+                        schemaVersion: z.literal('1'),
+                        kind: z.literal('none')
+                    })
+                    .strict()
+            })
+            .strict(),
+        z
+            .object({
+                schemaVersion: z.literal('1'),
+                kind: z.literal('playcanvasEditor'),
+                packageSlug: z
+                    .string()
+                    .trim()
+                    .min(1)
+                    .max(96)
+                    .regex(/^[a-z0-9][a-z0-9-]*$/),
+                supportedDisplayModes: z.array(z.enum(displayModes)).min(1),
+                defaultConfig: packageAttachmentDisplayConfigSchema,
+                artifact: z
+                    .object({
+                        packageName: z.literal('@universo-react/playcanvas-editor'),
+                        manifestFileName: z.literal('universo-artifact-manifest.json'),
+                        outputRoot: z.literal('dist/editor'),
+                        smokeMode: z.literal('artifact-only')
+                    })
+                    .strict()
+            })
+            .strict()
+    ])
+    .superRefine((value, ctx) => {
+        if (value.kind === 'playcanvasEditor') {
+            if (new Set(value.supportedDisplayModes).size !== value.supportedDisplayModes.length) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['supportedDisplayModes'],
+                    message: 'Display modes must be unique'
+                })
+            }
+
+            if (value.defaultConfig.kind !== 'display') {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['defaultConfig'],
+                    message: 'PlayCanvas Editor requires display default config'
+                })
+                return
+            }
+
+            if (!value.supportedDisplayModes.includes(value.defaultConfig.display.mode)) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['defaultConfig', 'display', 'mode'],
+                    message: 'Default display mode must be supported'
+                })
+            }
+
+            if (value.defaultConfig.display.developmentUrl) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['defaultConfig', 'display', 'developmentUrl'],
+                    message: 'Default development URL must be empty'
+                })
+            }
+        }
+    })
+
+export const parsePackageAttachmentConfig = (value: unknown): PackageAttachmentConfig => {
+    const parsed = packageAttachmentConfigSchema.safeParse(value)
+    if (!parsed.success) {
+        throw new MetahubValidationError('Invalid package config payload', { details: parsed.error.flatten() })
+    }
+    return parsed.data
+}
+
+export const parsePackageAuthoringSurface = (value: unknown): PackageAuthoringSurfaceDescriptor => {
+    const parsed = packageAuthoringSurfaceSchema.safeParse(value)
+    if (!parsed.success) {
+        throw new MetahubValidationError('Invalid package authoring surface descriptor', { details: parsed.error.flatten() })
+    }
+    return parsed.data
+}
+
+export const resolvePackageAuthoringSurface = (value: unknown): PackageAuthoringSurfaceDescriptor => {
+    if (!value || typeof value !== 'object' || Object.keys(value).length === 0) {
+        return {
+            schemaVersion: '1',
+            kind: 'none',
+            supportedDisplayModes: [],
+            defaultConfig: {
+                schemaVersion: '1',
+                kind: 'none'
+            }
+        }
+    }
+
+    return parsePackageAuthoringSurface(value)
+}
+
+const normalizeDevelopmentUrlOrigin = (value: string): string | null => {
+    try {
+        const parsed = new URL(value)
+        if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+            return null
+        }
+        return parsed.origin
+    } catch {
+        return null
+    }
+}
+
+const getAllowedDevelopmentUrlOrigins = (): string[] =>
+    Array.from(
+        new Set(
+            (process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS ?? '')
+                .split(',')
+                .map((origin) => normalizeDevelopmentUrlOrigin(origin.trim()))
+                .filter((origin): origin is string => Boolean(origin))
+        )
+    )
+
+export const isDevelopmentUrlModeEnabled = (): boolean => getAllowedDevelopmentUrlOrigins().length > 0
+
+export const validateDevelopmentUrl = (value: string | null | undefined): void => {
+    if (!value) {
+        throw new MetahubValidationError('Development URL is required')
+    }
+
+    const parsed = new URL(value)
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+        throw new MetahubValidationError('Development URL is invalid')
+    }
+
+    const allowedOrigins = getAllowedDevelopmentUrlOrigins()
+
+    if (allowedOrigins.length === 0 || !allowedOrigins.includes(parsed.origin)) {
+        throw new MetahubValidationError('Development URL is not allowed')
+    }
+}
+
+export const resolveAllowedPackageDisplayModes = (authoringSurface: PackageAuthoringSurfaceDescriptor): PackageDisplayMode[] => {
+    if (authoringSurface.kind === 'none') {
+        return []
+    }
+
+    return authoringSurface.supportedDisplayModes.filter((mode) => mode !== 'developmentUrl' || isDevelopmentUrlModeEnabled())
+}
+
+export const resolvePackageAttachmentConfig = (
+    value: unknown,
+    authoringSurface: PackageAuthoringSurfaceDescriptor,
+    options?: { validateDevelopmentUrlAllowlist?: boolean }
+): PackageAttachmentConfig => {
+    const validateDevelopmentUrlAllowlist = options?.validateDevelopmentUrlAllowlist ?? true
+    const config = parsePackageAttachmentConfig(value)
+
+    if (authoringSurface.kind === 'none') {
+        if (config.kind !== 'none') {
+            throw new MetahubValidationError('Package does not support display settings')
+        }
+        return config
+    }
+
+    if (config.kind !== 'display') {
+        throw new MetahubValidationError('Package display settings are required')
+    }
+
+    if (!authoringSurface.supportedDisplayModes.includes(config.display.mode)) {
+        throw new MetahubValidationError('Package display mode is not supported')
+    }
+
+    const normalized: PackageAttachmentConfig = {
+        schemaVersion: '1',
+        kind: 'display',
+        display: {
+            mode: config.display.mode,
+            developmentUrl: config.display.mode === 'developmentUrl' ? config.display.developmentUrl ?? null : null,
+            showArtifactOnlyNotice: config.display.showArtifactOnlyNotice
+        }
+    }
+
+    if (normalized.display.mode === 'developmentUrl' && validateDevelopmentUrlAllowlist) {
+        validateDevelopmentUrl(normalized.display.developmentUrl)
+    }
+
+    return normalized
+}
+
+export const resolveStoredPackageAttachmentConfig = (
+    value: unknown,
+    authoringSurface: PackageAuthoringSurfaceDescriptor
+): PackageAttachmentConfig =>
+    resolvePackageAttachmentConfig(value, authoringSurface, {
+        validateDevelopmentUrlAllowlist: false
+    })
+
+export const resolveDefaultPackageAttachmentConfig = (authoringSurface: PackageAuthoringSurfaceDescriptor): PackageAttachmentConfig =>
+    resolvePackageAttachmentConfig(authoringSurface.defaultConfig, authoringSurface)
+
+export const resolveCompatiblePackageAttachmentConfig = (
+    value: unknown,
+    authoringSurface: PackageAuthoringSurfaceDescriptor
+): PackageAttachmentConfig => {
+    try {
+        return resolvePackageAttachmentConfig(value, authoringSurface)
+    } catch {
+        return resolveDefaultPackageAttachmentConfig(authoringSurface)
+    }
+}
+
+export const resolveCompatiblePackageAttachmentConfigOrThrow = (
+    value: unknown,
+    authoringSurface: PackageAuthoringSurfaceDescriptor
+): PackageAttachmentConfig => {
+    try {
+        return resolvePackageAttachmentConfig(value, authoringSurface)
+    } catch {
+        throw new MetahubValidationError('Package display settings are not compatible with the selected package version', {
+            resetConfigRequired: true
+        })
+    }
+}

--- a/packages/universo-react-metahubs-backend/src/domains/packages/services/packageConfigValidation.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/packages/services/packageConfigValidation.ts
@@ -166,7 +166,13 @@ export const validateDevelopmentUrl = (value: string | null | undefined): void =
         throw new MetahubValidationError('Development URL is required')
     }
 
-    const parsed = new URL(value)
+    let parsed: URL
+    try {
+        parsed = new URL(value)
+    } catch {
+        throw new MetahubValidationError('Development URL is invalid')
+    }
+
     if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
         throw new MetahubValidationError('Development URL is invalid')
     }

--- a/packages/universo-react-metahubs-backend/src/domains/publications/services/SnapshotSerializer.ts
+++ b/packages/universo-react-metahubs-backend/src/domains/publications/services/SnapshotSerializer.ts
@@ -685,9 +685,12 @@ export class SnapshotSerializer {
      */
     async serializeMetahub(
         metahubId: string,
-        options?: Partial<MetahubSnapshotVersionEnvelope> & { runtimePolicy?: MetahubRuntimePolicySnapshot }
+        options?: Partial<MetahubSnapshotVersionEnvelope> & {
+            runtimePolicy?: MetahubRuntimePolicySnapshot
+            packageMode?: 'runtime' | 'metahub'
+        }
     ): Promise<MetahubSnapshot> {
-        const { runtimePolicy, ...versionEnvelope } = options ?? {}
+        const { runtimePolicy, packageMode = 'runtime', ...versionEnvelope } = options ?? {}
         const { typeByKind, entityTypeDefinitions } = await this.loadSnapshotTypeDefinitions(metahubId)
         const objectKinds = [...typeByKind.keys()].filter((kind) => {
             const definition = typeByKind.get(kind)
@@ -726,7 +729,11 @@ export class SnapshotSerializer {
                   config: module.config
               }))
             : []
-        const publishedPackages = this.packagesService ? await this.packagesService.listPublishedPackages(metahubId) : []
+        const publishedPackages = this.packagesService
+            ? packageMode === 'metahub'
+                ? await this.packagesService.listMetahubSnapshotPackages(metahubId)
+                : await this.packagesService.listPublishedPackages(metahubId)
+            : []
         const settings = this.settingsService
             ? (await this.settingsService.findAll(metahubId))
                   .filter((setting) => typeof setting.key === 'string' && setting.value && typeof setting.value === 'object')

--- a/packages/universo-react-metahubs-backend/src/persistence/index.ts
+++ b/packages/universo-react-metahubs-backend/src/persistence/index.ts
@@ -108,9 +108,11 @@ export {
     listPackageCatalog,
     listMetahubPackages,
     copyMetahubPackages,
+    prepareMetahubPackagesFromSnapshot,
     replaceMetahubPackagesFromSnapshot,
     attachMetahubPackage,
     changeMetahubPackageVersion,
+    updateMetahubPackageConfig,
     detachMetahubPackage
 } from './packagesStore'
 export type { UpsertPackageInput } from './packagesStore'

--- a/packages/universo-react-metahubs-backend/src/persistence/packagesStore.ts
+++ b/packages/universo-react-metahubs-backend/src/persistence/packagesStore.ts
@@ -1,5 +1,7 @@
 import { qSchemaTable } from '@universo-react/database'
 import type {
+    PackageAttachmentConfig,
+    PackageAuthoringSurfaceDescriptor,
     MetahubPackageAttachment,
     MetahubPackageCatalogItem,
     MetahubPackageRegistryItem,
@@ -8,11 +10,37 @@ import type {
 } from '@universo-react/types'
 import type { SqlQueryable, PackageRow } from './types'
 import { appFieldAliases, uplFieldAliases } from './types'
+import {
+    resolvePackageAuthoringSurface,
+    resolveCompatiblePackageAttachmentConfig,
+    resolveCompatiblePackageAttachmentConfigOrThrow,
+    resolveDefaultPackageAttachmentConfig,
+    resolvePackageAttachmentConfig,
+    resolveStoredPackageAttachmentConfig
+} from '../domains/packages/services/packageConfigValidation'
 
 const PACKAGES_TABLE = qSchemaTable('metahubs', 'obj_packages')
 const METAHUB_PACKAGES_TABLE = qSchemaTable('metahubs', 'rel_metahub_packages')
 
 type AttachmentResultRow = Omit<MetahubPackageAttachment, 'attachedAt'> & { attachedAt: Date | string }
+type SelectedPackageRow = Pick<PackageRow, 'id' | 'packageName' | 'version' | 'authoringSurface' | 'source'>
+type SnapshotPackageInput = {
+    packageName: string
+    version: string
+    source?: PackageSourceDescriptor
+    config?: PackageAttachmentConfig
+}
+type PreparedSnapshotPackage = { selectedPackage: SelectedPackageRow; config: PackageAttachmentConfig }
+
+const DEFAULT_AUTHORING_SURFACE: PackageAuthoringSurfaceDescriptor = {
+    schemaVersion: '1',
+    kind: 'none',
+    supportedDisplayModes: [],
+    defaultConfig: {
+        schemaVersion: '1',
+        kind: 'none'
+    }
+}
 
 const activePackagePredicate = (alias: string): string =>
     `${alias}.is_active = true AND ${alias}._upl_deleted = false AND ${alias}._app_deleted = false`
@@ -25,6 +53,7 @@ const PACKAGE_SELECT = (alias: string) =>
     ${alias}.display_name AS "displayName",
     ${alias}.description,
     ${alias}.source,
+    ${alias}.authoring_surface AS "authoringSurface",
     ${alias}.is_active AS "isActive",
     ${uplFieldAliases(alias)},
     ${appFieldAliases(alias)}
@@ -36,23 +65,121 @@ export interface UpsertPackageInput {
     displayName: VersionedLocalizedContent<string>
     description?: VersionedLocalizedContent<string> | null
     source: PackageSourceDescriptor
+    authoringSurface?: PackageAuthoringSurfaceDescriptor
     userId?: string | null
 }
 
+const normalizeAuthoringSurface = (value: unknown): PackageAuthoringSurfaceDescriptor => resolvePackageAuthoringSurface(value)
+
+const normalizeAttachmentConfig = (
+    value: PackageAttachmentConfig | null | undefined,
+    authoringSurface: PackageAuthoringSurfaceDescriptor = DEFAULT_AUTHORING_SURFACE
+): PackageAttachmentConfig => {
+    if (!value || typeof value !== 'object' || Object.keys(value).length === 0) {
+        return resolveDefaultPackageAttachmentConfig(authoringSurface)
+    }
+    return value
+}
+
+const selectActivePackageBySnapshotItem = async (
+    exec: SqlQueryable,
+    item: { packageName: string; version: string; source?: PackageSourceDescriptor }
+): Promise<SelectedPackageRow | null> => {
+    const rows = await exec.query<SelectedPackageRow>(
+        `SELECT p.id,
+                p.package_name AS "packageName",
+                p.version,
+                p.source,
+                p.authoring_surface AS "authoringSurface"
+         FROM ${PACKAGES_TABLE} p
+         WHERE p.package_name = $1
+           AND p.version = $2
+           AND ($3::jsonb IS NULL OR p.source = $3::jsonb)
+           AND ${activePackagePredicate('p')}
+         LIMIT 1`,
+        [item.packageName, item.version, item.source ? JSON.stringify(item.source) : null]
+    )
+    return rows[0] ? { ...rows[0], authoringSurface: normalizeAuthoringSurface(rows[0].authoringSurface) } : null
+}
+
+const normalizeAttachmentRow = (row: AttachmentResultRow): MetahubPackageAttachment => ({
+    ...row,
+    authoringSurface: normalizeAuthoringSurface(row.authoringSurface),
+    config: normalizeAttachmentConfig(row.config, normalizeAuthoringSurface(row.authoringSurface)),
+    attachedAt: row.attachedAt instanceof Date ? row.attachedAt.toISOString() : String(row.attachedAt)
+})
+
+export async function prepareMetahubPackagesFromSnapshot(
+    exec: SqlQueryable,
+    packages: SnapshotPackageInput[]
+): Promise<PreparedSnapshotPackage[]> {
+    const packageNames = new Set<string>()
+    for (const item of packages) {
+        if (packageNames.has(item.packageName)) {
+            throw new Error(`Duplicate package in metahub snapshot: ${item.packageName}`)
+        }
+        packageNames.add(item.packageName)
+    }
+
+    const restoredPackages: PreparedSnapshotPackage[] = []
+    for (const item of packages) {
+        const selectedPackage = await selectActivePackageBySnapshotItem(exec, item)
+        if (!selectedPackage) {
+            throw new Error(`Package from metahub snapshot is not registered: ${item.packageName}@${item.version}`)
+        }
+        const restoredConfig =
+            item.config === undefined
+                ? resolveDefaultPackageAttachmentConfig(selectedPackage.authoringSurface)
+                : resolveStoredPackageAttachmentConfig(item.config, selectedPackage.authoringSurface)
+        restoredPackages.push({ selectedPackage, config: restoredConfig })
+    }
+
+    return restoredPackages
+}
+
 export async function upsertPackageRegistryItem(exec: SqlQueryable, input: UpsertPackageInput): Promise<PackageRow> {
+    const authoringSurface = normalizeAuthoringSurface(input.authoringSurface)
+    if (authoringSurface.kind === 'playcanvasEditor') {
+        const slugConflicts = await exec.query<{ packageName: string }>(
+            `SELECT p.package_name AS "packageName"
+             FROM ${PACKAGES_TABLE} p
+             WHERE p.authoring_surface ->> 'kind' = 'playcanvasEditor'
+               AND p.authoring_surface ->> 'packageSlug' = $1
+               AND p.package_name <> $2
+               AND ${activePackagePredicate('p')}
+             LIMIT 1`,
+            [authoringSurface.packageSlug, input.packageName]
+        )
+        if (slugConflicts[0]?.packageName) {
+            throw new Error(
+                `Package authoring surface slug "${authoringSurface.packageSlug}" is already used by "${slugConflicts[0].packageName}"`
+            )
+        }
+    }
+
     const rows = await exec.query<PackageRow>(
         `INSERT INTO ${PACKAGES_TABLE} AS p
-            (package_name, version, display_name, description, source, is_active, _upl_created_by, _upl_updated_by)
-         VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, true, $6, $6)
+            (package_name, version, display_name, description, source, authoring_surface, is_active, _upl_created_by, _upl_updated_by)
+         VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb, true, $7, $7)
          ON CONFLICT (package_name, version)
          WHERE _upl_deleted = false AND _app_deleted = false AND is_active = true
          DO UPDATE SET
             display_name = EXCLUDED.display_name,
             description = EXCLUDED.description,
             source = EXCLUDED.source,
+            authoring_surface = EXCLUDED.authoring_surface,
             is_active = true,
             _upl_updated_at = now(),
-            _upl_updated_by = EXCLUDED._upl_updated_by
+            _upl_updated_by = EXCLUDED._upl_updated_by,
+            _upl_version = CASE
+                WHEN p.display_name IS DISTINCT FROM EXCLUDED.display_name
+                  OR p.description IS DISTINCT FROM EXCLUDED.description
+                  OR p.source IS DISTINCT FROM EXCLUDED.source
+                  OR p.authoring_surface IS DISTINCT FROM EXCLUDED.authoring_surface
+                  OR p.is_active IS DISTINCT FROM true
+                THEN p._upl_version + 1
+                ELSE p._upl_version
+            END
          RETURNING ${PACKAGE_SELECT('p')}`,
         [
             input.packageName,
@@ -60,10 +187,14 @@ export async function upsertPackageRegistryItem(exec: SqlQueryable, input: Upser
             JSON.stringify(input.displayName),
             JSON.stringify(input.description ?? null),
             JSON.stringify(input.source),
+            JSON.stringify(authoringSurface),
             input.userId ?? null
         ]
     )
-    return rows[0]
+    return {
+        ...rows[0],
+        authoringSurface: normalizeAuthoringSurface(rows[0].authoringSurface)
+    }
 }
 
 export async function findPackageByNameVersion(
@@ -80,7 +211,12 @@ export async function findPackageByNameVersion(
          LIMIT 1`,
         [packageName, version]
     )
-    return rows[0] ?? null
+    return rows[0]
+        ? {
+              ...rows[0],
+              authoringSurface: normalizeAuthoringSurface(rows[0].authoringSurface)
+          }
+        : null
 }
 
 export async function listPackageCatalog(exec: SqlQueryable, metahubId: string): Promise<MetahubPackageCatalogItem[]> {
@@ -116,6 +252,7 @@ export async function listPackageCatalog(exec: SqlQueryable, metahubId: string):
         displayName: row.displayName,
         description: row.description,
         source: row.source,
+        authoringSurface: normalizeAuthoringSurface(row.authoringSurface),
         isActive: row.isActive,
         attached: Boolean(row.attachmentId),
         attachmentId: row.attachmentId,
@@ -125,19 +262,22 @@ export async function listPackageCatalog(exec: SqlQueryable, metahubId: string):
 }
 
 export async function listMetahubPackages(exec: SqlQueryable, metahubId: string): Promise<MetahubPackageAttachment[]> {
-    const rows = await exec.query<{
-        id: string
-        metahubId: string
-        packageId: string
-        packageName: string
-        version: string
-        displayName: VersionedLocalizedContent<string>
-        description: VersionedLocalizedContent<string> | null
-        source: PackageSourceDescriptor
-        attachedAt: Date | string
-        isActive: boolean
-    }>(
-        `SELECT
+    const rows =
+        (await exec.query<{
+            id: string
+            metahubId: string
+            packageId: string
+            packageName: string
+            version: string
+            displayName: VersionedLocalizedContent<string>
+            description: VersionedLocalizedContent<string> | null
+            source: PackageSourceDescriptor
+            authoringSurface: PackageAuthoringSurfaceDescriptor
+            config: PackageAttachmentConfig
+            attachedAt: Date | string
+            isActive: boolean
+        }>(
+            `SELECT
             a.id,
             a.metahub_id AS "metahubId",
             a.package_id AS "packageId",
@@ -146,6 +286,8 @@ export async function listMetahubPackages(exec: SqlQueryable, metahubId: string)
             p.display_name AS "displayName",
             p.description,
             p.source,
+            p.authoring_surface AS "authoringSurface",
+            a.config,
             a._upl_created_at AS "attachedAt",
             a.is_active AS "isActive"
          FROM ${METAHUB_PACKAGES_TABLE} a
@@ -156,13 +298,10 @@ export async function listMetahubPackages(exec: SqlQueryable, metahubId: string)
            AND a._app_deleted = false
            AND ${activePackagePredicate('p')}
          ORDER BY a.package_name ASC`,
-        [metahubId]
-    )
+            [metahubId]
+        )) ?? []
 
-    return rows.map((row) => ({
-        ...row,
-        attachedAt: row.attachedAt instanceof Date ? row.attachedAt.toISOString() : String(row.attachedAt)
-    }))
+    return rows.map((row) => normalizeAttachmentRow(row))
 }
 
 export async function copyMetahubPackages(
@@ -170,13 +309,14 @@ export async function copyMetahubPackages(
     input: { sourceMetahubId: string; targetMetahubId: string; userId: string }
 ): Promise<number> {
     const rows = await exec.query<{ id: string }>(
-        `INSERT INTO ${METAHUB_PACKAGES_TABLE}
-            (metahub_id, package_id, package_name, expected_version, is_active, _upl_created_by, _upl_updated_by)
+        `INSERT INTO ${METAHUB_PACKAGES_TABLE} AS target
+            (metahub_id, package_id, package_name, expected_version, config, is_active, _upl_created_by, _upl_updated_by)
          SELECT
             $2,
             source.package_id,
             source.package_name,
             source.expected_version,
+            source.config,
             true,
             $3,
             $3
@@ -189,13 +329,15 @@ export async function copyMetahubPackages(
            AND ${activePackagePredicate('p')}
          ON CONFLICT (metahub_id, package_name)
          WHERE _upl_deleted = false AND _app_deleted = false AND is_active = true
-         DO UPDATE SET
-            package_id = EXCLUDED.package_id,
-            expected_version = EXCLUDED.expected_version,
-            is_active = true,
-            _upl_updated_at = now(),
-            _upl_updated_by = EXCLUDED._upl_updated_by
-         RETURNING id`,
+	         DO UPDATE SET
+	            package_id = EXCLUDED.package_id,
+	            expected_version = EXCLUDED.expected_version,
+	            config = EXCLUDED.config,
+	            is_active = true,
+	            _upl_updated_at = now(),
+	            _upl_updated_by = EXCLUDED._upl_updated_by,
+	            _upl_version = target._upl_version + 1
+	         RETURNING id`,
         [input.sourceMetahubId, input.targetMetahubId, input.userId]
     )
 
@@ -206,27 +348,22 @@ export async function replaceMetahubPackagesFromSnapshot(
     exec: SqlQueryable,
     input: {
         metahubId: string
-        packages: Array<{ packageName: string; version: string; source?: PackageSourceDescriptor }>
+        packages: SnapshotPackageInput[]
         userId: string
     }
 ): Promise<number> {
-    const packageNames = new Set<string>()
-    for (const item of input.packages) {
-        if (packageNames.has(item.packageName)) {
-            throw new Error(`Duplicate package in metahub snapshot: ${item.packageName}`)
-        }
-        packageNames.add(item.packageName)
-    }
+    const restoredPackages = await prepareMetahubPackagesFromSnapshot(exec, input.packages)
 
     await exec.query(
         `UPDATE ${METAHUB_PACKAGES_TABLE}
          SET is_active = false,
              _upl_deleted = true,
              _upl_deleted_at = now(),
-             _upl_deleted_by = $2,
-             _upl_updated_at = now(),
-             _upl_updated_by = $2
-         WHERE metahub_id = $1
+	             _upl_deleted_by = $2,
+	             _upl_updated_at = now(),
+	             _upl_updated_by = $2,
+	             _upl_version = _upl_version + 1
+	         WHERE metahub_id = $1
            AND is_active = true
            AND _upl_deleted = false
            AND _app_deleted = false
@@ -235,31 +372,22 @@ export async function replaceMetahubPackagesFromSnapshot(
     )
 
     let restored = 0
-    for (const item of input.packages) {
+    for (const { selectedPackage, config } of restoredPackages) {
         const rows = await exec.query<{ id: string }>(
-            `WITH selected_package AS (
-                SELECT p.id, p.package_name, p.version
-                FROM ${PACKAGES_TABLE} p
-                WHERE p.package_name = $2
-                  AND p.version = $3
-                  AND ($5::jsonb IS NULL OR p.source = $5::jsonb)
-                  AND ${activePackagePredicate('p')}
-                LIMIT 1
-             ),
-             inserted AS (
-                INSERT INTO ${METAHUB_PACKAGES_TABLE}
-                    (metahub_id, package_id, package_name, expected_version, is_active, _upl_created_by, _upl_updated_by)
-                SELECT $1, id, package_name, version, true, $4, $4
-                FROM selected_package
-                RETURNING id
-             )
-             SELECT id FROM inserted`,
-            [input.metahubId, item.packageName, item.version, input.userId, item.source ? JSON.stringify(item.source) : null]
+            `INSERT INTO ${METAHUB_PACKAGES_TABLE}
+                (metahub_id, package_id, package_name, expected_version, config, is_active, _upl_created_by, _upl_updated_by)
+             VALUES ($1, $2, $3, $4, $5::jsonb, true, $6, $6)
+             RETURNING id`,
+            [
+                input.metahubId,
+                selectedPackage.id,
+                selectedPackage.packageName,
+                selectedPackage.version,
+                JSON.stringify(config),
+                input.userId
+            ]
         )
 
-        if (rows.length === 0) {
-            throw new Error(`Package from metahub snapshot is not registered: ${item.packageName}@${item.version}`)
-        }
         restored += rows.length
     }
 
@@ -270,29 +398,58 @@ export async function attachMetahubPackage(
     exec: SqlQueryable,
     input: { metahubId: string; packageName: string; version: string; userId: string }
 ): Promise<MetahubPackageAttachment | null> {
+    const selectedRows = await exec.query<SelectedPackageRow>(
+        `SELECT p.id,
+                p.package_name AS "packageName",
+                p.version,
+                p.source,
+                p.authoring_surface AS "authoringSurface"
+         FROM ${PACKAGES_TABLE} p
+         WHERE p.package_name = $1
+           AND p.version = $2
+           AND ${activePackagePredicate('p')}
+         LIMIT 1`,
+        [input.packageName, input.version]
+    )
+    const selectedPackage = selectedRows[0]
+        ? { ...selectedRows[0], authoringSurface: normalizeAuthoringSurface(selectedRows[0].authoringSurface) }
+        : null
+    if (!selectedPackage) {
+        return null
+    }
+    const currentRows = await exec.query<{ packageId: string; config: PackageAttachmentConfig }>(
+        `SELECT a.package_id AS "packageId",
+                a.config
+         FROM ${METAHUB_PACKAGES_TABLE} a
+         WHERE a.metahub_id = $1
+           AND a.package_name = $2
+           AND a.is_active = true
+           AND a._upl_deleted = false
+           AND a._app_deleted = false
+         LIMIT 1`,
+        [input.metahubId, selectedPackage.packageName]
+    )
+    const currentAttachment = currentRows[0]
+    const nextConfig = currentAttachment
+        ? resolveCompatiblePackageAttachmentConfig(currentAttachment.config, selectedPackage.authoringSurface)
+        : resolveDefaultPackageAttachmentConfig(selectedPackage.authoringSurface)
+
     const rows = await exec.query<AttachmentResultRow>(
-        `WITH selected_package AS (
-            SELECT p.id, p.package_name, p.version
-            FROM ${PACKAGES_TABLE} p
-            WHERE p.package_name = $2
-              AND p.version = $3
-              AND ${activePackagePredicate('p')}
-            LIMIT 1
-         ),
-         upserted AS (
-            INSERT INTO ${METAHUB_PACKAGES_TABLE}
-                (metahub_id, package_id, package_name, expected_version, is_active, _upl_created_by, _upl_updated_by)
-            SELECT $1, id, package_name, version, true, $4, $4
-            FROM selected_package
+        `WITH upserted AS (
+            INSERT INTO ${METAHUB_PACKAGES_TABLE} AS target
+                (metahub_id, package_id, package_name, expected_version, config, is_active, _upl_created_by, _upl_updated_by)
+            VALUES ($1, $2, $3, $4, $5::jsonb, true, $6, $6)
             ON CONFLICT (metahub_id, package_name)
             WHERE _upl_deleted = false AND _app_deleted = false AND is_active = true
             DO UPDATE SET
-                package_id = EXCLUDED.package_id,
-                expected_version = EXCLUDED.expected_version,
-                is_active = true,
-                _upl_updated_at = now(),
-                _upl_updated_by = EXCLUDED._upl_updated_by
-            RETURNING id, metahub_id, package_id, package_name, expected_version, is_active, _upl_created_at
+	                package_id = EXCLUDED.package_id,
+	                expected_version = EXCLUDED.expected_version,
+	                config = EXCLUDED.config,
+	                is_active = true,
+	                _upl_updated_at = now(),
+	                _upl_updated_by = EXCLUDED._upl_updated_by,
+	                _upl_version = target._upl_version + 1
+	            RETURNING id, metahub_id, package_id, package_name, expected_version, config, is_active, _upl_created_at
          )
          SELECT
             u.id,
@@ -303,20 +460,24 @@ export async function attachMetahubPackage(
             p.display_name AS "displayName",
             p.description,
             p.source,
+            p.authoring_surface AS "authoringSurface",
+            u.config,
             u._upl_created_at AS "attachedAt",
             u.is_active AS "isActive"
          FROM upserted u
          JOIN ${PACKAGES_TABLE} p ON p.id = u.package_id`,
-        [input.metahubId, input.packageName, input.version, input.userId]
+        [
+            input.metahubId,
+            selectedPackage.id,
+            selectedPackage.packageName,
+            selectedPackage.version,
+            JSON.stringify(nextConfig),
+            input.userId
+        ]
     )
 
     const row = rows[0]
-    return row
-        ? {
-              ...row,
-              attachedAt: row.attachedAt instanceof Date ? row.attachedAt.toISOString() : String(row.attachedAt)
-          }
-        : null
+    return row ? normalizeAttachmentRow(row) : null
 }
 
 export async function detachMetahubPackage(
@@ -328,10 +489,11 @@ export async function detachMetahubPackage(
          SET is_active = false,
              _upl_deleted = true,
              _upl_deleted_at = now(),
-             _upl_deleted_by = $3,
-             _upl_updated_at = now(),
-             _upl_updated_by = $3
-         WHERE id = $2
+	             _upl_deleted_by = $3,
+	             _upl_updated_at = now(),
+	             _upl_updated_by = $3,
+	             _upl_version = _upl_version + 1
+	         WHERE id = $2
            AND metahub_id = $1
            AND is_active = true
            AND _upl_deleted = false
@@ -345,40 +507,63 @@ export async function detachMetahubPackage(
 
 export async function changeMetahubPackageVersion(
     exec: SqlQueryable,
-    input: { metahubId: string; attachmentId: string; version: string; userId: string }
+    input: { metahubId: string; attachmentId: string; version: string; userId: string; resetConfig?: boolean }
 ): Promise<MetahubPackageAttachment | null> {
+    const candidates = await exec.query<{
+        attachmentId: string
+        packageName: string
+        config: PackageAttachmentConfig
+        currentPackageId: string
+        selectedPackageId: string
+        selectedVersion: string
+        selectedAuthoringSurface: PackageAuthoringSurfaceDescriptor
+    }>(
+        `SELECT
+            a.id AS "attachmentId",
+            a.package_name AS "packageName",
+            a.config,
+            a.package_id AS "currentPackageId",
+            p.id AS "selectedPackageId",
+            p.version AS "selectedVersion",
+            p.authoring_surface AS "selectedAuthoringSurface"
+         FROM ${METAHUB_PACKAGES_TABLE} a
+         JOIN ${PACKAGES_TABLE} p ON p.package_name = a.package_name
+         WHERE a.id = $2
+           AND a.metahub_id = $1
+           AND a.is_active = true
+           AND a._upl_deleted = false
+           AND a._app_deleted = false
+           AND p.version = $3
+           AND ${activePackagePredicate('p')}
+         LIMIT 1`,
+        [input.metahubId, input.attachmentId, input.version]
+    )
+    const candidate = candidates[0]
+    if (!candidate) {
+        return null
+    }
+    const selectedAuthoringSurface = normalizeAuthoringSurface(candidate.selectedAuthoringSurface)
+    const nextConfig =
+        input.resetConfig === true
+            ? resolveDefaultPackageAttachmentConfig(selectedAuthoringSurface)
+            : resolveCompatiblePackageAttachmentConfigOrThrow(candidate.config, selectedAuthoringSurface)
+
     const rows = await exec.query<AttachmentResultRow>(
-        `WITH current_attachment AS (
-            SELECT id, package_name
-            FROM ${METAHUB_PACKAGES_TABLE}
-            WHERE id = $2
-              AND metahub_id = $1
-              AND is_active = true
-              AND _upl_deleted = false
-              AND _app_deleted = false
-            LIMIT 1
-         ),
-         selected_package AS (
-            SELECT p.id, p.package_name, p.version
-            FROM ${PACKAGES_TABLE} p
-            JOIN current_attachment a ON a.package_name = p.package_name
-            WHERE p.version = $3
-              AND ${activePackagePredicate('p')}
-            LIMIT 1
-         ),
-         updated AS (
+        `WITH updated AS (
             UPDATE ${METAHUB_PACKAGES_TABLE} a
-            SET package_id = p.id,
-                expected_version = p.version,
-                _upl_updated_at = now(),
-                _upl_updated_by = $4
-            FROM selected_package p
-            WHERE a.id = $2
+            SET package_id = $3,
+                expected_version = $4,
+	                config = $5::jsonb,
+	                _upl_updated_at = now(),
+	                _upl_updated_by = $6,
+	                _upl_version = a._upl_version + 1
+	            WHERE a.id = $2
               AND a.metahub_id = $1
               AND a.is_active = true
               AND a._upl_deleted = false
               AND a._app_deleted = false
-            RETURNING a.id, a.metahub_id, a.package_id, a.package_name, a.expected_version, a.is_active, a._upl_created_at
+              AND a.package_id = $7
+            RETURNING a.id, a.metahub_id, a.package_id, a.package_name, a.expected_version, a.config, a.is_active, a._upl_created_at
          )
          SELECT
             u.id,
@@ -389,18 +574,64 @@ export async function changeMetahubPackageVersion(
             p.display_name AS "displayName",
             p.description,
             p.source,
+            p.authoring_surface AS "authoringSurface",
+            u.config,
             u._upl_created_at AS "attachedAt",
             u.is_active AS "isActive"
          FROM updated u
          JOIN ${PACKAGES_TABLE} p ON p.id = u.package_id`,
-        [input.metahubId, input.attachmentId, input.version, input.userId]
+        [
+            input.metahubId,
+            input.attachmentId,
+            candidate.selectedPackageId,
+            candidate.selectedVersion,
+            JSON.stringify(nextConfig),
+            input.userId,
+            candidate.currentPackageId
+        ]
     )
 
     const row = rows[0]
-    return row
-        ? {
-              ...row,
-              attachedAt: row.attachedAt instanceof Date ? row.attachedAt.toISOString() : String(row.attachedAt)
-          }
-        : null
+    return row ? normalizeAttachmentRow(row) : null
+}
+
+export async function updateMetahubPackageConfig(
+    exec: SqlQueryable,
+    input: { metahubId: string; attachmentId: string; config: PackageAttachmentConfig; userId: string; expectedPackageId?: string }
+): Promise<MetahubPackageAttachment | null> {
+    const rows = await exec.query<AttachmentResultRow>(
+        `WITH updated AS (
+            UPDATE ${METAHUB_PACKAGES_TABLE} a
+	            SET config = $3::jsonb,
+	                _upl_updated_at = now(),
+	                _upl_updated_by = $4,
+	                _upl_version = a._upl_version + 1
+	            WHERE a.id = $2
+              AND a.metahub_id = $1
+              AND a.is_active = true
+              AND a._upl_deleted = false
+              AND a._app_deleted = false
+              AND ($5::uuid IS NULL OR a.package_id = $5::uuid)
+            RETURNING a.id, a.metahub_id, a.package_id, a.package_name, a.expected_version, a.config, a.is_active, a._upl_created_at
+         )
+         SELECT
+            u.id,
+            u.metahub_id AS "metahubId",
+            u.package_id AS "packageId",
+            u.package_name AS "packageName",
+            u.expected_version AS "version",
+            p.display_name AS "displayName",
+            p.description,
+            p.source,
+            p.authoring_surface AS "authoringSurface",
+            u.config,
+            u._upl_created_at AS "attachedAt",
+            u.is_active AS "isActive"
+         FROM updated u
+         JOIN ${PACKAGES_TABLE} p ON p.id = u.package_id`,
+        [input.metahubId, input.attachmentId, JSON.stringify(input.config), input.userId, input.expectedPackageId ?? null]
+    )
+
+    const row = rows[0]
+    return row ? normalizeAttachmentRow(row) : null
 }

--- a/packages/universo-react-metahubs-backend/src/persistence/types.ts
+++ b/packages/universo-react-metahubs-backend/src/persistence/types.ts
@@ -1,4 +1,10 @@
-import type { VersionedLocalizedContent, TemplateDefinitionManifest, PackageSourceDescriptor } from '@universo-react/types'
+import type {
+    VersionedLocalizedContent,
+    TemplateDefinitionManifest,
+    PackageSourceDescriptor,
+    PackageAuthoringSurfaceDescriptor,
+    PackageAttachmentConfig
+} from '@universo-react/types'
 
 // Re-export canonical SqlQueryable from @universo-react/utils
 export type { SqlQueryable } from '@universo-react/utils'
@@ -173,6 +179,7 @@ export interface PackageRow extends UplSystemFields, AppSystemFields {
     displayName: VersionedLocalizedContent<string>
     description: VersionedLocalizedContent<string> | null
     source: PackageSourceDescriptor
+    authoringSurface: PackageAuthoringSurfaceDescriptor
     isActive: boolean
 }
 
@@ -182,6 +189,7 @@ export interface MetahubPackageRow extends UplSystemFields, AppSystemFields {
     packageId: string
     packageName: string
     expectedVersion: string
+    config: PackageAttachmentConfig
     isActive: boolean
 }
 

--- a/packages/universo-react-metahubs-backend/src/platform/migrations/1766351182000-CreateMetahubsSchema.sql.ts
+++ b/packages/universo-react-metahubs-backend/src/platform/migrations/1766351182000-CreateMetahubsSchema.sql.ts
@@ -307,6 +307,7 @@ export const createMetahubsSchemaMigrationDefinition: SqlMigrationDefinition = {
                     display_name JSONB NOT NULL DEFAULT '{}',
                     description JSONB DEFAULT '{}',
                     source JSONB NOT NULL DEFAULT '{}',
+                    authoring_surface JSONB NOT NULL DEFAULT '{}',
                     is_active BOOLEAN NOT NULL DEFAULT true,
                     _upl_created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                     _upl_created_by UUID,
@@ -347,6 +348,7 @@ export const createMetahubsSchemaMigrationDefinition: SqlMigrationDefinition = {
                     package_id UUID NOT NULL,
                     package_name TEXT NOT NULL,
                     expected_version VARCHAR(64) NOT NULL,
+                    config JSONB NOT NULL DEFAULT '{}',
                     is_active BOOLEAN NOT NULL DEFAULT true,
                     _upl_created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                     _upl_created_by UUID,
@@ -724,6 +726,57 @@ export const createMetahubsSchemaMigrationDefinition: SqlMigrationDefinition = {
         },
         { sql: `CREATE INDEX IF NOT EXISTS idx_template_versions_template ON metahubs.doc_template_versions (template_id)` },
         { sql: `CREATE INDEX IF NOT EXISTS idx_template_versions_hash ON metahubs.doc_template_versions (manifest_hash)` },
+        {
+            sql: `
+                CREATE OR REPLACE FUNCTION metahubs.enforce_authoring_package_slug_owner()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                DECLARE
+                    next_slug text := NEW.authoring_surface ->> 'packageSlug';
+                    next_kind text := NEW.authoring_surface ->> 'kind';
+                BEGIN
+                    IF NEW._upl_deleted = false
+                       AND NEW._app_deleted = false
+                       AND NEW.is_active = true
+                       AND next_kind = 'playcanvasEditor'
+                       AND next_slug IS NOT NULL
+                       AND next_slug <> ''
+                       AND EXISTS (
+                           SELECT 1
+                           FROM metahubs.obj_packages existing
+                           WHERE existing.id <> NEW.id
+                             AND existing._upl_deleted = false
+                             AND existing._app_deleted = false
+                             AND existing.is_active = true
+                             AND existing.authoring_surface ->> 'kind' = 'playcanvasEditor'
+                             AND existing.authoring_surface ->> 'packageSlug' = next_slug
+                             AND existing.package_name <> NEW.package_name
+                       ) THEN
+                        RAISE EXCEPTION 'authoring package slug % is already used by another package', next_slug
+                            USING ERRCODE = 'unique_violation';
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$
+            `
+        },
+        {
+            sql: `
+                DROP TRIGGER IF EXISTS trg_obj_packages_authoring_slug_owner
+                ON metahubs.obj_packages
+            `
+        },
+        {
+            sql: `
+                CREATE TRIGGER trg_obj_packages_authoring_slug_owner
+                BEFORE INSERT OR UPDATE OF authoring_surface, package_name, is_active, _upl_deleted, _app_deleted
+                ON metahubs.obj_packages
+                FOR EACH ROW
+                EXECUTE FUNCTION metahubs.enforce_authoring_package_slug_owner()
+            `
+        },
         { sql: `CREATE INDEX IF NOT EXISTS idx_metahubs_template ON metahubs.obj_metahubs (template_id)` },
         { sql: `CREATE INDEX IF NOT EXISTS idx_metahub_name_gin ON metahubs.obj_metahubs USING GIN (name)` },
         { sql: `CREATE INDEX IF NOT EXISTS idx_pub_metahub ON metahubs.doc_publications(metahub_id)` },
@@ -981,6 +1034,8 @@ export const createMetahubsSchemaMigrationDefinition: SqlMigrationDefinition = {
         { sql: `DROP INDEX IF EXISTS metahubs.idx_metahub_packages_name_active` },
         { sql: `DROP INDEX IF EXISTS metahubs.idx_packages_name_active` },
         { sql: `DROP INDEX IF EXISTS metahubs.idx_packages_name_version_active` },
+        { sql: `DROP TRIGGER IF EXISTS trg_obj_packages_authoring_slug_owner ON metahubs.obj_packages` },
+        { sql: `DROP FUNCTION IF EXISTS metahubs.enforce_authoring_package_slug_owner()` },
         { sql: `DROP INDEX IF EXISTS metahubs.idx_publications_versions_publication` },
         { sql: `DROP INDEX IF EXISTS metahubs.idx_publications_versions_branch` },
         { sql: `DROP INDEX IF EXISTS metahubs.idx_publications_versions_number_active` },

--- a/packages/universo-react-metahubs-backend/src/platform/migrations/1800000000260-SeedBuiltinPackages.ts
+++ b/packages/universo-react-metahubs-backend/src/platform/migrations/1800000000260-SeedBuiltinPackages.ts
@@ -1,7 +1,11 @@
 import type { Knex } from 'knex'
 import { createKnexExecutor } from '@universo-react/database'
 import type { PlatformMigrationFile } from '@universo-react/migrations-core'
-import { builtinPackageSeedChecksumSource, seedPackages } from '../../domains/packages/services/PackageSeeder'
+import {
+    isLegacyBuiltinPackageSeed,
+    legacyBuiltinPackageSeedChecksumSource,
+    seedPackages
+} from '../../domains/packages/services/PackageSeeder'
 
 export const seedBuiltinPackagesMigration: PlatformMigrationFile = {
     id: 'SeedBuiltinMetahubPackages1800000000260',
@@ -11,13 +15,14 @@ export const seedBuiltinPackagesMigration: PlatformMigrationFile = {
         key: 'metahubs'
     },
     sourceKind: 'template_seed',
-    checksumSource: builtinPackageSeedChecksumSource,
+    checksumSource: legacyBuiltinPackageSeedChecksumSource,
     transactionMode: 'single',
     lockMode: 'transaction_advisory',
     summary: 'Seed built-in metahub packages through the unified platform migration flow',
     async up(ctx) {
         await seedPackages(createKnexExecutor(ctx.knex as Knex), {
-            failFast: true
+            failFast: true,
+            packageFilter: isLegacyBuiltinPackageSeed
         })
     }
 }

--- a/packages/universo-react-metahubs-backend/src/platform/migrations/1800000000270-AddPackageAuthoringSettings.ts
+++ b/packages/universo-react-metahubs-backend/src/platform/migrations/1800000000270-AddPackageAuthoringSettings.ts
@@ -1,0 +1,96 @@
+import type { PlatformMigrationFile } from '@universo-react/migrations-core'
+import type { Knex } from 'knex'
+import { createKnexExecutor } from '@universo-react/database'
+import {
+    packageAuthoringSettingsSeedChecksumSource,
+    playCanvasEditorPackageName,
+    seedPackages
+} from '../../domains/packages/services/PackageSeeder'
+
+export const addPackageAuthoringSettingsMigration: PlatformMigrationFile = {
+    id: 'AddMetahubPackageAuthoringSettings1800000000270',
+    version: '1800000000270',
+    scope: {
+        kind: 'platform_schema',
+        key: 'metahubs'
+    },
+    sourceKind: 'file',
+    checksumSource: packageAuthoringSettingsSeedChecksumSource,
+    transactionMode: 'single',
+    lockMode: 'transaction_advisory',
+    summary: 'Add authoring surface metadata and per-metahub package attachment config',
+    async up(ctx) {
+        await ctx.knex.raw(`
+            ALTER TABLE metahubs.obj_packages
+                ADD COLUMN IF NOT EXISTS authoring_surface JSONB NOT NULL DEFAULT '{}'::jsonb
+        `)
+        await ctx.knex.raw(`
+            ALTER TABLE metahubs.rel_metahub_packages
+                ADD COLUMN IF NOT EXISTS config JSONB NOT NULL DEFAULT '{}'::jsonb
+        `)
+        await ctx.knex.raw(`
+            CREATE OR REPLACE FUNCTION metahubs.enforce_authoring_package_slug_owner()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                next_slug text := NEW.authoring_surface ->> 'packageSlug';
+                next_kind text := NEW.authoring_surface ->> 'kind';
+            BEGIN
+                IF NEW._upl_deleted = false
+                   AND NEW._app_deleted = false
+                   AND NEW.is_active = true
+                   AND next_kind = 'playcanvasEditor'
+                   AND next_slug IS NOT NULL
+                   AND next_slug <> ''
+                   AND EXISTS (
+                       SELECT 1
+                       FROM metahubs.obj_packages existing
+                       WHERE existing.id <> NEW.id
+                         AND existing._upl_deleted = false
+                         AND existing._app_deleted = false
+                         AND existing.is_active = true
+                         AND existing.authoring_surface ->> 'kind' = 'playcanvasEditor'
+                         AND existing.authoring_surface ->> 'packageSlug' = next_slug
+                         AND existing.package_name <> NEW.package_name
+                   ) THEN
+                    RAISE EXCEPTION 'authoring package slug % is already used by another package', next_slug
+                        USING ERRCODE = 'unique_violation';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$
+        `)
+        await ctx.knex.raw(`
+            DROP TRIGGER IF EXISTS trg_obj_packages_authoring_slug_owner
+            ON metahubs.obj_packages
+        `)
+        await ctx.knex.raw(`
+            CREATE TRIGGER trg_obj_packages_authoring_slug_owner
+            BEFORE INSERT OR UPDATE OF authoring_surface, package_name, is_active, _upl_deleted, _app_deleted
+            ON metahubs.obj_packages
+            FOR EACH ROW
+            EXECUTE FUNCTION metahubs.enforce_authoring_package_slug_owner()
+        `)
+        await seedPackages(createKnexExecutor(ctx.knex as Knex), {
+            failFast: true,
+            packageFilter: (seed) => seed.packageName === playCanvasEditorPackageName
+        })
+        await ctx.knex.raw(`
+            UPDATE metahubs.rel_metahub_packages AS attachment
+            SET config = COALESCE(pkg.authoring_surface -> 'defaultConfig', '{"schemaVersion":"1","kind":"none"}'::jsonb),
+                _upl_updated_at = now(),
+                _upl_version = attachment._upl_version + 1
+            FROM metahubs.obj_packages AS pkg
+            WHERE pkg.id = attachment.package_id
+              AND attachment.is_active = true
+              AND attachment._upl_deleted = false
+              AND attachment._app_deleted = false
+              AND (
+                  attachment.config IS NULL
+                  OR attachment.config = '{}'::jsonb
+              )
+        `)
+    }
+}

--- a/packages/universo-react-metahubs-backend/src/platform/migrations/index.ts
+++ b/packages/universo-react-metahubs-backend/src/platform/migrations/index.ts
@@ -5,3 +5,4 @@ export {
 } from './1766351182000-CreateMetahubsSchema.sql'
 export { seedBuiltinTemplatesMigration } from './1800000000200-SeedBuiltinTemplates'
 export { seedBuiltinPackagesMigration } from './1800000000260-SeedBuiltinPackages'
+export { addPackageAuthoringSettingsMigration } from './1800000000270-AddPackageAuthoringSettings'

--- a/packages/universo-react-metahubs-backend/src/platform/systemAppDefinition.ts
+++ b/packages/universo-react-metahubs-backend/src/platform/systemAppDefinition.ts
@@ -6,6 +6,7 @@ import {
 import { ComponentDefinitionDataType } from '@universo-react/types'
 import {
     finalizeMetahubsSchemaSupportMigrationDefinition,
+    addPackageAuthoringSettingsMigration,
     prepareMetahubsSchemaSupportMigrationDefinition,
     seedBuiltinPackagesMigration,
     seedBuiltinTemplatesMigration
@@ -302,6 +303,13 @@ const metahubBusinessTables: readonly SystemAppBusinessTableDefinition[] = [
                 isRequired: true
             },
             {
+                codename: 'authoring_surface',
+                physicalColumnName: 'authoring_surface',
+                dataType: ComponentDefinitionDataType.JSON,
+                defaultSqlExpression: `'{}'::jsonb`,
+                isRequired: true
+            },
+            {
                 codename: 'is_active',
                 physicalColumnName: 'is_active',
                 dataType: ComponentDefinitionDataType.BOOLEAN,
@@ -342,6 +350,13 @@ const metahubBusinessTables: readonly SystemAppBusinessTableDefinition[] = [
                 physicalColumnName: 'expected_version',
                 dataType: ComponentDefinitionDataType.STRING,
                 physicalDataType: 'VARCHAR(64)',
+                isRequired: true
+            },
+            {
+                codename: 'config',
+                physicalColumnName: 'config',
+                dataType: ComponentDefinitionDataType.JSON,
+                defaultSqlExpression: `'{}'::jsonb`,
                 isRequired: true
             },
             {
@@ -618,6 +633,11 @@ export const metahubsSystemAppDefinition: SystemAppDefinition = {
         {
             kind: 'file',
             migration: seedBuiltinPackagesMigration,
+            bootstrapPhase: 'post_schema_generation'
+        },
+        {
+            kind: 'file',
+            migration: addPackageAuthoringSettingsMigration,
             bootstrapPhase: 'post_schema_generation'
         }
     ],

--- a/packages/universo-react-metahubs-backend/src/tests/persistence/packagesStore.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/persistence/packagesStore.test.ts
@@ -6,7 +6,9 @@ import {
     detachMetahubPackage,
     listMetahubPackages,
     listPackageCatalog,
-    replaceMetahubPackagesFromSnapshot
+    replaceMetahubPackagesFromSnapshot,
+    upsertPackageRegistryItem,
+    updateMetahubPackageConfig
 } from '../../persistence/packagesStore'
 
 const localized = (content: string) => ({
@@ -31,12 +33,167 @@ const source = {
     upstreamVersion: '0.17.43',
     runtimeTargets: ['server'] as const
 }
+const editorPackageName = `@universo-react/${'playcanvas-editor'}`
+
+const config = {
+    schemaVersion: '1' as const,
+    kind: 'none' as const
+}
+
+const authoringSurface = {
+    schemaVersion: '1' as const,
+    kind: 'none' as const,
+    supportedDisplayModes: [] as const,
+    defaultConfig: config
+}
 
 const createExec = (rows: unknown[] = []): SqlQueryable => ({
     query: jest.fn(async () => rows)
 })
 
 describe('packagesStore', () => {
+    it('increments package registry row versions only when seed content changes', async () => {
+        const exec = createExec([
+            {
+                id: 'pkg-1',
+                packageName: '@universo-react/colyseus-server',
+                version: '0.1.0',
+                displayName: localized('Colyseus Server'),
+                description: localized('Server wrapper'),
+                source,
+                authoringSurface,
+                isActive: true
+            }
+        ])
+
+        await upsertPackageRegistryItem(exec, {
+            packageName: '@universo-react/colyseus-server',
+            version: '0.1.0',
+            displayName: localized('Colyseus Server'),
+            description: localized('Server wrapper'),
+            source,
+            authoringSurface,
+            userId: null
+        })
+
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('_upl_version = CASE')
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('p.authoring_surface IS DISTINCT FROM EXCLUDED.authoring_surface')
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('THEN p._upl_version + 1')
+    })
+
+    it('rejects malformed package authoring surface descriptors before registry writes', async () => {
+        const exec = createExec()
+
+        await expect(
+            upsertPackageRegistryItem(exec, {
+                packageName: editorPackageName,
+                version: '0.1.0',
+                displayName: localized('PlayCanvas Editor'),
+                description: localized('Editor wrapper'),
+                source,
+                authoringSurface: {
+                    schemaVersion: '1',
+                    kind: 'playcanvasEditor',
+                    packageSlug: '../playcanvas-editor',
+                    supportedDisplayModes: ['embeddedIframe'],
+                    defaultConfig: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'embeddedIframe',
+                            developmentUrl: null,
+                            showArtifactOnlyNotice: true
+                        }
+                    },
+                    artifact: {
+                        packageName: editorPackageName,
+                        manifestFileName: 'universo-artifact-manifest.json',
+                        outputRoot: 'dist/editor',
+                        smokeMode: 'artifact-only'
+                    }
+                } as never,
+                userId: null
+            })
+        ).rejects.toThrow('Invalid package authoring surface descriptor')
+
+        expect(exec.query).not.toHaveBeenCalled()
+
+        await expect(
+            upsertPackageRegistryItem(exec, {
+                packageName: editorPackageName,
+                version: '0.1.0',
+                displayName: localized('PlayCanvas Editor'),
+                description: localized('Editor wrapper'),
+                source,
+                authoringSurface: {
+                    schemaVersion: '1',
+                    kind: 'playcanvasEditor',
+                    packageSlug: 'playcanvas-editor',
+                    supportedDisplayModes: ['embeddedIframe', 'developmentUrl'],
+                    defaultConfig: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'developmentUrl',
+                            developmentUrl: 'http://localhost:5100/editor',
+                            showArtifactOnlyNotice: true
+                        }
+                    },
+                    artifact: {
+                        packageName: editorPackageName,
+                        manifestFileName: 'universo-artifact-manifest.json',
+                        outputRoot: 'dist/editor',
+                        smokeMode: 'artifact-only'
+                    }
+                } as never,
+                userId: null
+            })
+        ).rejects.toThrow('Invalid package authoring surface descriptor')
+
+        expect(exec.query).not.toHaveBeenCalled()
+    })
+
+    it('rejects active PlayCanvas Editor authoring slug collisions across package names before registry writes', async () => {
+        const exec = createExec()
+        jest.mocked(exec.query).mockResolvedValueOnce([{ packageName: `@universo-react/${'playcanvas-editor'}-fork` }])
+
+        await expect(
+            upsertPackageRegistryItem(exec, {
+                packageName: editorPackageName,
+                version: '0.1.0',
+                displayName: localized('PlayCanvas Editor'),
+                description: localized('Editor wrapper'),
+                source,
+                authoringSurface: {
+                    schemaVersion: '1',
+                    kind: 'playcanvasEditor',
+                    packageSlug: 'playcanvas-editor',
+                    supportedDisplayModes: ['embeddedIframe'],
+                    defaultConfig: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'embeddedIframe',
+                            developmentUrl: null,
+                            showArtifactOnlyNotice: true
+                        }
+                    },
+                    artifact: {
+                        packageName: editorPackageName,
+                        manifestFileName: 'universo-artifact-manifest.json',
+                        outputRoot: 'dist/editor',
+                        smokeMode: 'artifact-only'
+                    }
+                },
+                userId: null
+            })
+        ).rejects.toThrow('Package authoring surface slug "playcanvas-editor" is already used')
+
+        expect(exec.query).toHaveBeenCalledTimes(1)
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain("p.authoring_surface ->> 'packageSlug' = $1")
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).not.toContain('INSERT INTO')
+    })
+
     it('lists package catalog rows without exposing raw attachment ids as display data', async () => {
         const exec = createExec([
             {
@@ -123,6 +280,13 @@ describe('packagesStore', () => {
 
     it('uses RETURNING mutations for attach, version change, and detach contracts', async () => {
         const attachedAt = new Date('2026-05-27T12:00:00.000Z')
+        const packageRow = {
+            id: 'pkg-1',
+            packageName: '@universo-react/colyseus-server',
+            version: '0.1.0',
+            source,
+            authoringSurface
+        }
         const attachmentRow = {
             id: 'attach-1',
             metahubId: 'metahub-1',
@@ -132,10 +296,13 @@ describe('packagesStore', () => {
             displayName: localized('Colyseus Server'),
             description: null,
             source,
+            authoringSurface,
+            config,
             attachedAt,
             isActive: true
         }
-        const exec = createExec([attachmentRow])
+        const exec = createExec()
+        jest.mocked(exec.query).mockResolvedValueOnce([packageRow]).mockResolvedValueOnce([]).mockResolvedValueOnce([attachmentRow])
 
         const attached = await attachMetahubPackage(exec, {
             metahubId: 'metahub-1',
@@ -144,16 +311,40 @@ describe('packagesStore', () => {
             userId: 'user-1'
         })
 
-        expect(exec.query).toHaveBeenCalledWith(expect.stringContaining('RETURNING id, metahub_id, package_id'), [
+        expect(exec.query).toHaveBeenNthCalledWith(1, expect.stringContaining('FROM "metahubs"."obj_packages" p'), [
+            '@universo-react/colyseus-server',
+            '0.1.0'
+        ])
+        expect(exec.query).toHaveBeenNthCalledWith(2, expect.stringContaining('FROM "metahubs"."rel_metahub_packages" a'), [
             'metahub-1',
+            '@universo-react/colyseus-server'
+        ])
+        expect(exec.query).toHaveBeenNthCalledWith(3, expect.stringContaining('RETURNING id, metahub_id, package_id'), [
+            'metahub-1',
+            'pkg-1',
             '@universo-react/colyseus-server',
             '0.1.0',
+            JSON.stringify(config),
             'user-1'
         ])
+        expect(jest.mocked(exec.query).mock.calls[2]?.[0]).toContain('config = EXCLUDED.config')
+        expect(jest.mocked(exec.query).mock.calls[2]?.[0]).toContain('_upl_version = target._upl_version + 1')
         expect(attached?.attachedAt).toBe('2026-05-27T12:00:00.000Z')
 
         jest.mocked(exec.query).mockClear()
-        jest.mocked(exec.query).mockResolvedValueOnce([attachmentRow])
+        jest.mocked(exec.query)
+            .mockResolvedValueOnce([
+                {
+                    attachmentId: 'attach-1',
+                    packageName: '@universo-react/colyseus-server',
+                    config,
+                    currentPackageId: 'pkg-current',
+                    selectedPackageId: 'pkg-1',
+                    selectedVersion: '0.1.1',
+                    selectedAuthoringSurface: authoringSurface
+                }
+            ])
+            .mockResolvedValueOnce([attachmentRow])
 
         await changeMetahubPackageVersion(exec, {
             metahubId: 'metahub-1',
@@ -162,13 +353,97 @@ describe('packagesStore', () => {
             userId: 'user-1'
         })
 
-        expect(exec.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE "metahubs"."rel_metahub_packages"'), [
+        expect(exec.query).toHaveBeenNthCalledWith(1, expect.stringContaining('JOIN "metahubs"."obj_packages" p'), [
             'metahub-1',
             'attach-1',
-            '0.1.1',
-            'user-1'
+            '0.1.1'
         ])
-        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('RETURNING a.id')
+        expect(exec.query).toHaveBeenNthCalledWith(2, expect.stringContaining('UPDATE "metahubs"."rel_metahub_packages"'), [
+            'metahub-1',
+            'attach-1',
+            'pkg-1',
+            '0.1.1',
+            JSON.stringify(config),
+            'user-1',
+            'pkg-current'
+        ])
+        expect(jest.mocked(exec.query).mock.calls[1]?.[0]).toContain('RETURNING a.id')
+        expect(jest.mocked(exec.query).mock.calls[1]?.[0]).toContain('_upl_version = a._upl_version + 1')
+
+        jest.mocked(exec.query).mockClear()
+        jest.mocked(exec.query).mockResolvedValueOnce([
+            {
+                attachmentId: 'attach-1',
+                packageName: '@universo-react/colyseus-server',
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'embeddedIframe',
+                        developmentUrl: null,
+                        showArtifactOnlyNotice: true
+                    }
+                },
+                currentPackageId: 'pkg-current',
+                selectedPackageId: 'pkg-1',
+                selectedVersion: '0.1.2',
+                selectedAuthoringSurface: authoringSurface
+            }
+        ])
+
+        await expect(
+            changeMetahubPackageVersion(exec, {
+                metahubId: 'metahub-1',
+                attachmentId: 'attach-1',
+                version: '0.1.2',
+                userId: 'user-1'
+            })
+        ).rejects.toMatchObject({
+            message: 'Package display settings are not compatible with the selected package version',
+            details: { resetConfigRequired: true }
+        })
+        expect(exec.query).toHaveBeenCalledTimes(1)
+
+        jest.mocked(exec.query).mockClear()
+        jest.mocked(exec.query)
+            .mockResolvedValueOnce([
+                {
+                    attachmentId: 'attach-1',
+                    packageName: '@universo-react/colyseus-server',
+                    config: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'embeddedIframe',
+                            developmentUrl: null,
+                            showArtifactOnlyNotice: true
+                        }
+                    },
+                    currentPackageId: 'pkg-current',
+                    selectedPackageId: 'pkg-1',
+                    selectedVersion: '0.1.2',
+                    selectedAuthoringSurface: authoringSurface
+                }
+            ])
+            .mockResolvedValueOnce([attachmentRow])
+
+        await changeMetahubPackageVersion(exec, {
+            metahubId: 'metahub-1',
+            attachmentId: 'attach-1',
+            version: '0.1.2',
+            userId: 'user-1',
+            resetConfig: true
+        })
+
+        expect(exec.query).toHaveBeenNthCalledWith(2, expect.stringContaining('UPDATE "metahubs"."rel_metahub_packages"'), [
+            'metahub-1',
+            'attach-1',
+            'pkg-1',
+            '0.1.2',
+            JSON.stringify(config),
+            'user-1',
+            'pkg-current'
+        ])
 
         jest.mocked(exec.query).mockClear()
         jest.mocked(exec.query).mockResolvedValueOnce([{ id: 'attach-1' }])
@@ -180,6 +455,7 @@ describe('packagesStore', () => {
         })
 
         expect(exec.query).toHaveBeenCalledWith(expect.stringContaining('RETURNING id'), ['metahub-1', 'attach-1', 'user-1'])
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('_upl_version = _upl_version + 1')
     })
 
     it('normalizes attached package timestamps from Postgres rows', async () => {
@@ -193,6 +469,8 @@ describe('packagesStore', () => {
                 displayName: localized('Colyseus Server'),
                 description: null,
                 source,
+                authoringSurface,
+                config,
                 attachedAt: new Date('2026-05-27T12:00:00.000Z'),
                 isActive: true
             }
@@ -201,6 +479,107 @@ describe('packagesStore', () => {
         const rows = await listMetahubPackages(exec, 'metahub-1')
 
         expect(rows[0]?.attachedAt).toBe('2026-05-27T12:00:00.000Z')
+    })
+
+    it('normalizes legacy empty attachment configs to descriptor defaults', async () => {
+        const exec = createExec([
+            {
+                id: 'attach-1',
+                metahubId: 'metahub-1',
+                packageId: 'pkg-1',
+                packageName: '@universo-react/colyseus-server',
+                version: '0.1.0',
+                displayName: localized('Colyseus Server'),
+                description: null,
+                source,
+                authoringSurface,
+                config: {},
+                attachedAt: new Date('2026-05-27T12:00:00.000Z'),
+                isActive: true
+            }
+        ])
+
+        const rows = await listMetahubPackages(exec, 'metahub-1')
+
+        expect(rows[0]?.config).toEqual(config)
+    })
+
+    it('preserves compatible config when direct attach reuses an active package attachment', async () => {
+        const displayConfig = {
+            schemaVersion: '1' as const,
+            kind: 'display' as const,
+            display: {
+                mode: 'openSeparately' as const,
+                developmentUrl: null,
+                showArtifactOnlyNotice: false
+            }
+        }
+        const editorAuthoringSurface = {
+            schemaVersion: '1' as const,
+            kind: 'playcanvasEditor' as const,
+            packageSlug: 'playcanvas-editor',
+            supportedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately'] as const,
+            defaultConfig: {
+                schemaVersion: '1' as const,
+                kind: 'display' as const,
+                display: {
+                    mode: 'embeddedIframe' as const,
+                    developmentUrl: null,
+                    showArtifactOnlyNotice: true
+                }
+            },
+            artifact: {
+                packageName: editorPackageName,
+                manifestFileName: 'universo-artifact-manifest.json',
+                outputRoot: 'dist/editor',
+                smokeMode: 'artifact-only' as const
+            }
+        }
+        const exec = createExec()
+        jest.mocked(exec.query)
+            .mockResolvedValueOnce([
+                {
+                    id: 'pkg-editor-next',
+                    packageName: editorPackageName,
+                    version: '0.2.0',
+                    source,
+                    authoringSurface: editorAuthoringSurface
+                }
+            ])
+            .mockResolvedValueOnce([{ packageId: 'pkg-editor-current', config: displayConfig }])
+            .mockResolvedValueOnce([
+                {
+                    id: 'attach-editor',
+                    metahubId: 'metahub-1',
+                    packageId: 'pkg-editor-next',
+                    packageName: editorPackageName,
+                    version: '0.2.0',
+                    displayName: localized('PlayCanvas Editor'),
+                    description: null,
+                    source,
+                    authoringSurface: editorAuthoringSurface,
+                    config: displayConfig,
+                    attachedAt: new Date('2026-06-01T00:00:00.000Z'),
+                    isActive: true
+                }
+            ])
+
+        const attached = await attachMetahubPackage(exec, {
+            metahubId: 'metahub-1',
+            packageName: editorPackageName,
+            version: '0.2.0',
+            userId: 'user-1'
+        })
+
+        expect(attached?.config).toEqual(displayConfig)
+        expect(exec.query).toHaveBeenNthCalledWith(3, expect.stringContaining('INSERT INTO "metahubs"."rel_metahub_packages"'), [
+            'metahub-1',
+            'pkg-editor-next',
+            editorPackageName,
+            '0.2.0',
+            JSON.stringify(displayConfig),
+            'user-1'
+        ])
     })
 
     it('copies active package attachments with registry-backed source filtering', async () => {
@@ -218,6 +597,8 @@ describe('packagesStore', () => {
             'metahub-copy',
             'user-1'
         ])
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('source.config')
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('_upl_version = target._upl_version + 1')
         expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('source._upl_deleted = false')
         expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('p._upl_deleted = false')
         expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('RETURNING id')
@@ -225,27 +606,73 @@ describe('packagesStore', () => {
 
     it('replaces metahub packages from a snapshot and rejects duplicate package names', async () => {
         const exec = createExec()
+        const restoredConfig = {
+            schemaVersion: '1' as const,
+            kind: 'display' as const,
+            display: {
+                mode: 'disabled' as const,
+                developmentUrl: null,
+                showArtifactOnlyNotice: false
+            }
+        }
+        const restoredAuthoringSurface = {
+            schemaVersion: '1' as const,
+            kind: 'playcanvasEditor' as const,
+            packageSlug: 'playcanvas-editor',
+            supportedDisplayModes: ['disabled', 'embeddedIframe'] as const,
+            defaultConfig: {
+                schemaVersion: '1' as const,
+                kind: 'display' as const,
+                display: {
+                    mode: 'embeddedIframe' as const,
+                    developmentUrl: null,
+                    showArtifactOnlyNotice: true
+                }
+            },
+            artifact: {
+                packageName: editorPackageName,
+                manifestFileName: 'universo-artifact-manifest.json',
+                outputRoot: 'dist/editor',
+                smokeMode: 'artifact-only' as const
+            }
+        }
         jest.mocked(exec.query)
+            .mockResolvedValueOnce([
+                {
+                    id: 'pkg-1',
+                    packageName: editorPackageName,
+                    version: '0.1.0',
+                    source,
+                    authoringSurface: restoredAuthoringSurface
+                }
+            ])
             .mockResolvedValueOnce([{ id: 'old-attach' }])
             .mockResolvedValueOnce([{ id: 'new-attach' }])
 
         const restored = await replaceMetahubPackagesFromSnapshot(exec, {
             metahubId: 'metahub-1',
-            packages: [{ packageName: '@universo-react/colyseus-server', version: '0.1.0', source }],
+            packages: [{ packageName: editorPackageName, version: '0.1.0', source, config: restoredConfig }],
             userId: 'user-1'
         })
 
         expect(restored).toBe(1)
-        expect(exec.query).toHaveBeenNthCalledWith(1, expect.stringContaining('UPDATE "metahubs"."rel_metahub_packages"'), [
+        expect(exec.query).toHaveBeenNthCalledWith(1, expect.stringContaining('FROM "metahubs"."obj_packages" p'), [
+            editorPackageName,
+            '0.1.0',
+            JSON.stringify(source)
+        ])
+        expect(exec.query).toHaveBeenNthCalledWith(2, expect.stringContaining('UPDATE "metahubs"."rel_metahub_packages"'), [
             'metahub-1',
             'user-1'
         ])
-        expect(exec.query).toHaveBeenNthCalledWith(2, expect.stringContaining('WITH selected_package AS'), [
+        expect(jest.mocked(exec.query).mock.calls[1]?.[0]).toContain('_upl_version = _upl_version + 1')
+        expect(exec.query).toHaveBeenNthCalledWith(3, expect.stringContaining('INSERT INTO "metahubs"."rel_metahub_packages"'), [
             'metahub-1',
-            '@universo-react/colyseus-server',
+            'pkg-1',
+            editorPackageName,
             '0.1.0',
-            'user-1',
-            JSON.stringify(source)
+            JSON.stringify(restoredConfig),
+            'user-1'
         ])
 
         await expect(
@@ -258,5 +685,119 @@ describe('packagesStore', () => {
                 userId: 'user-1'
             })
         ).rejects.toThrow('Duplicate package in metahub snapshot')
+    })
+
+    it('prevalidates all snapshot packages before deleting existing attachments', async () => {
+        const exec = createExec([])
+
+        await expect(
+            replaceMetahubPackagesFromSnapshot(exec, {
+                metahubId: 'metahub-1',
+                packages: [{ packageName: editorPackageName, version: '9.9.9', source }],
+                userId: 'user-1'
+            })
+        ).rejects.toThrow('Package from metahub snapshot is not registered')
+
+        expect(exec.query).toHaveBeenCalledTimes(1)
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('FROM "metahubs"."obj_packages" p')
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).not.toContain('UPDATE "metahubs"."rel_metahub_packages"')
+    })
+
+    it('restores saved development URL package configs without applying the current server allowlist', async () => {
+        const exec = createExec()
+        const restoredConfig = {
+            schemaVersion: '1' as const,
+            kind: 'display' as const,
+            display: {
+                mode: 'developmentUrl' as const,
+                developmentUrl: 'http://localhost:5100/editor',
+                showArtifactOnlyNotice: true
+            }
+        }
+        const restoredAuthoringSurface = {
+            schemaVersion: '1' as const,
+            kind: 'playcanvasEditor' as const,
+            packageSlug: 'playcanvas-editor',
+            supportedDisplayModes: ['disabled', 'embeddedIframe', 'developmentUrl'] as const,
+            defaultConfig: {
+                schemaVersion: '1' as const,
+                kind: 'display' as const,
+                display: {
+                    mode: 'embeddedIframe' as const,
+                    developmentUrl: null,
+                    showArtifactOnlyNotice: true
+                }
+            },
+            artifact: {
+                packageName: editorPackageName,
+                manifestFileName: 'universo-artifact-manifest.json',
+                outputRoot: 'dist/editor',
+                smokeMode: 'artifact-only' as const
+            }
+        }
+        jest.mocked(exec.query)
+            .mockResolvedValueOnce([
+                {
+                    id: 'pkg-1',
+                    packageName: editorPackageName,
+                    version: '0.1.0',
+                    source,
+                    authoringSurface: restoredAuthoringSurface
+                }
+            ])
+            .mockResolvedValueOnce([{ id: 'old-attach' }])
+            .mockResolvedValueOnce([{ id: 'new-attach' }])
+
+        const restored = await replaceMetahubPackagesFromSnapshot(exec, {
+            metahubId: 'metahub-1',
+            packages: [{ packageName: editorPackageName, version: '0.1.0', source, config: restoredConfig }],
+            userId: 'user-1'
+        })
+
+        expect(restored).toBe(1)
+        expect(exec.query).toHaveBeenNthCalledWith(3, expect.stringContaining('INSERT INTO "metahubs"."rel_metahub_packages"'), [
+            'metahub-1',
+            'pkg-1',
+            editorPackageName,
+            '0.1.0',
+            JSON.stringify(restoredConfig),
+            'user-1'
+        ])
+    })
+
+    it('updates package attachment config with a returning row contract', async () => {
+        const exec = createExec([
+            {
+                id: 'attach-1',
+                metahubId: 'metahub-1',
+                packageId: 'pkg-1',
+                packageName: '@universo-react/colyseus-server',
+                version: '0.1.0',
+                displayName: localized('Colyseus Server'),
+                description: null,
+                source,
+                authoringSurface,
+                config,
+                attachedAt: new Date('2026-05-27T12:00:00.000Z'),
+                isActive: true
+            }
+        ])
+
+        const updated = await updateMetahubPackageConfig(exec, {
+            metahubId: 'metahub-1',
+            attachmentId: 'attach-1',
+            config,
+            userId: 'user-1'
+        })
+
+        expect(updated?.config).toEqual(config)
+        expect(exec.query).toHaveBeenCalledWith(expect.stringContaining('SET config = $3::jsonb'), [
+            'metahub-1',
+            'attach-1',
+            JSON.stringify(config),
+            'user-1',
+            null
+        ])
+        expect(jest.mocked(exec.query).mock.calls[0]?.[0]).toContain('_upl_version = a._upl_version + 1')
     })
 })

--- a/packages/universo-react-metahubs-backend/src/tests/platform/builtinTemplateSeedMigration.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/platform/builtinTemplateSeedMigration.test.ts
@@ -1,5 +1,6 @@
 jest.mock('@universo-react/database', () => ({
-    createKnexExecutor: jest.fn(() => ({ tag: 'executor' }))
+    createKnexExecutor: jest.fn(() => ({ tag: 'executor' })),
+    qSchemaTable: jest.fn((schema: string, table: string) => `"${schema}"."${table}"`)
 }))
 
 jest.mock('../../domains/templates/services/TemplateSeeder', () => ({

--- a/packages/universo-react-metahubs-backend/src/tests/platform/metahubsSchemaParityContract.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/platform/metahubsSchemaParityContract.test.ts
@@ -33,7 +33,9 @@ describe('metahubs fixed-schema parity contract', () => {
         ).toEqual([
             'PrepareMetahubsSchemaSupport1766351182000',
             'FinalizeMetahubsSchemaSupport1766351182001',
-            'SeedBuiltinMetahubTemplates1800000000250'
+            'SeedBuiltinMetahubTemplates1800000000250',
+            'SeedBuiltinMetahubPackages1800000000260',
+            'AddMetahubPackageAuthoringSettings1800000000270'
         ])
         expect(metahubsSystemAppDefinition.currentBusinessTables).toEqual(metahubsSystemAppDefinition.targetBusinessTables)
     })
@@ -169,6 +171,10 @@ describe('metahubs fixed-schema parity contract', () => {
             'CREATE UNIQUE INDEX IF NOT EXISTS idx_template_versions_number',
             'CREATE UNIQUE INDEX IF NOT EXISTS idx_publications_schema_name_active',
             'CREATE UNIQUE INDEX IF NOT EXISTS idx_publications_versions_number_active',
+            'CREATE OR REPLACE FUNCTION metahubs.enforce_authoring_package_slug_owner()',
+            'CREATE TRIGGER trg_obj_packages_authoring_slug_owner',
+            "AND existing.authoring_surface ->> 'kind' = 'playcanvasEditor'",
+            'AND existing.package_name <> NEW.package_name',
             'CREATE INDEX IF NOT EXISTS idx_pub_schema_name ON metahubs.doc_publications(schema_name)'
         ]
         const requiredRlsEnables = [
@@ -191,6 +197,10 @@ describe('metahubs fixed-schema parity contract', () => {
         ]) {
             expect(upSql).toContain(normalizeSql(fragment))
         }
+
+        const downSql = normalizeSql(createMetahubsSchemaMigrationDefinition.down.map((statement) => statement.sql).join('\n'))
+        expect(downSql).toContain(normalizeSql('DROP TRIGGER IF EXISTS trg_obj_packages_authoring_slug_owner ON metahubs.obj_packages'))
+        expect(downSql).toContain(normalizeSql('DROP FUNCTION IF EXISTS metahubs.enforce_authoring_package_slug_owner()'))
 
         expect(upSql).not.toMatch(/CREATE UNIQUE INDEX(?! IF NOT EXISTS)/)
         expect(upSql).not.toMatch(/CREATE INDEX(?! IF NOT EXISTS)/)

--- a/packages/universo-react-metahubs-backend/src/tests/platform/packageAuthoringSettingsMigration.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/platform/packageAuthoringSettingsMigration.test.ts
@@ -1,0 +1,52 @@
+jest.mock('@universo-react/database', () => ({
+    createKnexExecutor: jest.fn(() => ({ tag: 'executor' })),
+    qSchemaTable: jest.fn((schema: string, table: string) => `"${schema}"."${table}"`)
+}))
+
+jest.mock('../../domains/packages/services/PackageSeeder', () => ({
+    playCanvasEditorPackageName: `@universo-react/${'playcanvas-editor'}`,
+    packageAuthoringSettingsSeedChecksumSource: `builtin-metahub-package-authoring-settings-seed-migration-v1:@universo-react/${'playcanvas-editor'}:playcanvasEditor`,
+    seedPackages: jest.fn(async () => undefined)
+}))
+
+import { createKnexExecutor } from '@universo-react/database'
+import { seedPackages } from '../../domains/packages/services/PackageSeeder'
+import { addPackageAuthoringSettingsMigration } from '../../platform/migrations'
+
+describe('addPackageAuthoringSettingsMigration', () => {
+    it('adds package authoring columns, reseeds packages, and backfills legacy empty attachment configs', async () => {
+        const knex = {
+            raw: jest.fn(async () => undefined)
+        }
+
+        await addPackageAuthoringSettingsMigration.up({
+            knex: knex as never,
+            logger: console,
+            runId: 'run-1',
+            scope: addPackageAuthoringSettingsMigration.scope,
+            raw: jest.fn()
+        })
+
+        expect(createKnexExecutor).toHaveBeenCalledWith(knex)
+        expect(seedPackages).toHaveBeenCalledWith(
+            { tag: 'executor' },
+            expect.objectContaining({
+                failFast: true,
+                packageFilter: expect.any(Function)
+            })
+        )
+        const packageFilter = jest.mocked(seedPackages).mock.calls[0]?.[1]?.packageFilter
+        expect(packageFilter?.({ packageName: `@universo-react/${'playcanvas-editor'}` } as never)).toBe(true)
+        expect(packageFilter?.({ packageName: `@universo-react/${'playcanvas-engine'}` } as never)).toBe(false)
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('ADD COLUMN IF NOT EXISTS authoring_surface'))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('ADD COLUMN IF NOT EXISTS config JSONB'))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('enforce_authoring_package_slug_owner'))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('trg_obj_packages_authoring_slug_owner'))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining("authoring_surface ->> 'packageSlug'"))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining("authoring_surface ->> 'kind' = 'playcanvasEditor'"))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('existing.package_name <> NEW.package_name'))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining("attachment.config = '{}'::jsonb"))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining("pkg.authoring_surface -> 'defaultConfig'"))
+        expect(knex.raw).toHaveBeenCalledWith(expect.stringContaining('_upl_version = attachment._upl_version + 1'))
+    })
+})

--- a/packages/universo-react-metahubs-backend/src/tests/routes/metahubsRoutes.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/routes/metahubsRoutes.test.ts
@@ -1803,7 +1803,7 @@ describe('Metahubs Routes', () => {
                     })
                 })
             )
-            expect(mockSerializeMetahub).toHaveBeenCalledWith('new-metahub-id', expect.any(Object))
+            expect(mockSerializeMetahub).toHaveBeenCalledWith('new-metahub-id', expect.not.objectContaining({ packageMode: 'metahub' }))
             expect(mockAttachLayoutsToSnapshot).toHaveBeenCalledWith(
                 expect.objectContaining({ metahubId: 'new-metahub-id', userId: 'test-user-id' })
             )

--- a/packages/universo-react-metahubs-backend/src/tests/routes/packagesRoutes.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/routes/packagesRoutes.test.ts
@@ -471,6 +471,27 @@ describe('Packages Routes', () => {
         expect(mockUpdateMetahubPackageConfig).not.toHaveBeenCalled()
     })
 
+    it('rejects malformed development URLs with a validation error before saving config', async () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'http://localhost:5100'
+
+        await request(buildApp())
+            .patch('/metahub/metahub-1/package/attach-playcanvas/config')
+            .send({
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'not a url',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            })
+            .expect(400)
+
+        expect(mockUpdateMetahubPackageConfig).not.toHaveBeenCalled()
+    })
+
     it('rejects non-http development URLs even when their origin is allowlisted', async () => {
         process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'ftp://localhost:5100'
 

--- a/packages/universo-react-metahubs-backend/src/tests/routes/packagesRoutes.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/routes/packagesRoutes.test.ts
@@ -1,0 +1,579 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { RateLimitRequestHandler } from 'express-rate-limit'
+import type { MetahubPackageAttachment } from '@universo-react/types'
+
+const express = require('express') as typeof import('express')
+const request = require('supertest') as typeof import('supertest')
+
+const mockResolveUserId = jest.fn<() => string | undefined>()
+const mockEnsureMetahubAccess = jest.fn()
+const mockListMetahubPackages = jest.fn()
+const mockListPackageCatalog = jest.fn()
+const mockUpdateMetahubPackageConfig = jest.fn()
+const mockChangeMetahubPackageVersion = jest.fn()
+const mockAccess = jest.fn()
+const mockRealpath = jest.fn()
+
+const mockDbSession = { isReleased: () => false }
+const editorPackageName = `@universo-react/${'playcanvas-editor'}`
+
+jest.mock('node:fs/promises', () => ({
+    __esModule: true,
+    default: {
+        access: (...args: unknown[]) => mockAccess(...args),
+        realpath: (...args: unknown[]) => mockRealpath(...args)
+    },
+    access: (...args: unknown[]) => mockAccess(...args),
+    realpath: (...args: unknown[]) => mockRealpath(...args)
+}))
+
+jest.mock('../../utils', () => ({
+    __esModule: true,
+    getRequestDbExecutor: (_req: unknown, fallback: unknown) => fallback
+}))
+
+jest.mock('@universo-react/utils/database', () => ({
+    __esModule: true,
+    getRequestDbSession: () => mockDbSession
+}))
+
+jest.mock('../../domains/shared/routeAuth', () => ({
+    __esModule: true,
+    resolveUserId: (...args: unknown[]) => mockResolveUserId(...args)
+}))
+
+jest.mock('../../domains/shared/guards', () => ({
+    __esModule: true,
+    ensureMetahubAccess: (...args: unknown[]) => mockEnsureMetahubAccess(...args)
+}))
+
+jest.mock('../../domains/metahubs/services/MetahubSchemaService', () => ({
+    __esModule: true,
+    MetahubSchemaService: jest.fn().mockImplementation(() => ({}))
+}))
+
+jest.mock('../../persistence', () => ({
+    __esModule: true,
+    attachMetahubPackage: jest.fn(),
+    changeMetahubPackageVersion: (...args: unknown[]) => mockChangeMetahubPackageVersion(...args),
+    detachMetahubPackage: jest.fn(),
+    listMetahubPackages: (...args: unknown[]) => mockListMetahubPackages(...args),
+    listPackageCatalog: (...args: unknown[]) => mockListPackageCatalog(...args),
+    updateMetahubPackageConfig: (...args: unknown[]) => mockUpdateMetahubPackageConfig(...args)
+}))
+
+import { createPackagesRoutes } from '../../domains/packages/routes/packagesRoutes'
+
+const displayConfig = {
+    schemaVersion: '1' as const,
+    kind: 'display' as const,
+    display: {
+        mode: 'embeddedIframe' as const,
+        developmentUrl: null,
+        showArtifactOnlyNotice: true
+    }
+}
+
+const playCanvasAttachment: MetahubPackageAttachment = {
+    id: 'attach-playcanvas',
+    metahubId: 'metahub-1',
+    packageId: 'pkg-playcanvas',
+    packageName: editorPackageName,
+    version: '0.1.0',
+    displayName: {
+        _schema: '1',
+        _primary: 'en',
+        locales: { en: { content: 'PlayCanvas Editor', version: 1, isActive: true } }
+    },
+    description: null,
+    source: {
+        kind: 'workspace',
+        packageName: editorPackageName,
+        importName: editorPackageName,
+        upstreamPackageName: 'playcanvas-editor',
+        upstreamVersion: '2026.05.30',
+        runtimeTargets: []
+    },
+    authoringSurface: {
+        schemaVersion: '1',
+        kind: 'playcanvasEditor',
+        packageSlug: 'playcanvas-editor',
+        supportedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'],
+        defaultConfig: displayConfig,
+        artifact: {
+            packageName: editorPackageName,
+            manifestFileName: 'universo-artifact-manifest.json',
+            outputRoot: 'dist/editor',
+            smokeMode: 'artifact-only'
+        }
+    },
+    config: displayConfig,
+    attachedAt: '2026-06-01T00:00:00.000Z',
+    isActive: true
+}
+
+const noneAttachment: MetahubPackageAttachment = {
+    ...playCanvasAttachment,
+    id: 'attach-engine',
+    packageId: 'pkg-engine',
+    packageName: '@universo-react/playcanvas-engine',
+    authoringSurface: {
+        schemaVersion: '1',
+        kind: 'none',
+        supportedDisplayModes: [],
+        defaultConfig: { schemaVersion: '1', kind: 'none' }
+    },
+    config: { schemaVersion: '1', kind: 'none' }
+}
+
+describe('Packages Routes', () => {
+    const ensureAuth = (_req: Request, _res: Response, next: NextFunction) => next()
+    const mockRateLimiter: RateLimitRequestHandler = ((_req: Request, _res: Response, next: NextFunction) =>
+        next()) as RateLimitRequestHandler
+    const mockExec = { query: jest.fn(), isReleased: jest.fn(() => false) }
+
+    const buildApp = (auth: RequestHandler = ensureAuth) => {
+        const app = express()
+        app.response.sendFile = function sendFileStub(filePath: string) {
+            this.setHeader('X-Test-SendFile', filePath)
+            return this.send('artifact')
+        } as never
+        app.use(express.json())
+        app.use(createPackagesRoutes(auth, () => mockExec as never, mockRateLimiter, mockRateLimiter))
+        return app
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockResolveUserId.mockReturnValue('user-1')
+        mockEnsureMetahubAccess.mockResolvedValue(undefined)
+        mockAccess.mockResolvedValue(undefined)
+        mockRealpath.mockImplementation(async (filePath: string) => filePath)
+        mockListMetahubPackages.mockResolvedValue([playCanvasAttachment, noneAttachment])
+        mockListPackageCatalog.mockResolvedValue([])
+        mockUpdateMetahubPackageConfig.mockImplementation(async (_exec, input) => ({
+            ...playCanvasAttachment,
+            id: input.attachmentId,
+            config: input.config
+        }))
+        mockChangeMetahubPackageVersion.mockImplementation(async (_exec, input) => ({
+            ...playCanvasAttachment,
+            id: input.attachmentId,
+            version: input.version
+        }))
+        delete process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS
+    })
+
+    it('requires manageMetahub permission before returning the authoring host descriptor', async () => {
+        const response = await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(200)
+
+        expect(response.body.artifactStatus).toBe('available')
+        expect(response.body.allowedDisplayModes).toEqual(['disabled', 'embeddedIframe', 'openSeparately'])
+        expect(response.body.artifactUrl).toMatch(
+            /^\/api\/v1\/metahub\/metahub-1\/packages\/playcanvas-editor\/editor-artifact-token\/[^/]+\/index\.html$/
+        )
+        expect(mockEnsureMetahubAccess).toHaveBeenCalledWith(mockExec, 'user-1', 'metahub-1', 'manageMetahub', mockDbSession)
+        expect(mockAccess).toHaveBeenCalledTimes(2)
+    })
+
+    it('redacts saved development URLs from the read-level attached packages list', async () => {
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            }
+        ])
+
+        const response = await request(buildApp()).get('/metahub/metahub-1/packages').expect(200)
+
+        expect(response.body.items[0].config).toEqual({
+            schemaVersion: '1',
+            kind: 'display',
+            display: {
+                mode: 'developmentUrl',
+                developmentUrl: null,
+                showArtifactOnlyNotice: true
+            }
+        })
+        expect(JSON.stringify(response.body)).not.toContain('http://localhost:5100/editor')
+        expect(JSON.stringify(response.body)).not.toContain('dist/editor')
+        expect(JSON.stringify(response.body)).not.toContain('universo-artifact-manifest.json')
+    })
+
+    it('redacts artifact internals from the read-level catalog list', async () => {
+        mockListPackageCatalog.mockResolvedValueOnce([
+            {
+                id: playCanvasAttachment.packageId,
+                packageName: playCanvasAttachment.packageName,
+                version: playCanvasAttachment.version,
+                displayName: playCanvasAttachment.displayName,
+                description: playCanvasAttachment.description,
+                source: playCanvasAttachment.source,
+                authoringSurface: playCanvasAttachment.authoringSurface,
+                isActive: true,
+                attached: true,
+                attachmentId: playCanvasAttachment.id,
+                attachedPackageId: playCanvasAttachment.packageId,
+                attachedVersion: playCanvasAttachment.version
+            }
+        ])
+
+        const response = await request(buildApp()).get('/metahub/metahub-1/packages/catalog').expect(200)
+
+        expect(response.body.items[0].authoringSurface.kind).toBe('playcanvasEditor')
+        expect(response.body.items[0].authoringSurface.artifact).toBeUndefined()
+        expect(JSON.stringify(response.body)).not.toContain('dist/editor')
+        expect(JSON.stringify(response.body)).not.toContain('universo-artifact-manifest.json')
+    })
+
+    it('blocks stale saved development URLs that are no longer allowlisted when returning the authoring host descriptor', async () => {
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            },
+            noneAttachment
+        ])
+
+        const response = await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(200)
+
+        expect(response.body.artifactStatus).toBe('blocked')
+        expect(response.body.artifactUrl).toBeNull()
+        expect(response.body.attachmentConfig).toEqual(displayConfig)
+        expect(JSON.stringify(response.body)).not.toContain('http://localhost:5100/editor')
+    })
+
+    it('rejects duplicate authoring package slugs instead of selecting an arbitrary package', async () => {
+        mockListMetahubPackages.mockResolvedValueOnce([
+            playCanvasAttachment,
+            {
+                ...playCanvasAttachment,
+                id: 'attach-playcanvas-fork',
+                packageId: 'pkg-playcanvas-fork',
+                packageName: `@universo-react/${'playcanvas-editor'}-fork`
+            }
+        ])
+
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(400)
+    })
+
+    it('serves editor artifacts with defensive headers and a root-contained file path', async () => {
+        const response = await request(buildApp())
+            .get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/assets/editor.js')
+            .expect(200)
+
+        expect(response.text).toBe('artifact')
+        expect(response.headers['x-content-type-options']).toBe('nosniff')
+        expect(response.headers['cache-control']).toBe('private, max-age=300')
+        expect(response.headers['content-security-policy']).toContain('sandbox allow-scripts')
+        expect(response.headers['content-security-policy']).toContain("'unsafe-inline'")
+        expect(response.headers['content-security-policy']).toContain("frame-ancestors 'self'")
+        expect(response.headers['content-type']).toContain('application/javascript')
+        expect(response.headers['x-test-sendfile']).toContain('/assets/editor.js')
+        expect(mockEnsureMetahubAccess).toHaveBeenCalledWith(mockExec, 'user-1', 'metahub-1', 'manageMetahub', mockDbSession)
+    })
+
+    it('serves tokenized editor artifact assets without session cookies for sandboxed subresources', async () => {
+        const hostResponse = await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(200)
+        const assetUrl = String(hostResponse.body.artifactUrl)
+            .replace(/^\/api\/v1/, '')
+            .replace('/index.html', '/assets/editor.js')
+        const rejectingAuth: RequestHandler = (_req, res) => res.status(401).json({ error: 'Unauthorized' })
+
+        const response = await request(buildApp(rejectingAuth)).get(assetUrl).expect(200)
+
+        expect(response.text).toBe('artifact')
+        expect(response.headers['cache-control']).toBe('private, max-age=300')
+        expect(response.headers['x-test-sendfile']).toContain('/assets/editor.js')
+        expect(mockEnsureMetahubAccess).toHaveBeenLastCalledWith(mockExec, 'user-1', 'metahub-1', 'manageMetahub')
+        expect(mockListMetahubPackages).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects tokenized editor artifact URLs when the issuing user no longer manages the metahub', async () => {
+        const hostResponse = await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(200)
+        const assetUrl = String(hostResponse.body.artifactUrl)
+            .replace(/^\/api\/v1/, '')
+            .replace('/index.html', '/assets/editor.js')
+        const rejectingAuth: RequestHandler = (_req, res) => res.status(401).json({ error: 'Unauthorized' })
+
+        mockEnsureMetahubAccess.mockRejectedValueOnce(new Error('revoked'))
+
+        await request(buildApp(rejectingAuth)).get(assetUrl).expect(404)
+        expect(mockListMetahubPackages).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects tokenized editor artifact URLs when the package display mode changes after token issue', async () => {
+        const hostResponse = await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(200)
+        const assetUrl = String(hostResponse.body.artifactUrl)
+            .replace(/^\/api\/v1/, '')
+            .replace('/index.html', '/assets/editor.js')
+        const rejectingAuth: RequestHandler = (_req, res) => res.status(401).json({ error: 'Unauthorized' })
+
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'disabled',
+                        developmentUrl: null,
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            }
+        ])
+
+        await request(buildApp(rejectingAuth)).get(assetUrl).expect(404)
+        expect(mockListMetahubPackages).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects invalid tokenized editor artifact URLs before the authenticated package routes', async () => {
+        const rejectingAuth: RequestHandler = (_req, res) => res.status(401).json({ error: 'Unauthorized' })
+
+        await request(buildApp(rejectingAuth))
+            .get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact-token/not-a-token/assets/editor.js')
+            .expect(404)
+
+        expect(mockEnsureMetahubAccess).not.toHaveBeenCalled()
+    })
+
+    it('passes explicit config reset intent when changing package versions', async () => {
+        await request(buildApp())
+            .patch('/metahub/metahub-1/package/attach-playcanvas')
+            .send({ version: '0.2.0', resetConfig: true })
+            .expect(200)
+
+        expect(mockChangeMetahubPackageVersion).toHaveBeenCalledWith(mockExec, {
+            metahubId: 'metahub-1',
+            attachmentId: 'attach-playcanvas',
+            version: '0.2.0',
+            resetConfig: true,
+            userId: 'user-1'
+        })
+    })
+
+    it('does not serve editor artifacts when the package display mode is disabled', async () => {
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'disabled',
+                        developmentUrl: null,
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            }
+        ])
+
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/index.html').expect(404)
+        expect(mockAccess).not.toHaveBeenCalled()
+    })
+
+    it('does not serve editor artifacts when the package uses a development URL', async () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'http://localhost:5100'
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            }
+        ])
+
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/index.html').expect(404)
+        expect(mockAccess).not.toHaveBeenCalled()
+    })
+
+    it('does not serve editor artifacts when saved development URL settings are stale', async () => {
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            }
+        ])
+
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/index.html').expect(400)
+        expect(mockAccess).not.toHaveBeenCalled()
+    })
+
+    it('rejects traversal and symlink escapes for editor artifact files', async () => {
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/%2e%2e/secret.txt').expect(400)
+
+        mockRealpath.mockImplementation(async (filePath: string) =>
+            filePath.endsWith('/leak.js') ? '/tmp/playcanvas-editor-leak.js' : filePath
+        )
+
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/leak.js').expect(404)
+    })
+
+    it('requires the manifest and requested artifact file before serving an editor artifact', async () => {
+        mockAccess.mockRejectedValueOnce(new Error('missing manifest')).mockResolvedValue(undefined)
+
+        await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/editor-artifact/index.html').expect(404)
+    })
+
+    it('rejects display settings for packages without an authoring surface', async () => {
+        await request(buildApp()).patch('/metahub/metahub-1/package/attach-engine/config').send({ config: displayConfig }).expect(400)
+
+        expect(mockUpdateMetahubPackageConfig).not.toHaveBeenCalled()
+    })
+
+    it('rejects unallowlisted development URLs before saving config', async () => {
+        await request(buildApp())
+            .patch('/metahub/metahub-1/package/attach-playcanvas/config')
+            .send({
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            })
+            .expect(400)
+
+        expect(mockUpdateMetahubPackageConfig).not.toHaveBeenCalled()
+    })
+
+    it('rejects non-http development URLs even when their origin is allowlisted', async () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'ftp://localhost:5100'
+
+        await request(buildApp())
+            .patch('/metahub/metahub-1/package/attach-playcanvas/config')
+            .send({
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'ftp://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            })
+            .expect(400)
+
+        expect(mockUpdateMetahubPackageConfig).not.toHaveBeenCalled()
+    })
+
+    it('rejects development URLs with embedded credentials', async () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'http://localhost:5100'
+
+        await request(buildApp())
+            .patch('/metahub/metahub-1/package/attach-playcanvas/config')
+            .send({
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://user:pass@localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            })
+            .expect(400)
+
+        expect(mockUpdateMetahubPackageConfig).not.toHaveBeenCalled()
+    })
+
+    it('returns allowlisted development URL settings through the manager-only authoring host', async () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'http://localhost:5100/, https://editor.example.test/path'
+        mockListMetahubPackages.mockResolvedValueOnce([
+            {
+                ...playCanvasAttachment,
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            }
+        ])
+
+        const response = await request(buildApp()).get('/metahub/metahub-1/packages/playcanvas-editor/authoring-host').expect(200)
+
+        expect(response.body.allowedDisplayModes).toEqual(['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'])
+        expect(response.body.artifactStatus).toBe('available')
+        expect(response.body.artifactUrl).toBeNull()
+        expect(response.body.attachmentConfig.display).toEqual({
+            mode: 'developmentUrl',
+            developmentUrl: 'http://localhost:5100/editor',
+            showArtifactOnlyNotice: true
+        })
+    })
+
+    it('normalizes and saves allowlisted development URL settings', async () => {
+        process.env.PLAYCANVAS_EDITOR_DEVELOPMENT_URLS = 'http://localhost:5100/, https://editor.example.test/path'
+
+        await request(buildApp())
+            .patch('/metahub/metahub-1/package/attach-playcanvas/config')
+            .send({
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: false
+                    }
+                }
+            })
+            .expect(200)
+
+        expect(mockUpdateMetahubPackageConfig).toHaveBeenCalledWith(mockExec, {
+            metahubId: 'metahub-1',
+            attachmentId: 'attach-playcanvas',
+            config: {
+                schemaVersion: '1',
+                kind: 'display',
+                display: {
+                    mode: 'developmentUrl',
+                    developmentUrl: 'http://localhost:5100/editor',
+                    showArtifactOnlyNotice: false
+                }
+            },
+            userId: 'user-1',
+            expectedPackageId: 'pkg-playcanvas'
+        })
+    })
+})

--- a/packages/universo-react-metahubs-backend/src/tests/services/MetahubModulesService.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/services/MetahubModulesService.test.ts
@@ -6,6 +6,8 @@ const mockInsertStoredMetahubModule = jest.fn()
 const mockListStoredMetahubModules = jest.fn()
 const mockIncrementVersion = jest.fn()
 const mockListEditableTypes = jest.fn()
+const mockListMetahubPackages = jest.fn()
+const editorPackageName = `@universo-react/${'playcanvas-editor'}`
 
 jest.mock('@universo-react/modules-engine', () => ({
     compileModuleSource: (...args: unknown[]) => mockCompileModuleSource(...args),
@@ -36,6 +38,11 @@ jest.mock('../../domains/entities/services/EntityTypeService', () => ({
     EntityTypeService: jest.fn().mockImplementation(() => ({
         listEditableTypes: (...args: unknown[]) => mockListEditableTypes(...args)
     }))
+}))
+
+jest.mock('../../persistence', () => ({
+    __esModule: true,
+    listMetahubPackages: (...args: unknown[]) => mockListMetahubPackages(...args)
 }))
 
 import { MetahubModulesService } from '../../domains/modules/services/MetahubModulesService'
@@ -99,11 +106,13 @@ describe('MetahubModulesService', () => {
 
     beforeEach(() => {
         jest.clearAllMocks()
+        ;(executor.query as jest.Mock).mockResolvedValue([])
         mockEnsureSchema.mockResolvedValue(schemaName)
         mockFindStoredMetahubModuleByScope.mockResolvedValue(null)
         mockFindStoredMetahubModuleById.mockResolvedValue(createStoredModuleRow())
         mockListStoredMetahubModules.mockResolvedValue([])
         mockListEditableTypes.mockResolvedValue([])
+        mockListMetahubPackages.mockResolvedValue([])
         mockCompileModuleSource.mockResolvedValue({
             manifest: {
                 className: 'QuizWidgetModule',
@@ -234,7 +243,7 @@ describe('MetahubModulesService', () => {
                 }
             }
         ])
-        ;(executor.query as jest.Mock).mockResolvedValueOnce([{ id: 'object-1' }])
+        ;(executor.query as jest.Mock).mockResolvedValueOnce([{ id: 'object-1' }]).mockResolvedValueOnce([])
         mockInsertStoredMetahubModule.mockResolvedValueOnce(
             createStoredModuleRow({
                 attached_to_kind: 'object',
@@ -821,5 +830,50 @@ describe('MetahubModulesService', () => {
         })
 
         expect(mockCompileModuleSource).not.toHaveBeenCalled()
+    })
+
+    it('excludes authoring-only packages from module package import allowlists', async () => {
+        mockListMetahubPackages.mockResolvedValue([
+            {
+                packageName: '@universo-react/playcanvas-engine',
+                version: '0.1.0',
+                source: {
+                    runtimeTargets: ['client']
+                }
+            },
+            {
+                packageName: editorPackageName,
+                version: '0.1.0',
+                source: {
+                    runtimeTargets: []
+                }
+            }
+        ])
+        mockListStoredMetahubModules.mockResolvedValue([
+            createStoredModuleRow({
+                id: 'module-with-package-import',
+                codename: {
+                    _schema: '1',
+                    _primary: 'en',
+                    locales: {
+                        en: { content: 'module-with-package-import' }
+                    }
+                }
+            })
+        ])
+
+        await service.listPublishedModules('metahub-1')
+
+        expect(mockCompileModuleSource).toHaveBeenCalledWith(
+            expect.objectContaining({
+                allowedPackageImports: [
+                    {
+                        packageName: '@universo-react/playcanvas-engine',
+                        version: '0.1.0',
+                        targets: ['client']
+                    }
+                ]
+            })
+        )
     })
 })

--- a/packages/universo-react-metahubs-backend/src/tests/services/MetahubPackagesService.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/services/MetahubPackagesService.test.ts
@@ -1,0 +1,107 @@
+const mockListMetahubPackages = jest.fn()
+
+jest.mock('../../persistence', () => ({
+    __esModule: true,
+    listMetahubPackages: (...args: unknown[]) => mockListMetahubPackages(...args)
+}))
+
+import { MetahubPackagesService } from '../../domains/packages/services/MetahubPackagesService'
+
+const editorPackageName = `@universo-react/${'playcanvas-editor'}`
+
+const packageSource = (runtimeTargets: string[]) => ({
+    kind: 'workspace' as const,
+    packageName: '@universo-react/example',
+    importName: '@universo-react/example',
+    upstreamPackageName: 'example',
+    upstreamVersion: '1.0.0',
+    runtimeTargets
+})
+
+const createPackage = (overrides: Record<string, unknown> = {}) => ({
+    id: 'attach-1',
+    metahubId: 'metahub-1',
+    packageId: 'pkg-1',
+    packageName: '@universo-react/example',
+    version: '0.1.0',
+    displayName: null,
+    description: null,
+    source: packageSource(['client']),
+    authoringSurface: {
+        schemaVersion: '1',
+        kind: 'none',
+        supportedDisplayModes: [],
+        defaultConfig: { schemaVersion: '1', kind: 'none' }
+    },
+    config: { schemaVersion: '1', kind: 'none' },
+    attachedAt: '2026-06-01T00:00:00.000Z',
+    isActive: true,
+    ...overrides
+})
+
+describe('MetahubPackagesService', () => {
+    const exec = { query: jest.fn() }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('excludes authoring-only packages from runtime publication packages', async () => {
+        mockListMetahubPackages.mockResolvedValue([
+            createPackage({ packageName: '@universo-react/playcanvas-engine', source: packageSource(['client']) }),
+            createPackage({
+                packageName: editorPackageName,
+                source: packageSource([]),
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'embeddedIframe',
+                        developmentUrl: null,
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            })
+        ])
+
+        const packages = await new MetahubPackagesService(exec).listPublishedPackages('metahub-1')
+
+        expect(packages).toEqual([
+            {
+                packageName: '@universo-react/playcanvas-engine',
+                version: '0.1.0',
+                source: packageSource(['client'])
+            }
+        ])
+    })
+
+    it('preserves package config in design-time metahub snapshots', async () => {
+        const editorConfig = {
+            schemaVersion: '1',
+            kind: 'display',
+            display: {
+                mode: 'openSeparately',
+                developmentUrl: null,
+                showArtifactOnlyNotice: false
+            }
+        }
+        mockListMetahubPackages.mockResolvedValue([
+            createPackage({
+                packageName: editorPackageName,
+                source: packageSource([]),
+                config: editorConfig
+            })
+        ])
+
+        const packages = await new MetahubPackagesService(exec).listMetahubSnapshotPackages('metahub-1')
+
+        expect(packages).toEqual([
+            {
+                packageName: editorPackageName,
+                version: '0.1.0',
+                source: packageSource([]),
+                config: editorConfig
+            }
+        ])
+    })
+})

--- a/packages/universo-react-metahubs-backend/src/tests/services/PackageSeeder.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/services/PackageSeeder.test.ts
@@ -1,6 +1,11 @@
 import type { DbExecutor } from '@universo-react/utils'
 import { builtinPackageSeeds } from '../../domains/packages/data'
-import { PackageSeeder, builtinPackageSeedChecksumSource } from '../../domains/packages/services/PackageSeeder'
+import {
+    PackageSeeder,
+    isLegacyBuiltinPackageSeed,
+    legacyBuiltinPackageSeedChecksumSource,
+    packageAuthoringSettingsSeedChecksumSource
+} from '../../domains/packages/services/PackageSeeder'
 
 describe('PackageSeeder', () => {
     const exec: DbExecutor = {
@@ -12,26 +17,44 @@ describe('PackageSeeder', () => {
         jest.mocked(exec.query).mockResolvedValue([{ id: 'pkg-1' }])
     })
 
-    it('idempotently upserts the three built-in package registry entries', async () => {
+    it('idempotently upserts the built-in package registry entries', async () => {
         const logger = { info: jest.fn(), error: jest.fn() }
 
         await new PackageSeeder(exec, { logger, failFast: true }).seed()
 
-        expect(exec.query).toHaveBeenCalledTimes(3)
+        expect(exec.query).toHaveBeenCalledTimes(5)
         expect(builtinPackageSeeds.map((seed) => seed.packageName)).toEqual([
             '@universo-react/colyseus-client',
             '@universo-react/colyseus-server',
-            '@universo-react/playcanvas-engine'
+            '@universo-react/playcanvas-engine',
+            '@universo-react/playcanvas-editor'
         ])
         expect(exec.query).toHaveBeenCalledWith(expect.stringContaining('ON CONFLICT (package_name, version)'), expect.any(Array))
         expect(logger.error).not.toHaveBeenCalled()
-        expect(logger.info).toHaveBeenCalledWith('[PackageSeeder] Seed complete: 3 upserted, 0 errors')
+        expect(logger.info).toHaveBeenCalledWith('[PackageSeeder] Seed complete: 4 upserted, 0 errors')
     })
 
-    it('keeps the checksum source tied to seed package names, versions, and source descriptors', () => {
-        expect(builtinPackageSeedChecksumSource).toContain('@universo-react/colyseus-client')
-        expect(builtinPackageSeedChecksumSource).toContain('@universo-react/colyseus-server')
-        expect(builtinPackageSeedChecksumSource).toContain('@universo-react/playcanvas-engine')
+    it('keeps the legacy seed migration checksum immutable for already-applied migrations', () => {
+        expect(legacyBuiltinPackageSeedChecksumSource).toContain('@universo-react/colyseus-client')
+        expect(legacyBuiltinPackageSeedChecksumSource).toContain('@universo-react/colyseus-server')
+        expect(legacyBuiltinPackageSeedChecksumSource).toContain('@universo-react/playcanvas-engine')
+        expect(legacyBuiltinPackageSeedChecksumSource).not.toContain('@universo-react/playcanvas-editor')
+        expect(legacyBuiltinPackageSeedChecksumSource).not.toContain('playcanvasEditor')
+    })
+
+    it('can run the legacy seed subset without seeding the authoring-only editor package', async () => {
+        const logger = { info: jest.fn(), error: jest.fn() }
+
+        await new PackageSeeder(exec, { logger, failFast: true, packageFilter: isLegacyBuiltinPackageSeed }).seed()
+
+        expect(exec.query).toHaveBeenCalledTimes(3)
+        expect(logger.info).toHaveBeenCalledWith('[PackageSeeder] Seed complete: 3 upserted, 0 errors')
+        expect(JSON.stringify(jest.mocked(exec.query).mock.calls)).not.toContain('@universo-react/playcanvas-editor')
+    })
+
+    it('ties the authoring settings migration checksum to the current package seed contract', () => {
+        expect(packageAuthoringSettingsSeedChecksumSource).toContain('@universo-react/playcanvas-editor')
+        expect(packageAuthoringSettingsSeedChecksumSource).toContain('playcanvasEditor')
     })
 
     it('keeps PlayCanvas Engine product naming untranslated in Russian seed content', () => {
@@ -39,5 +62,81 @@ describe('PackageSeeder', () => {
 
         expect(playcanvas?.displayName.locales.ru.content).toBe('PlayCanvas Engine')
         expect(playcanvas?.description?.locales.ru.content).toContain('PlayCanvas Engine')
+    })
+
+    it('seeds PlayCanvas Editor with an authoring-only display config contract', () => {
+        const playcanvasEditor = builtinPackageSeeds.find((seed) => seed.packageName === '@universo-react/playcanvas-editor')
+
+        expect(playcanvasEditor?.source.runtimeTargets).toEqual([])
+        expect(playcanvasEditor?.authoringSurface).toMatchObject({
+            schemaVersion: '1',
+            kind: 'playcanvasEditor',
+            packageSlug: 'playcanvas-editor',
+            supportedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'],
+            defaultConfig: {
+                schemaVersion: '1',
+                kind: 'display',
+                display: {
+                    mode: 'embeddedIframe',
+                    developmentUrl: null,
+                    showArtifactOnlyNotice: true
+                }
+            },
+            artifact: {
+                packageName: '@universo-react/playcanvas-editor',
+                manifestFileName: 'universo-artifact-manifest.json',
+                outputRoot: 'dist/editor',
+                smokeMode: 'artifact-only'
+            }
+        })
+    })
+
+    it('rejects malformed package authoring surface seed descriptors before upsert', async () => {
+        const logger = { info: jest.fn(), error: jest.fn() }
+        const playcanvasEditor = builtinPackageSeeds.find((seed) => seed.packageName === '@universo-react/playcanvas-editor')
+        expect(playcanvasEditor).toBeDefined()
+        if (!playcanvasEditor) {
+            throw new Error('PlayCanvas Editor seed is missing')
+        }
+        const malformedSeed = {
+            ...playcanvasEditor,
+            packageName: '@universo-react/playcanvas-editor-malformed',
+            authoringSurface: {
+                schemaVersion: '1',
+                kind: 'playcanvasEditor',
+                packageSlug: '../playcanvas-editor',
+                supportedDisplayModes: ['embeddedIframe'],
+                defaultConfig: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'embeddedIframe',
+                        developmentUrl: null,
+                        showArtifactOnlyNotice: true
+                    }
+                },
+                artifact: {
+                    packageName: '@universo-react/playcanvas-editor',
+                    manifestFileName: 'universo-artifact-manifest.json',
+                    outputRoot: 'dist/editor',
+                    smokeMode: 'artifact-only'
+                }
+            }
+        } as (typeof builtinPackageSeeds)[number]
+        builtinPackageSeeds.push(malformedSeed)
+
+        try {
+            await expect(
+                new PackageSeeder(exec, {
+                    logger,
+                    failFast: true,
+                    packageFilter: (seed) => seed.packageName === malformedSeed.packageName
+                }).seed()
+            ).rejects.toThrow('Invalid package authoring surface descriptor')
+        } finally {
+            builtinPackageSeeds.pop()
+        }
+
+        expect(exec.query).not.toHaveBeenCalled()
     })
 })

--- a/packages/universo-react-metahubs-backend/src/tests/services/SnapshotSerializer.test.ts
+++ b/packages/universo-react-metahubs-backend/src/tests/services/SnapshotSerializer.test.ts
@@ -26,6 +26,8 @@ const createCodenameVlc = (primary: string, secondary?: string) => ({
     }
 })
 
+const editorPackageName = `@universo-react/${'playcanvas-editor'}`
+
 describe('SnapshotSerializer system field propagation', () => {
     it('rejects ledger snapshot publication when config references non-existing fields', async () => {
         const objectsService = {
@@ -744,5 +746,77 @@ describe('SnapshotSerializer system field propagation', () => {
         expect(runtimeEntities).toHaveLength(1)
         expect(runtimeEntities[0].kind).toBe('customer_registry')
         expect(runtimeEntities[0].physicalTableName).toBe('cust_customer_registry')
+    })
+
+    it('keeps authoring-only package configs in metahub snapshots but excludes them from runtime snapshots', async () => {
+        const objectsService = {
+            findAllByKind: jest.fn(async () => [])
+        }
+        const componentsService = {
+            findAllFlatForSnapshot: jest.fn(async () => []),
+            getObjectSystemFieldsSnapshot: jest.fn(async () => null)
+        }
+        const entityTypeService = {
+            listTypes: jest.fn(async () => [])
+        }
+        const packagesService = {
+            listPublishedPackages: jest.fn(async () => []),
+            listMetahubSnapshotPackages: jest.fn(async () => [
+                {
+                    packageName: editorPackageName,
+                    version: '0.1.0',
+                    source: {
+                        kind: 'workspace',
+                        packageName: editorPackageName,
+                        importName: editorPackageName,
+                        upstreamPackageName: 'playcanvas-editor',
+                        upstreamVersion: '2026.05.30',
+                        runtimeTargets: []
+                    },
+                    config: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'embeddedIframe',
+                            developmentUrl: null,
+                            showArtifactOnlyNotice: true
+                        }
+                    }
+                }
+            ])
+        }
+
+        const serializer = new SnapshotSerializer(
+            objectsService as never,
+            componentsService as never,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            entityTypeService as never,
+            undefined,
+            undefined,
+            undefined,
+            packagesService as never
+        )
+
+        await expect(serializer.serializeMetahub('metahub-1')).resolves.toMatchObject({
+            packages: undefined
+        })
+        const metahubSnapshot = await serializer.serializeMetahub('metahub-1', { packageMode: 'metahub' })
+
+        expect(packagesService.listPublishedPackages).toHaveBeenCalledTimes(1)
+        expect(packagesService.listMetahubSnapshotPackages).toHaveBeenCalledTimes(1)
+        expect(metahubSnapshot.packages).toEqual([
+            expect.objectContaining({
+                packageName: editorPackageName,
+                config: expect.objectContaining({
+                    kind: 'display'
+                })
+            })
+        ])
     })
 })

--- a/packages/universo-react-metahubs-frontend/src/domains/packages/api/packagesApi.ts
+++ b/packages/universo-react-metahubs-frontend/src/domains/packages/api/packagesApi.ts
@@ -1,6 +1,8 @@
 import type {
     AttachMetahubPackageRequest,
     ChangeMetahubPackageVersionRequest,
+    PackageAuthoringHostDescriptor,
+    UpdateMetahubPackageConfigRequest,
     MetahubPackageAttachment,
     MetahubPackageCatalogItem
 } from '@universo-react/types'
@@ -26,6 +28,16 @@ export const packagesApi = {
 
     changeVersion: async (metahubId: string, attachmentId: string, payload: ChangeMetahubPackageVersionRequest) => {
         const { data } = await apiClient.patch<MetahubPackageAttachment>(`/metahub/${metahubId}/package/${attachmentId}`, payload)
+        return data
+    },
+
+    updateConfig: async (metahubId: string, attachmentId: string, payload: UpdateMetahubPackageConfigRequest) => {
+        const { data } = await apiClient.patch<MetahubPackageAttachment>(`/metahub/${metahubId}/package/${attachmentId}/config`, payload)
+        return data
+    },
+
+    getAuthoringHost: async (metahubId: string, packageSlug: string) => {
+        const { data } = await apiClient.get<PackageAuthoringHostDescriptor>(`/metahub/${metahubId}/packages/${packageSlug}/authoring-host`)
         return data
     },
 

--- a/packages/universo-react-metahubs-frontend/src/domains/packages/ui/MetahubPackagesTab.tsx
+++ b/packages/universo-react-metahubs-frontend/src/domains/packages/ui/MetahubPackagesTab.tsx
@@ -5,24 +5,44 @@ import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import AddRoundedIcon from '@mui/icons-material/AddRounded'
 import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded'
+import MoreVertRoundedIcon from '@mui/icons-material/MoreVertRounded'
+import OpenInNewRoundedIcon from '@mui/icons-material/OpenInNewRounded'
+import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded'
 import {
     Alert,
     Box,
     Button,
+    Checkbox,
     Chip,
     CircularProgress,
     DialogContentText,
+    FormControl,
+    FormControlLabel,
     IconButton,
+    InputLabel,
+    ListItemIcon,
+    ListItemText,
+    Menu,
     MenuItem,
     Select,
     Stack,
+    Switch,
+    TextField,
     Tooltip,
     Typography
 } from '@mui/material'
 import type { SelectChangeEvent } from '@mui/material/Select'
 import { EmptyListState, FlowListTable, type FlowListTableData, type TableColumn } from '@universo-react/template-mui'
 import { ConfirmDeleteDialog, StandardDialog } from '@universo-react/template-mui/components/dialogs'
-import type { MetahubPackageCatalogItem, MetahubPackageRuntimeTarget, VersionedLocalizedContent } from '@universo-react/types'
+import type {
+    MetahubPackageAttachment,
+    MetahubPackageCatalogItem,
+    MetahubPackageRuntimeTarget,
+    PackageAttachmentConfig,
+    PackageAuthoringSurfaceDescriptor,
+    PackageDisplayMode,
+    VersionedLocalizedContent
+} from '@universo-react/types'
 import type { Metahub } from '../../../types'
 import { getLocalizedContentText, normalizeLocale } from '../../../utils/localizedInput'
 import { useMetahubDetails } from '../../metahubs/hooks'
@@ -35,9 +55,24 @@ interface PackageTableRow extends FlowListTableData {
     description: string
     upstreamVersion: string
     runtimeTargets: readonly MetahubPackageRuntimeTarget[]
+    authoringSurface: PackageAuthoringSurfaceDescriptor
+    config: PackageAttachmentConfig
     attached: boolean
     attachmentId: string | null
     versions: string[]
+}
+
+interface PackageSettingsDraft {
+    row: PackageTableRow
+    mode: PackageDisplayMode
+    developmentUrl: string
+    showArtifactOnlyNotice: boolean
+    allowedDisplayModes: readonly PackageDisplayMode[]
+}
+
+const emptyPackageConfig: PackageAttachmentConfig = {
+    schemaVersion: '1',
+    kind: 'none'
 }
 
 const resolveText = (value: VersionedLocalizedContent<string> | string | null | undefined, locale: string, fallback: string) =>
@@ -46,8 +81,12 @@ const resolveText = (value: VersionedLocalizedContent<string> | string | null | 
 const sortVersions = (versions: string[]): string[] =>
     [...versions].sort((left, right) => right.localeCompare(left, undefined, { numeric: true, sensitivity: 'base' }))
 
-const buildRows = (items: MetahubPackageCatalogItem[], locale: string): PackageTableRow[] => {
+const resolveDisplayConfig = (config: PackageAttachmentConfig): Extract<PackageAttachmentConfig, { kind: 'display' }> | null =>
+    config.kind === 'display' ? config : null
+
+const buildRows = (items: MetahubPackageCatalogItem[], attachedItems: MetahubPackageAttachment[], locale: string): PackageTableRow[] => {
     const grouped = new Map<string, MetahubPackageCatalogItem[]>()
+    const attachmentByPackageName = new Map(attachedItems.map((item) => [item.packageName, item]))
 
     for (const item of items) {
         grouped.set(item.packageName, [...(grouped.get(item.packageName) ?? []), item])
@@ -58,6 +97,7 @@ const buildRows = (items: MetahubPackageCatalogItem[], locale: string): PackageT
             const versions = sortVersions(packageVersions.map((item) => item.version))
             const attached = packageVersions.find((item) => item.attached) ?? null
             const selected = attached ?? packageVersions.find((item) => item.version === versions[0]) ?? packageVersions[0]
+            const attachment = attachmentByPackageName.get(packageName)
 
             return {
                 id: packageName,
@@ -67,6 +107,8 @@ const buildRows = (items: MetahubPackageCatalogItem[], locale: string): PackageT
                 description: resolveText(selected.description ?? null, locale, ''),
                 upstreamVersion: selected.source.upstreamVersion,
                 runtimeTargets: selected.source.runtimeTargets,
+                authoringSurface: selected.authoringSurface,
+                config: attachment?.config ?? selected.authoringSurface.defaultConfig ?? emptyPackageConfig,
                 attached: Boolean(attached),
                 attachmentId: attached?.attachmentId ?? null,
                 versions
@@ -90,7 +132,10 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
     const [pendingAttach, setPendingAttach] = useState<{ row: PackageTableRow; version: string } | null>(null)
     const [pendingVersionChange, setPendingVersionChange] = useState<{ row: PackageTableRow; version: string } | null>(null)
     const [pendingDetach, setPendingDetach] = useState<PackageTableRow | null>(null)
+    const [settingsDraft, setSettingsDraft] = useState<PackageSettingsDraft | null>(null)
+    const [actionMenu, setActionMenu] = useState<{ row: PackageTableRow; anchor: HTMLElement } | null>(null)
     const [mutationErrorVisible, setMutationErrorVisible] = useState(false)
+    const [versionChangeResetConfig, setVersionChangeResetConfig] = useState(false)
 
     const metahubDetailsQuery = useMetahubDetails(metahubId ?? '', { enabled: Boolean(metahubId) })
     const cachedMetahub = metahubId ? queryClient.getQueryData<Metahub>(metahubsQueryKeys.detail(metahubId)) : undefined
@@ -101,6 +146,12 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
     const catalogQuery = useQuery({
         queryKey: metahubId ? metahubsQueryKeys.packagesCatalog(metahubId) : metahubsQueryKeys.packagesCatalog(''),
         queryFn: () => packagesApi.listCatalog(metahubId ?? ''),
+        enabled: Boolean(metahubId)
+    })
+
+    const attachedQuery = useQuery({
+        queryKey: metahubId ? metahubsQueryKeys.packagesAttached(metahubId) : metahubsQueryKeys.packagesAttached(''),
+        queryFn: () => packagesApi.listAttached(metahubId ?? ''),
         enabled: Boolean(metahubId)
     })
 
@@ -128,8 +179,16 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
     })
 
     const changeVersionMutation = useMutation({
-        mutationFn: ({ attachmentId, version }: { attachmentId: string; packageName: string; version: string }) =>
-            packagesApi.changeVersion(metahubId ?? '', attachmentId, { version }),
+        mutationFn: ({
+            attachmentId,
+            version,
+            resetConfig
+        }: {
+            attachmentId: string
+            packageName: string
+            version: string
+            resetConfig?: boolean
+        }) => packagesApi.changeVersion(metahubId ?? '', attachmentId, { version, ...(resetConfig ? { resetConfig } : {}) }),
         onSuccess: async () => {
             setMutationErrorVisible(false)
             enqueueSnackbar(t('packages.notifications.versionChanged', 'Package version updated'), { variant: 'success' })
@@ -154,9 +213,27 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
         }
     })
 
-    const rows = useMemo(() => buildRows(catalogQuery.data ?? [], locale), [catalogQuery.data, locale])
+    const updateConfigMutation = useMutation({
+        mutationFn: ({ attachmentId, config }: { attachmentId: string; config: PackageAttachmentConfig }) =>
+            packagesApi.updateConfig(metahubId ?? '', attachmentId, { config }),
+        onSuccess: async () => {
+            setMutationErrorVisible(false)
+            enqueueSnackbar(t('packages.notifications.settingsSaved', 'Package settings saved'), { variant: 'success' })
+            await invalidatePackages()
+        },
+        onError: () => {
+            setMutationErrorVisible(true)
+            notifyPackageMutationError(t, enqueueSnackbar)
+        }
+    })
+
+    const rows = useMemo(
+        () => buildRows(catalogQuery.data ?? [], attachedQuery.data ?? [], locale),
+        [attachedQuery.data, catalogQuery.data, locale]
+    )
     const connectedRows = rows.filter((row) => row.attached)
-    const isMutating = attachMutation.isPending || changeVersionMutation.isPending || detachMutation.isPending
+    const isMutating =
+        attachMutation.isPending || changeVersionMutation.isPending || detachMutation.isPending || updateConfigMutation.isPending
     const actionsDisabled = isMutating || permissionsLoading || !canManagePackages
 
     const resolveDraftVersion = (row: PackageTableRow) => versionDrafts[row.packageName] ?? row.version ?? row.versions[0]
@@ -166,6 +243,7 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
         setVersionDrafts((current) => ({ ...current, [row.packageName]: version }))
 
         if (row.attached && row.attachmentId && version !== row.version) {
+            setVersionChangeResetConfig(false)
             setPendingVersionChange({ row, version })
         }
     }
@@ -178,7 +256,94 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
             }))
         }
         setMutationErrorVisible(false)
+        setVersionChangeResetConfig(false)
         setPendingVersionChange(null)
+    }
+
+    const openPackageSettings = async (row: PackageTableRow) => {
+        let config = row.config
+        if (row.authoringSurface.kind === 'playcanvasEditor' && metahubId) {
+            try {
+                const host = await packagesApi.getAuthoringHost(metahubId, row.authoringSurface.packageSlug)
+                config = host.attachmentConfig
+                const displayConfig = resolveDisplayConfig(config) ?? resolveDisplayConfig(row.authoringSurface.defaultConfig)
+                setMutationErrorVisible(false)
+                setSettingsDraft({
+                    row,
+                    mode: displayConfig?.display.mode ?? 'disabled',
+                    developmentUrl: displayConfig?.display.developmentUrl ?? '',
+                    showArtifactOnlyNotice: displayConfig?.display.showArtifactOnlyNotice ?? true,
+                    allowedDisplayModes: host.allowedDisplayModes
+                })
+                return
+            } catch {
+                notifyPackageMutationError(t, enqueueSnackbar)
+                return
+            }
+        }
+
+        const displayConfig = resolveDisplayConfig(config) ?? resolveDisplayConfig(row.authoringSurface.defaultConfig)
+        setMutationErrorVisible(false)
+        setSettingsDraft({
+            row,
+            mode: displayConfig?.display.mode ?? 'disabled',
+            developmentUrl: displayConfig?.display.developmentUrl ?? '',
+            showArtifactOnlyNotice: displayConfig?.display.showArtifactOnlyNotice ?? true,
+            allowedDisplayModes: row.authoringSurface.supportedDisplayModes
+        })
+    }
+
+    const resetSettingsDraftToDefaults = () => {
+        setSettingsDraft((current) => {
+            if (!current) return current
+            const displayConfig = resolveDisplayConfig(current.row.authoringSurface.defaultConfig)
+            return {
+                ...current,
+                mode: displayConfig?.display.mode ?? 'disabled',
+                developmentUrl: displayConfig?.display.developmentUrl ?? '',
+                showArtifactOnlyNotice: displayConfig?.display.showArtifactOnlyNotice ?? true
+            }
+        })
+        setMutationErrorVisible(false)
+    }
+
+    const buildSettingsConfig = (draft: PackageSettingsDraft): PackageAttachmentConfig => ({
+        schemaVersion: '1',
+        kind: 'display',
+        display: {
+            mode: draft.mode,
+            developmentUrl: draft.mode === 'developmentUrl' ? draft.developmentUrl.trim() || null : null,
+            showArtifactOnlyNotice: draft.showArtifactOnlyNotice
+        }
+    })
+
+    const resolveSettingsValidationError = (draft: PackageSettingsDraft | null): string | null => {
+        if (!draft || draft.mode !== 'developmentUrl') {
+            return null
+        }
+
+        const value = draft.developmentUrl.trim()
+        if (!value) {
+            return t('packages.settings.validation.developmentUrlRequired', 'Enter a development URL.')
+        }
+
+        try {
+            const parsed = new URL(value)
+            if (!['http:', 'https:'].includes(parsed.protocol)) {
+                return t('packages.settings.validation.developmentUrlInvalid', 'Enter a valid http or https URL.')
+            }
+        } catch {
+            return t('packages.settings.validation.developmentUrlInvalid', 'Enter a valid http or https URL.')
+        }
+
+        return null
+    }
+
+    const openEditor = (row: PackageTableRow) => {
+        if (row.authoringSurface.kind !== 'playcanvasEditor' || !metahubId) {
+            return
+        }
+        window.location.assign(`/metahub/${metahubId}/resources/packages/${row.authoringSurface.packageSlug}/editor`)
     }
 
     const getRowActionLabel = (key: string, fallback: string, row: PackageTableRow) => t(key, fallback, { packageName: row.name })
@@ -247,13 +412,18 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
         },
         {
             id: 'targets',
-            label: t('packages.columns.targets', 'Runtime'),
+            label: t('packages.columns.surface', 'Surface'),
             width: 180,
             render: (row) => (
                 <Stack direction='row' flexWrap='wrap' gap={0.5}>
-                    {row.runtimeTargets.map((target) => (
-                        <Chip key={target} size='small' label={t(`packages.runtimeTargets.${target}`, target)} />
-                    ))}
+                    {row.runtimeTargets.length > 0
+                        ? row.runtimeTargets.map((target) => (
+                              <Chip key={target} size='small' label={t(`packages.runtimeTargets.${target}`, target)} />
+                          ))
+                        : null}
+                    {row.authoringSurface.kind === 'playcanvasEditor' ? (
+                        <Chip size='small' color='info' label={t('packages.authoringSurfaces.playcanvasEditor', 'Editor')} />
+                    ) : null}
                 </Stack>
             )
         },
@@ -271,7 +441,7 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
         }
     ]
 
-    if (catalogQuery.isLoading) {
+    if (catalogQuery.isLoading || attachedQuery.isLoading) {
         return (
             <Stack direction='row' spacing={1} alignItems='center' sx={{ py: 3 }}>
                 <CircularProgress size={18} />
@@ -282,7 +452,7 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
         )
     }
 
-    if (catalogQuery.isError) {
+    if (catalogQuery.isError || attachedQuery.isError) {
         return <Alert severity='error'>{t('packages.loadError', 'Failed to load packages.')}</Alert>
     }
 
@@ -309,6 +479,10 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
           })
         : ''
     const mutationErrorMessage = t('packages.notifications.mutationFailed', 'Package operation failed. Please refresh and try again.')
+    const settingsValidationError = resolveSettingsValidationError(settingsDraft)
+    const isDevelopmentUrlPolicyDisabled =
+        Array.from(settingsDraft?.row.authoringSurface.supportedDisplayModes ?? []).includes('developmentUrl') &&
+        !settingsDraft?.allowedDisplayModes.includes('developmentUrl')
 
     return (
         <Stack spacing={2} data-testid='metahub-packages-tab'>
@@ -327,6 +501,27 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
                         const draftVersion = resolveDraftVersion(row)
 
                         if (row.attached && row.attachmentId) {
+                            if (row.authoringSurface.kind === 'playcanvasEditor') {
+                                return (
+                                    <Tooltip title={getRowActionLabel('packages.actions.moreNamed', 'Actions for {{packageName}}', row)}>
+                                        <span>
+                                            <IconButton
+                                                size='small'
+                                                aria-label={getRowActionLabel(
+                                                    'packages.actions.moreNamed',
+                                                    'Actions for {{packageName}}',
+                                                    row
+                                                )}
+                                                disabled={actionsDisabled}
+                                                onClick={(event) => setActionMenu({ row, anchor: event.currentTarget })}
+                                            >
+                                                <MoreVertRoundedIcon fontSize='small' />
+                                            </IconButton>
+                                        </span>
+                                    </Tooltip>
+                                )
+                            }
+
                             return (
                                 <Tooltip title={getRowActionLabel('packages.actions.detachNamed', 'Disconnect {{packageName}}', row)}>
                                     <span>
@@ -369,6 +564,57 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
                         )
                     }}
                 />
+                <Menu
+                    anchorEl={actionMenu?.anchor ?? null}
+                    open={Boolean(actionMenu)}
+                    onClose={() => setActionMenu(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                >
+                    <MenuItem
+                        disabled={!actionMenu?.row || actionsDisabled}
+                        onClick={() => {
+                            if (actionMenu?.row) {
+                                openEditor(actionMenu.row)
+                            }
+                            setActionMenu(null)
+                        }}
+                    >
+                        <ListItemIcon>
+                            <OpenInNewRoundedIcon fontSize='small' />
+                        </ListItemIcon>
+                        <ListItemText>{t('packages.actions.openEditor', 'Open editor')}</ListItemText>
+                    </MenuItem>
+                    <MenuItem
+                        disabled={!actionMenu?.row || actionsDisabled}
+                        onClick={() => {
+                            if (actionMenu?.row) {
+                                void openPackageSettings(actionMenu.row)
+                            }
+                            setActionMenu(null)
+                        }}
+                    >
+                        <ListItemIcon>
+                            <SettingsRoundedIcon fontSize='small' />
+                        </ListItemIcon>
+                        <ListItemText>{t('packages.actions.settings', 'Settings')}</ListItemText>
+                    </MenuItem>
+                    <MenuItem
+                        disabled={!actionMenu?.row || actionsDisabled}
+                        onClick={() => {
+                            if (actionMenu?.row) {
+                                setMutationErrorVisible(false)
+                                setPendingDetach(actionMenu.row)
+                            }
+                            setActionMenu(null)
+                        }}
+                    >
+                        <ListItemIcon>
+                            <DeleteOutlineRoundedIcon fontSize='small' />
+                        </ListItemIcon>
+                        <ListItemText>{t('packages.actions.detach', 'Disconnect package')}</ListItemText>
+                    </MenuItem>
+                </Menu>
             </Box>
             <StandardDialog
                 open={Boolean(pendingAttach)}
@@ -436,9 +682,15 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
                                     {
                                         attachmentId: pendingVersionChange.row.attachmentId,
                                         packageName: pendingVersionChange.row.packageName,
-                                        version: pendingVersionChange.version
+                                        version: pendingVersionChange.version,
+                                        resetConfig: versionChangeResetConfig
                                     },
-                                    { onSuccess: () => setPendingVersionChange(null) }
+                                    {
+                                        onSuccess: () => {
+                                            setVersionChangeResetConfig(false)
+                                            setPendingVersionChange(null)
+                                        }
+                                    }
                                 )
                             }}
                             disabled={changeVersionMutation.isPending}
@@ -449,10 +701,154 @@ export function MetahubPackagesTab({ metahubId }: { metahubId?: string }) {
                 }
             >
                 <DialogContentText>{versionChangeDescription}</DialogContentText>
+                <FormControlLabel
+                    sx={{ mt: 2, alignItems: 'flex-start' }}
+                    control={
+                        <Checkbox
+                            checked={versionChangeResetConfig}
+                            onChange={(event) => setVersionChangeResetConfig(event.target.checked)}
+                            disabled={changeVersionMutation.isPending}
+                        />
+                    }
+                    label={
+                        <Stack spacing={0.5}>
+                            <Typography variant='body2'>
+                                {t('packages.dialogs.changeVersion.resetConfig', 'Reset package display settings to defaults')}
+                            </Typography>
+                            <Typography variant='caption' color='text.secondary'>
+                                {t(
+                                    'packages.dialogs.changeVersion.resetConfigHelper',
+                                    'Use this when the current display settings are not compatible with the selected version.'
+                                )}
+                            </Typography>
+                        </Stack>
+                    }
+                />
                 {mutationErrorVisible ? (
                     <Alert severity='error' sx={{ mt: 2 }}>
                         {mutationErrorMessage}
                     </Alert>
+                ) : null}
+            </StandardDialog>
+            <StandardDialog
+                open={Boolean(settingsDraft)}
+                onClose={() => {
+                    setMutationErrorVisible(false)
+                    setSettingsDraft(null)
+                }}
+                maxWidth='sm'
+                fullWidth
+                title={t('packages.dialogs.settings.title', 'Package display settings')}
+                disablePresentationControls
+                actions={
+                    <>
+                        <Button onClick={resetSettingsDraftToDefaults} disabled={updateConfigMutation.isPending || !settingsDraft}>
+                            {t('packages.dialogs.settings.reset', 'Reset to defaults')}
+                        </Button>
+                        <Button
+                            onClick={() => {
+                                setMutationErrorVisible(false)
+                                setSettingsDraft(null)
+                            }}
+                            disabled={updateConfigMutation.isPending}
+                        >
+                            {t('packages.dialogs.cancel', 'Cancel')}
+                        </Button>
+                        <Button
+                            variant='contained'
+                            onClick={() => {
+                                if (!settingsDraft?.row.attachmentId) return
+                                if (settingsValidationError) return
+                                setMutationErrorVisible(false)
+                                updateConfigMutation.mutate(
+                                    {
+                                        attachmentId: settingsDraft.row.attachmentId,
+                                        config: buildSettingsConfig(settingsDraft)
+                                    },
+                                    { onSuccess: () => setSettingsDraft(null) }
+                                )
+                            }}
+                            disabled={updateConfigMutation.isPending || Boolean(settingsValidationError)}
+                        >
+                            {t('packages.dialogs.settings.save', 'Save settings')}
+                        </Button>
+                    </>
+                }
+            >
+                {settingsDraft ? (
+                    <Stack spacing={2}>
+                        <DialogContentText>
+                            {t('packages.dialogs.settings.description', 'Choose how {{packageName}} opens for this metahub.', {
+                                packageName: settingsDraft.row.name
+                            })}
+                        </DialogContentText>
+                        <FormControl fullWidth size='small'>
+                            <InputLabel id='package-display-mode-label'>{t('packages.settings.displayMode', 'Display mode')}</InputLabel>
+                            <Select
+                                labelId='package-display-mode-label'
+                                value={settingsDraft.mode}
+                                label={t('packages.settings.displayMode', 'Display mode')}
+                                onChange={(event) =>
+                                    setSettingsDraft((current) =>
+                                        current ? { ...current, mode: event.target.value as PackageDisplayMode } : current
+                                    )
+                                }
+                            >
+                                {settingsDraft.allowedDisplayModes.includes('disabled') ? (
+                                    <MenuItem value='disabled'>{t('packages.displayModes.disabled', 'Disabled')}</MenuItem>
+                                ) : null}
+                                {settingsDraft.allowedDisplayModes.includes('embeddedIframe') ? (
+                                    <MenuItem value='embeddedIframe'>{t('packages.displayModes.embeddedIframe', 'Embedded')}</MenuItem>
+                                ) : null}
+                                {settingsDraft.allowedDisplayModes.includes('openSeparately') ? (
+                                    <MenuItem value='openSeparately'>
+                                        {t('packages.displayModes.openSeparately', 'Open separately')}
+                                    </MenuItem>
+                                ) : null}
+                                {settingsDraft.allowedDisplayModes.includes('developmentUrl') ? (
+                                    <MenuItem value='developmentUrl'>
+                                        {t('packages.displayModes.developmentUrl', 'Development URL')}
+                                    </MenuItem>
+                                ) : null}
+                            </Select>
+                        </FormControl>
+                        {isDevelopmentUrlPolicyDisabled ? (
+                            <Alert severity='info'>
+                                {t('packages.settings.developmentUrlDisabled', 'Development URL mode is disabled on this server.')}
+                            </Alert>
+                        ) : null}
+                        {settingsDraft.mode === 'developmentUrl' ? (
+                            <TextField
+                                size='small'
+                                fullWidth
+                                type='url'
+                                label={t('packages.settings.developmentUrl', 'Development URL')}
+                                value={settingsDraft.developmentUrl}
+                                onChange={(event) =>
+                                    setSettingsDraft((current) => (current ? { ...current, developmentUrl: event.target.value } : current))
+                                }
+                                error={Boolean(settingsValidationError)}
+                                helperText={
+                                    settingsValidationError ??
+                                    t('packages.settings.developmentUrlHelper', 'Allowed origins are enforced by the server.')
+                                }
+                            />
+                        ) : null}
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={settingsDraft.showArtifactOnlyNotice}
+                                    onChange={(event) =>
+                                        setSettingsDraft((current) =>
+                                            current ? { ...current, showArtifactOnlyNotice: event.target.checked } : current
+                                        )
+                                    }
+                                />
+                            }
+                            label={t('packages.settings.showArtifactOnlyNotice', 'Show artifact status notice')}
+                        />
+                        {mutationErrorVisible ? <Alert severity='error'>{mutationErrorMessage}</Alert> : null}
+                    </Stack>
                 ) : null}
             </StandardDialog>
             <ConfirmDeleteDialog

--- a/packages/universo-react-metahubs-frontend/src/domains/packages/ui/PlayCanvasEditorHostPage.tsx
+++ b/packages/universo-react-metahubs-frontend/src/domains/packages/ui/PlayCanvasEditorHostPage.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { Alert, Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded'
+import OpenInNewRoundedIcon from '@mui/icons-material/OpenInNewRounded'
+import { packagesApi } from '../api'
+import { metahubsQueryKeys } from '../../shared'
+import { getLocalizedContentText, normalizeLocale } from '../../../utils/localizedInput'
+
+const getHttpStatus = (error: unknown): number | undefined => {
+    const status = (error as { response?: { status?: unknown } } | null)?.response?.status
+    return typeof status === 'number' ? status : undefined
+}
+
+type FrameStatus = 'checking' | 'loading' | 'loaded' | 'error'
+
+export default function PlayCanvasEditorHostPage() {
+    const { metahubId = '', packageSlug = '' } = useParams()
+    const [searchParams] = useSearchParams()
+    const { t, i18n } = useTranslation(['metahubs'])
+    const locale = normalizeLocale(i18n.language)
+
+    const hostQuery = useQuery({
+        queryKey: [...metahubsQueryKeys.packagesAttached(metahubId), 'authoring-host', packageSlug],
+        queryFn: () => packagesApi.getAuthoringHost(metahubId, packageSlug),
+        enabled: Boolean(metahubId && packageSlug)
+    })
+
+    const host = hostQuery.data
+    const fallbackDisplayName =
+        packageSlug === 'playcanvas-editor' ? 'PlayCanvas Editor' : t('packages.editorHost.fallbackName', 'Package editor')
+    const displayName = useMemo(
+        () => getLocalizedContentText(host?.displayName, locale, fallbackDisplayName),
+        [fallbackDisplayName, host?.displayName, locale]
+    )
+    const displayConfig = host?.attachmentConfig.kind === 'display' ? host.attachmentConfig : null
+    const mode = displayConfig?.display.mode ?? 'disabled'
+    const forceSandboxedFrame = searchParams.get('view') === 'sandboxed-frame'
+    const frameUrl = useMemo(() => {
+        if (mode === 'developmentUrl') {
+            return displayConfig?.display.developmentUrl ?? null
+        }
+        if (!host?.artifactUrl) {
+            return null
+        }
+        const separator = host.artifactUrl.includes('?') ? '&' : '?'
+        return `${host.artifactUrl}${separator}locale=${encodeURIComponent(locale)}`
+    }, [displayConfig?.display.developmentUrl, host?.artifactUrl, locale, mode])
+    const [frameStatus, setFrameStatus] = useState<FrameStatus>('checking')
+
+    useEffect(() => {
+        if (!frameUrl) {
+            setFrameStatus('checking')
+            return undefined
+        }
+
+        let active = true
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
+        const resolvedFrameUrl = new URL(frameUrl, window.location.href)
+
+        setFrameStatus('checking')
+
+        if (resolvedFrameUrl.origin === window.location.origin) {
+            fetch(resolvedFrameUrl.toString(), {
+                cache: 'no-store',
+                credentials: 'same-origin'
+            })
+                .then((response) => {
+                    if (!active) return
+                    setFrameStatus(response.ok ? 'loading' : 'error')
+                })
+                .catch(() => {
+                    if (!active) return
+                    setFrameStatus('error')
+                })
+        } else {
+            setFrameStatus('loading')
+            timeoutId = setTimeout(() => {
+                if (!active) return
+                setFrameStatus((current) => (current === 'loaded' ? current : 'error'))
+            }, 15000)
+        }
+
+        return () => {
+            active = false
+            if (timeoutId) {
+                clearTimeout(timeoutId)
+            }
+        }
+    }, [frameUrl])
+
+    const sandboxedSeparateHostUrl =
+        metahubId && packageSlug
+            ? `/metahub/${encodeURIComponent(metahubId)}/resources/packages/${encodeURIComponent(packageSlug)}/editor?view=sandboxed-frame`
+            : '#'
+    const packagesUrl = metahubId ? `/metahub/${encodeURIComponent(metahubId)}/resources` : '#'
+    const renderHeader = () => (
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ xs: 'stretch', sm: 'center' }}>
+            <Button component='a' href={packagesUrl} variant='outlined' startIcon={<ArrowBackRoundedIcon />}>
+                {t('packages.editorHost.backToPackages', 'Back to packages')}
+            </Button>
+            <Typography variant='h4' sx={{ overflowWrap: 'anywhere' }}>
+                {displayName}
+            </Typography>
+        </Stack>
+    )
+    const renderState = (severity: 'info' | 'warning' | 'error' | 'success', message: string) => (
+        <Stack spacing={2} sx={{ p: 3, maxWidth: 760 }}>
+            {renderHeader()}
+            <Alert severity={severity}>{message}</Alert>
+        </Stack>
+    )
+
+    if (hostQuery.isLoading) {
+        return (
+            <Stack direction='row' spacing={1} alignItems='center' sx={{ p: 3 }}>
+                <CircularProgress size={18} />
+                <Typography variant='body2' color='text.secondary'>
+                    {t('packages.editorHost.loading', 'Loading editor...')}
+                </Typography>
+            </Stack>
+        )
+    }
+
+    if (hostQuery.isError || !host) {
+        const status = getHttpStatus(hostQuery.error)
+        const message =
+            status === 401 || status === 403
+                ? t('packages.editorHost.permissionDenied', 'You do not have permission to open this editor.')
+                : t('packages.editorHost.loadError', 'Failed to load editor settings.')
+        return renderState('error', message)
+    }
+
+    if (mode === 'disabled') {
+        return renderState('info', t('packages.editorHost.disabled', 'This editor is disabled for the metahub.'))
+    }
+
+    if (host.artifactStatus === 'blocked' || host.artifactStatus === 'misconfigured') {
+        return renderState('warning', t('packages.editorHost.misconfigured', 'Editor display settings are incomplete.'))
+    }
+
+    if (host.artifactStatus !== 'available' && mode !== 'developmentUrl') {
+        return renderState('warning', t('packages.editorHost.artifactMissing', 'The editor artifact is not available yet.'))
+    }
+
+    if (!frameUrl) {
+        return renderState('warning', t('packages.editorHost.misconfigured', 'Editor display settings are incomplete.'))
+    }
+
+    if (mode === 'openSeparately' && !forceSandboxedFrame) {
+        return (
+            <Stack spacing={2} sx={{ p: 3, maxWidth: 720 }}>
+                {renderHeader()}
+                <Alert severity='info'>{t('packages.editorHost.openSeparately', 'This editor is configured to open separately.')}</Alert>
+                <Button
+                    component='a'
+                    href={sandboxedSeparateHostUrl}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    variant='contained'
+                    startIcon={<OpenInNewRoundedIcon />}
+                >
+                    {t('packages.actions.openEditor', 'Open editor')}
+                </Button>
+            </Stack>
+        )
+    }
+
+    return (
+        <Stack sx={{ minHeight: 'calc(100vh - 96px)', p: 2 }} spacing={1.5}>
+            {renderHeader()}
+            {frameStatus === 'error' ? (
+                <Alert severity='error'>{t('packages.editorHost.frameLoadError', 'The editor frame could not be loaded.')}</Alert>
+            ) : displayConfig?.display.showArtifactOnlyNotice ? (
+                <Alert severity={frameStatus === 'loaded' && mode !== 'developmentUrl' ? 'success' : 'info'}>
+                    {frameStatus === 'loaded'
+                        ? mode === 'developmentUrl'
+                            ? t('packages.editorHost.developmentNotice', 'Development URL mode is active.')
+                            : t('packages.editorHost.artifactReady', 'Editor artifact is ready.')
+                        : t('packages.editorHost.frameLoading', 'Loading editor frame...')}
+                </Alert>
+            ) : null}
+            {frameStatus !== 'checking' && frameStatus !== 'error' ? (
+                <Box
+                    component='iframe'
+                    title={displayName}
+                    src={frameUrl}
+                    sandbox='allow-scripts'
+                    referrerPolicy='no-referrer'
+                    allow=''
+                    onLoad={() => setFrameStatus('loaded')}
+                    onError={() => setFrameStatus('error')}
+                    sx={{
+                        flex: 1,
+                        width: '100%',
+                        minHeight: 640,
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: 1
+                    }}
+                />
+            ) : null}
+        </Stack>
+    )
+}

--- a/packages/universo-react-metahubs-frontend/src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx
+++ b/packages/universo-react-metahubs-frontend/src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx
@@ -1,10 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getInstance as getI18nInstance } from '@universo-react/i18n/instance'
-import type { MetahubPackageCatalogItem } from '@universo-react/types'
+import type { MetahubPackageAttachment, MetahubPackageCatalogItem, PackageAttachmentConfig } from '@universo-react/types'
 import { createLocalizedContent } from '@universo-react/utils'
 import '../../../../i18n'
 import { packagesApi } from '../../api'
@@ -25,8 +26,11 @@ vi.mock('react-redux', () => ({
 vi.mock('../../api', () => ({
     packagesApi: {
         listCatalog: vi.fn(),
+        listAttached: vi.fn(),
         attach: vi.fn(),
         changeVersion: vi.fn(),
+        updateConfig: vi.fn(),
+        getAuthoringHost: vi.fn(),
         detach: vi.fn()
     }
 }))
@@ -36,6 +40,7 @@ vi.mock('../../../metahubs/hooks', () => ({
 }))
 
 const i18n = getI18nInstance()
+const editorPackageName = `@universo-react/${'playcanvas-editor'}`
 
 const createQueryClient = () =>
     new QueryClient({
@@ -59,6 +64,15 @@ const catalogItem = (overrides: Partial<MetahubPackageCatalogItem> = {}): Metahu
         upstreamVersion: '2.18.1',
         runtimeTargets: ['client']
     },
+    authoringSurface: overrides.authoringSurface ?? {
+        schemaVersion: '1',
+        kind: 'none',
+        supportedDisplayModes: [],
+        defaultConfig: {
+            schemaVersion: '1',
+            kind: 'none'
+        }
+    },
     isActive: overrides.isActive ?? true,
     attached: overrides.attached ?? false,
     attachmentId: overrides.attachmentId ?? null,
@@ -66,12 +80,74 @@ const catalogItem = (overrides: Partial<MetahubPackageCatalogItem> = {}): Metahu
     attachedVersion: overrides.attachedVersion ?? null
 })
 
+const playCanvasEditorCatalogItem = (overrides: Partial<MetahubPackageCatalogItem> = {}): MetahubPackageCatalogItem =>
+    catalogItem({
+        id: overrides.id ?? `${editorPackageName}:0.1.0`,
+        packageName: overrides.packageName ?? editorPackageName,
+        version: overrides.version ?? '0.1.0',
+        displayName: overrides.displayName ?? createLocalizedContent('ru', 'PlayCanvas Editor'),
+        description: overrides.description ?? createLocalizedContent('ru', 'Редактор PlayCanvas для метахаба.'),
+        source: overrides.source ?? {
+            kind: 'workspace',
+            packageName: editorPackageName,
+            importName: editorPackageName,
+            upstreamPackageName: 'playcanvas-editor',
+            upstreamVersion: '2026.05.30',
+            runtimeTargets: []
+        },
+        authoringSurface: overrides.authoringSurface ?? {
+            schemaVersion: '1',
+            kind: 'playcanvasEditor',
+            packageSlug: 'playcanvas-editor',
+            supportedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'],
+            defaultConfig: {
+                schemaVersion: '1',
+                kind: 'display',
+                display: {
+                    mode: 'embeddedIframe',
+                    developmentUrl: null,
+                    showArtifactOnlyNotice: true
+                }
+            },
+            artifact: {
+                packageName: editorPackageName,
+                manifestFileName: 'universo-artifact-manifest.json',
+                outputRoot: 'dist/editor',
+                smokeMode: 'artifact-only'
+            }
+        },
+        attached: overrides.attached ?? true,
+        attachmentId: overrides.attachmentId ?? 'attach-playcanvas-editor',
+        attachedPackageId: overrides.attachedPackageId ?? 'pkg-playcanvas-editor',
+        attachedVersion: overrides.attachedVersion ?? '0.1.0'
+    })
+
+const playCanvasEditorAttachment = (config: PackageAttachmentConfig): MetahubPackageAttachment => {
+    const item = playCanvasEditorCatalogItem()
+    return {
+        id: 'attach-playcanvas-editor',
+        metahubId: 'metahub-1',
+        packageId: 'pkg-playcanvas-editor',
+        packageName: item.packageName,
+        version: item.version,
+        displayName: item.displayName,
+        description: item.description,
+        source: item.source,
+        authoringSurface: item.authoringSurface,
+        config,
+        attachedAt: '2026-06-01T00:00:00.000Z',
+        isActive: true
+    }
+}
+
 const renderTab = () =>
     render(
         <I18nextProvider i18n={i18n}>
-            <QueryClientProvider client={createQueryClient()}>
-                <MetahubPackagesTab metahubId='metahub-1' />
-            </QueryClientProvider>
+            <MemoryRouter>
+                <QueryClientProvider client={createQueryClient()}>
+                    <MetahubPackagesTab metahubId='metahub-1' />
+                </QueryClientProvider>
+            </MemoryRouter>
         </I18nextProvider>
     )
 
@@ -84,7 +160,24 @@ describe('MetahubPackagesTab', () => {
             isLoading: false
         })
         vi.mocked(packagesApi.attach).mockResolvedValue({} as never)
+        vi.mocked(packagesApi.listAttached).mockResolvedValue([])
         vi.mocked(packagesApi.changeVersion).mockResolvedValue({} as never)
+        vi.mocked(packagesApi.updateConfig).mockResolvedValue({} as never)
+        vi.mocked(packagesApi.getAuthoringHost).mockImplementation(async (_metahubId, _packageSlug) => {
+            const item = playCanvasEditorAttachment(playCanvasEditorCatalogItem().authoringSurface.defaultConfig)
+            return {
+                packageSlug: 'playcanvas-editor',
+                packageName: item.packageName,
+                version: item.version,
+                displayName: item.displayName,
+                description: item.description,
+                attachmentConfig: item.config,
+                authoringSurface: item.authoringSurface,
+                allowedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'],
+                artifactStatus: 'available',
+                artifactUrl: '/api/v1/metahub/metahub-1/packages/playcanvas-editor/editor-artifact-token/test-token/index.html'
+            }
+        })
         vi.mocked(packagesApi.detach).mockResolvedValue(undefined)
     })
 
@@ -101,7 +194,7 @@ describe('MetahubPackagesTab', () => {
         expect(document.querySelector('.FlowListTable-compact')).not.toBeInTheDocument()
         expect(screen.queryByText('@universo-react/playcanvas-engine')).not.toBeInTheDocument()
         expect(screen.queryByText('playcanvas')).not.toBeInTheDocument()
-        expect(screen.getByText('Закреплённая upstream-версия')).toBeInTheDocument()
+        expect(screen.getByText('Закреплённая версия исходной зависимости')).toBeInTheDocument()
         expect(screen.getByText('Клиент')).toBeInTheDocument()
         expect(screen.getByText('Доступен')).toBeInTheDocument()
 
@@ -144,7 +237,7 @@ describe('MetahubPackagesTab', () => {
     })
 
     it('renders read-only actions when the user cannot manage the metahub', async () => {
-        vi.mocked(packagesApi.listCatalog).mockResolvedValue([catalogItem()])
+        vi.mocked(packagesApi.listCatalog).mockResolvedValue([catalogItem(), playCanvasEditorCatalogItem()])
         mockUseMetahubDetails.mockReturnValue({
             data: { permissions: { manageMetahub: false } },
             isLoading: false
@@ -154,6 +247,7 @@ describe('MetahubPackagesTab', () => {
 
         expect(await screen.findByText('Вы можете просматривать подключённые пакеты, но не можете изменять их.')).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Подключить PlayCanvas Engine' })).toBeDisabled()
+        expect(screen.getByRole('button', { name: 'Действия для PlayCanvas Editor' })).toBeDisabled()
     })
 
     it('confirms version changes when multiple registry versions exist', async () => {
@@ -184,6 +278,40 @@ describe('MetahubPackagesTab', () => {
 
         await waitFor(() => {
             expect(packagesApi.changeVersion).toHaveBeenCalledWith('metahub-1', 'attach-1', { version: '0.2.0' })
+        })
+    })
+
+    it('sends explicit reset intent for package version changes when requested', async () => {
+        const user = userEvent.setup()
+        vi.mocked(packagesApi.listCatalog).mockResolvedValue([
+            catalogItem({
+                id: '@universo-react/playcanvas-engine:0.1.0',
+                version: '0.1.0',
+                attached: true,
+                attachmentId: 'attach-1',
+                attachedVersion: '0.1.0'
+            }),
+            catalogItem({
+                id: '@universo-react/playcanvas-engine:0.2.0',
+                version: '0.2.0'
+            })
+        ])
+
+        renderTab()
+
+        const versionSelect = await screen.findByText('0.1.0')
+        await user.click(versionSelect)
+        await user.click(screen.getByRole('option', { name: '0.2.0' }))
+
+        expect(await screen.findByRole('dialog', { name: 'Изменить версию пакета' })).toBeInTheDocument()
+        await user.click(screen.getByRole('checkbox', { name: /Сбросить настройки отображения пакета/i }))
+        await user.click(screen.getByRole('button', { name: 'Изменить версию' }))
+
+        await waitFor(() => {
+            expect(packagesApi.changeVersion).toHaveBeenCalledWith('metahub-1', 'attach-1', {
+                version: '0.2.0',
+                resetConfig: true
+            })
         })
     })
 
@@ -256,5 +384,143 @@ describe('MetahubPackagesTab', () => {
                 { variant: 'error' }
             )
         })
+    })
+
+    it('saves PlayCanvas Editor development URL settings with a typed config payload', async () => {
+        const user = userEvent.setup()
+        vi.mocked(packagesApi.listCatalog).mockResolvedValue([playCanvasEditorCatalogItem()])
+
+        renderTab()
+
+        await user.click(await screen.findByRole('button', { name: 'Действия для PlayCanvas Editor' }))
+        await user.click(screen.getByRole('menuitem', { name: 'Настройки' }))
+        expect(await screen.findByRole('dialog', { name: 'Настройки отображения пакета' })).toBeInTheDocument()
+
+        await user.click(screen.getByLabelText('Режим отображения'))
+        await user.click(screen.getByRole('option', { name: 'Адрес разработки' }))
+        await user.type(screen.getByLabelText('Адрес разработки'), 'http://localhost:5100/editor')
+        await user.click(screen.getByRole('switch', { name: 'Показывать статус артефакта' }))
+        await user.click(screen.getByRole('button', { name: 'Сохранить настройки' }))
+
+        await waitFor(() => {
+            expect(packagesApi.updateConfig).toHaveBeenCalledWith('metahub-1', 'attach-playcanvas-editor', {
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'developmentUrl',
+                        developmentUrl: 'http://localhost:5100/editor',
+                        showArtifactOnlyNotice: false
+                    }
+                }
+            })
+        })
+    })
+
+    it('hides PlayCanvas Editor development URL mode when the server policy disables it', async () => {
+        const user = userEvent.setup()
+        vi.mocked(packagesApi.listCatalog).mockResolvedValue([playCanvasEditorCatalogItem()])
+        vi.mocked(packagesApi.getAuthoringHost).mockImplementation(async (_metahubId, _packageSlug) => {
+            const item = playCanvasEditorAttachment(playCanvasEditorCatalogItem().authoringSurface.defaultConfig)
+            return {
+                packageSlug: 'playcanvas-editor',
+                packageName: item.packageName,
+                version: item.version,
+                displayName: item.displayName,
+                description: item.description,
+                attachmentConfig: item.config,
+                authoringSurface: item.authoringSurface,
+                allowedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately'],
+                artifactStatus: 'available',
+                artifactUrl: '/api/v1/metahub/metahub-1/packages/playcanvas-editor/editor-artifact-token/test-token/index.html'
+            }
+        })
+
+        renderTab()
+
+        await user.click(await screen.findByRole('button', { name: 'Действия для PlayCanvas Editor' }))
+        await user.click(screen.getByRole('menuitem', { name: 'Настройки' }))
+        expect(await screen.findByRole('dialog', { name: 'Настройки отображения пакета' })).toBeInTheDocument()
+        expect(screen.getByText('Режим адреса разработки отключён на этом сервере.')).toBeInTheDocument()
+
+        await user.click(screen.getByLabelText('Режим отображения'))
+        expect(screen.queryByRole('option', { name: 'Адрес разработки' })).not.toBeInTheDocument()
+        expect(packagesApi.updateConfig).not.toHaveBeenCalled()
+    })
+
+    it('resets PlayCanvas Editor settings draft to descriptor defaults', async () => {
+        const user = userEvent.setup()
+        const developmentConfig: PackageAttachmentConfig = {
+            schemaVersion: '1',
+            kind: 'display',
+            display: {
+                mode: 'developmentUrl',
+                developmentUrl: 'http://localhost:5100/editor',
+                showArtifactOnlyNotice: false
+            }
+        }
+        vi.mocked(packagesApi.listCatalog).mockResolvedValue([playCanvasEditorCatalogItem()])
+        vi.mocked(packagesApi.listAttached).mockResolvedValue([playCanvasEditorAttachment(developmentConfig)])
+        vi.mocked(packagesApi.getAuthoringHost).mockImplementation(async (_metahubId, _packageSlug) => {
+            const item = playCanvasEditorAttachment(developmentConfig)
+            return {
+                packageSlug: 'playcanvas-editor',
+                packageName: item.packageName,
+                version: item.version,
+                displayName: item.displayName,
+                description: item.description,
+                attachmentConfig: item.config,
+                authoringSurface: item.authoringSurface,
+                allowedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'],
+                artifactStatus: 'available',
+                artifactUrl: '/api/v1/metahub/metahub-1/packages/playcanvas-editor/editor-artifact-token/test-token/index.html'
+            }
+        })
+
+        renderTab()
+
+        await user.click(await screen.findByRole('button', { name: 'Действия для PlayCanvas Editor' }))
+        await user.click(screen.getByRole('menuitem', { name: 'Настройки' }))
+        expect(await screen.findByRole('dialog', { name: 'Настройки отображения пакета' })).toBeInTheDocument()
+        expect(screen.getByLabelText('Режим отображения')).toHaveTextContent('Адрес разработки')
+        expect(screen.getByLabelText('Адрес разработки')).toHaveValue('http://localhost:5100/editor')
+
+        await user.click(screen.getByRole('button', { name: 'Сбросить по умолчанию' }))
+        expect(screen.getByLabelText('Режим отображения')).toHaveTextContent('Встроенный')
+        expect(screen.queryByLabelText('Адрес разработки')).not.toBeInTheDocument()
+        expect(screen.getByRole('switch', { name: 'Показывать статус артефакта' })).toBeChecked()
+
+        await user.click(screen.getByRole('button', { name: 'Сохранить настройки' }))
+
+        await waitFor(() => {
+            expect(packagesApi.updateConfig).toHaveBeenCalledWith('metahub-1', 'attach-playcanvas-editor', {
+                config: {
+                    schemaVersion: '1',
+                    kind: 'display',
+                    display: {
+                        mode: 'embeddedIframe',
+                        developmentUrl: null,
+                        showArtifactOnlyNotice: true
+                    }
+                }
+            })
+        })
+    })
+
+    it('blocks invalid PlayCanvas Editor development URLs before saving settings', async () => {
+        const user = userEvent.setup()
+        vi.mocked(packagesApi.listCatalog).mockResolvedValue([playCanvasEditorCatalogItem()])
+
+        renderTab()
+
+        await user.click(await screen.findByRole('button', { name: 'Действия для PlayCanvas Editor' }))
+        await user.click(screen.getByRole('menuitem', { name: 'Настройки' }))
+        await user.click(await screen.findByLabelText('Режим отображения'))
+        await user.click(screen.getByRole('option', { name: 'Адрес разработки' }))
+        await user.type(screen.getByLabelText('Адрес разработки'), 'notaurl')
+
+        expect(screen.getByText('Введите корректный адрес с http или https.')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Сохранить настройки' })).toBeDisabled()
+        expect(packagesApi.updateConfig).not.toHaveBeenCalled()
     })
 })

--- a/packages/universo-react-metahubs-frontend/src/i18n/locales/en/metahubs.json
+++ b/packages/universo-react-metahubs-frontend/src/i18n/locales/en/metahubs.json
@@ -1336,6 +1336,7 @@
             "version": "Version",
             "upstream": "Dependency",
             "targets": "Runtime",
+            "surface": "Surface",
             "status": "Status"
         },
         "upstream": {
@@ -1345,6 +1346,9 @@
             "server": "Server",
             "client": "Client"
         },
+        "authoringSurfaces": {
+            "playcanvasEditor": "Editor"
+        },
         "status": {
             "connected": "Connected",
             "available": "Available"
@@ -1353,7 +1357,27 @@
             "attach": "Connect package",
             "attachNamed": "Connect {{packageName}}",
             "detach": "Disconnect package",
-            "detachNamed": "Disconnect {{packageName}}"
+            "detachNamed": "Disconnect {{packageName}}",
+            "moreNamed": "Actions for {{packageName}}",
+            "openEditor": "Open editor",
+            "settings": "Settings"
+        },
+        "displayModes": {
+            "disabled": "Disabled",
+            "embeddedIframe": "Embedded",
+            "openSeparately": "Open separately",
+            "developmentUrl": "Development URL"
+        },
+        "settings": {
+            "displayMode": "Display mode",
+            "developmentUrl": "Development URL",
+            "developmentUrlHelper": "Allowed origins are enforced by the server.",
+            "developmentUrlDisabled": "Development URL mode is disabled on this server.",
+            "showArtifactOnlyNotice": "Show artifact status notice",
+            "validation": {
+                "developmentUrlRequired": "Enter a development URL.",
+                "developmentUrlInvalid": "Enter a valid http or https URL."
+            }
         },
         "dialogs": {
             "cancel": "Cancel",
@@ -1364,19 +1388,43 @@
             "changeVersion": {
                 "title": "Change package version",
                 "description": "Switch {{packageName}} from version {{currentVersion}} to {{nextVersion}}.",
+                "resetConfig": "Reset package display settings to defaults",
+                "resetConfigHelper": "Use this when the current display settings are not compatible with the selected version.",
                 "confirm": "Change version"
             },
             "detach": {
                 "title": "Disconnect package",
                 "description": "Disconnect {{packageName}} from this metahub. Modules that expect it will no longer receive this package version during runtime sync.",
                 "deleting": "Disconnecting..."
+            },
+            "settings": {
+                "title": "Package display settings",
+                "description": "Choose how {{packageName}} opens for this metahub.",
+                "reset": "Reset to defaults",
+                "save": "Save settings"
             }
         },
         "notifications": {
             "attached": "Package connected",
             "detached": "Package disconnected",
+            "settingsSaved": "Package settings saved",
             "versionChanged": "Package version updated",
             "mutationFailed": "Package operation failed. Please refresh and try again."
+        },
+        "editorHost": {
+            "fallbackName": "Package editor",
+            "loading": "Loading editor...",
+            "loadError": "Failed to load editor settings.",
+            "permissionDenied": "You do not have permission to open this editor.",
+            "disabled": "This editor is disabled for the metahub.",
+            "artifactMissing": "The editor artifact is not available yet.",
+            "misconfigured": "Editor display settings are incomplete.",
+            "openSeparately": "This editor is configured to open separately.",
+            "backToPackages": "Back to packages",
+            "frameLoading": "Loading editor frame...",
+            "frameLoadError": "The editor frame could not be loaded.",
+            "developmentNotice": "Development URL mode is active.",
+            "artifactReady": "Editor artifact is ready."
         },
         "empty": {
             "title": "No packages available",

--- a/packages/universo-react-metahubs-frontend/src/i18n/locales/ru/metahubs.json
+++ b/packages/universo-react-metahubs-frontend/src/i18n/locales/ru/metahubs.json
@@ -1348,14 +1348,18 @@
             "version": "Версия",
             "upstream": "Зависимость",
             "targets": "Среда",
+            "surface": "Поверхность",
             "status": "Статус"
         },
         "upstream": {
-            "pinnedVersion": "Закреплённая upstream-версия"
+            "pinnedVersion": "Закреплённая версия исходной зависимости"
         },
         "runtimeTargets": {
             "server": "Сервер",
             "client": "Клиент"
+        },
+        "authoringSurfaces": {
+            "playcanvasEditor": "Редактор"
         },
         "status": {
             "connected": "Подключён",
@@ -1365,7 +1369,27 @@
             "attach": "Подключить пакет",
             "attachNamed": "Подключить {{packageName}}",
             "detach": "Отключить пакет",
-            "detachNamed": "Отключить {{packageName}}"
+            "detachNamed": "Отключить {{packageName}}",
+            "moreNamed": "Действия для {{packageName}}",
+            "openEditor": "Открыть редактор",
+            "settings": "Настройки"
+        },
+        "displayModes": {
+            "disabled": "Отключён",
+            "embeddedIframe": "Встроенный",
+            "openSeparately": "Открывать отдельно",
+            "developmentUrl": "Адрес разработки"
+        },
+        "settings": {
+            "displayMode": "Режим отображения",
+            "developmentUrl": "Адрес разработки",
+            "developmentUrlHelper": "Разрешённые источники проверяются сервером.",
+            "developmentUrlDisabled": "Режим адреса разработки отключён на этом сервере.",
+            "showArtifactOnlyNotice": "Показывать статус артефакта",
+            "validation": {
+                "developmentUrlRequired": "Введите адрес разработки.",
+                "developmentUrlInvalid": "Введите корректный адрес с http или https."
+            }
         },
         "dialogs": {
             "cancel": "Отмена",
@@ -1376,19 +1400,43 @@
             "changeVersion": {
                 "title": "Изменить версию пакета",
                 "description": "Переключить {{packageName}} с версии {{currentVersion}} на {{nextVersion}}.",
+                "resetConfig": "Сбросить настройки отображения пакета к значениям по умолчанию",
+                "resetConfigHelper": "Используйте это, если текущие настройки отображения несовместимы с выбранной версией.",
                 "confirm": "Изменить версию"
             },
             "detach": {
                 "title": "Отключить пакет",
                 "description": "Отключить {{packageName}} от этого метахаба. Модули, которым нужен этот пакет, больше не получат его версию при синхронизации среды выполнения.",
                 "deleting": "Отключение..."
+            },
+            "settings": {
+                "title": "Настройки отображения пакета",
+                "description": "Выберите, как {{packageName}} открывается для этого метахаба.",
+                "reset": "Сбросить по умолчанию",
+                "save": "Сохранить настройки"
             }
         },
         "notifications": {
             "attached": "Пакет подключён",
             "detached": "Пакет отключён",
+            "settingsSaved": "Настройки пакета сохранены",
             "versionChanged": "Версия пакета обновлена",
             "mutationFailed": "Не удалось выполнить операцию с пакетом. Обновите страницу и попробуйте ещё раз."
+        },
+        "editorHost": {
+            "fallbackName": "Редактор пакета",
+            "loading": "Загрузка редактора...",
+            "loadError": "Не удалось загрузить настройки редактора.",
+            "permissionDenied": "У вас нет прав для открытия этого редактора.",
+            "disabled": "Редактор отключён для этого метахаба.",
+            "artifactMissing": "Артефакт редактора пока недоступен.",
+            "misconfigured": "Настройки отображения редактора заполнены не полностью.",
+            "openSeparately": "Редактор настроен на открытие отдельно.",
+            "backToPackages": "Назад к пакетам",
+            "frameLoading": "Загрузка фрейма редактора...",
+            "frameLoadError": "Не удалось загрузить фрейм редактора.",
+            "developmentNotice": "Активен режим адреса разработки.",
+            "artifactReady": "Артефакт редактора готов."
         },
         "empty": {
             "title": "Нет доступных пакетов",

--- a/packages/universo-react-metahubs-frontend/src/index.ts
+++ b/packages/universo-react-metahubs-frontend/src/index.ts
@@ -20,6 +20,7 @@ import ComponentListComponent from './domains/entities/metadata/component/ui/Com
 import RecordListComponent from './domains/entities/metadata/record/ui/RecordList'
 import FixedValueListComponent from './domains/entities/metadata/fixedValue/ui/FixedValueList'
 import SharedResourcesPageComponent from './domains/entities/shared/ui/SharedResourcesPage'
+import PlayCanvasEditorHostPageComponent from './domains/packages/ui/PlayCanvasEditorHostPage'
 import MetahubLayoutsComponent from './domains/layouts/ui/LayoutList'
 import MetahubLayoutDetailsComponent from './domains/layouts/ui/LayoutDetails'
 import SettingsPageComponent from './domains/settings/ui/SettingsPage'
@@ -51,6 +52,7 @@ export const ComponentList = withMetahubDialogSettings(ComponentListComponent)
 export const RecordList = withMetahubDialogSettings(RecordListComponent)
 export const FixedValueList = withMetahubDialogSettings(FixedValueListComponent)
 export const MetahubResources = withMetahubDialogSettings(SharedResourcesPageComponent)
+export const PlayCanvasEditorHostPage = withMetahubDialogSettings(PlayCanvasEditorHostPageComponent)
 export const MetahubLayouts = withMetahubDialogSettings(MetahubLayoutsComponent)
 export const MetahubLayoutDetails = withMetahubDialogSettings(MetahubLayoutDetailsComponent)
 

--- a/packages/universo-react-migrations-platform/src/__tests__/platformMigrations.test.ts
+++ b/packages/universo-react-migrations-platform/src/__tests__/platformMigrations.test.ts
@@ -435,7 +435,9 @@ describe('platformMigrations', () => {
             'FinalizeApplicationsSchemaSupport1800000000001',
             'AddApplicationSettings1800000000100',
             'OptimizeRlsPolicies1800000000200',
-            'SeedBuiltinMetahubTemplates1800000000250'
+            'SeedBuiltinMetahubTemplates1800000000250',
+            'SeedBuiltinMetahubPackages1800000000260',
+            'AddMetahubPackageAuthoringSettings1800000000270'
         ])
     })
 

--- a/packages/universo-react-playcanvas-editor/e2e/editor-artifact.spec.ts
+++ b/packages/universo-react-playcanvas-editor/e2e/editor-artifact.spec.ts
@@ -26,7 +26,17 @@ test('PlayCanvas Editor artifact smoke page is safe and nonblank', async ({ page
     expect(rootResponse?.headers()['cache-control']).toBe('no-cache')
 
     await expect(page.getByRole('heading', { name: 'PlayCanvas Editor artifact is available' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Артефакт PlayCanvas Editor доступен' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Артефакт PlayCanvas Editor доступен' })).toBeHidden()
+    const previewCanvas = page.getByLabel('PlayCanvas Editor artifact preview')
+    await expect(previewCanvas).toBeVisible()
+    const isCanvasNonBlank = await previewCanvas.evaluate((node) => {
+        const canvas = node as HTMLCanvasElement
+        const context = canvas.getContext('2d')
+        if (!context) return false
+        const sample = context.getImageData(0, 0, canvas.width, canvas.height).data
+        return sample.some((channel) => channel !== 0)
+    })
+    expect(isCanvasNonBlank).toBe(true)
     await expect(page.locator('body')).not.toContainText('[object Object]')
     await expect(page.locator('body')).not.toContainText(/\{[\s\S]*"[^"]+"\s*:/)
     await expect(page.locator('body')).not.toContainText(/stack trace|Zod|Vite|absolute filesystem/i)
@@ -62,4 +72,13 @@ test('PlayCanvas Editor artifact smoke page is safe and nonblank', async ({ page
     await page.screenshot({ path: testInfo.outputPath(`playcanvas-editor-artifact-smoke-${testInfo.project.name}.png`), fullPage: true })
     expect(consoleErrors).toEqual([])
     expect(failedRequests).toEqual([])
+})
+
+test('PlayCanvas Editor artifact smoke page shows only the requested locale', async ({ page }) => {
+    const response = await page.goto('/?locale=ru', { waitUntil: 'networkidle' })
+    expect(response?.ok()).toBe(true)
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ru')
+    await expect(page.getByRole('heading', { name: 'Артефакт PlayCanvas Editor доступен' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'PlayCanvas Editor artifact is available' })).toBeHidden()
 })

--- a/packages/universo-react-playcanvas-editor/scripts/lib/playcanvas-editor-artifact.mjs
+++ b/packages/universo-react-playcanvas-editor/scripts/lib/playcanvas-editor-artifact.mjs
@@ -208,23 +208,50 @@ export const writeSafeUnavailablePage = (targetRoot) => {
     main { max-width: 760px; padding: 32px; line-height: 1.5; }
     h1 { font-size: 24px; margin: 0 0 16px; }
     p { margin: 0 0 12px; overflow-wrap: anywhere; }
-    [lang="ru"] { margin-top: 24px; }
+    [data-locale-panel][hidden] { display: none; }
     code { background: rgba(30, 41, 59, 0.08); padding: 2px 6px; border-radius: 4px; }
+    canvas { display: block; width: min(100%, 560px); height: 180px; margin: 0 0 24px; border-radius: 6px; background: #101828; }
   </style>
+
 </head>
 <body>
   <main>
-    <section lang="en" aria-labelledby="playcanvas-editor-artifact-title-en">
+    <canvas width="560" height="180" aria-label="PlayCanvas Editor artifact preview"></canvas>
+    <section lang="en" data-locale-panel="en" aria-labelledby="playcanvas-editor-artifact-title-en">
       <h1 id="playcanvas-editor-artifact-title-en">PlayCanvas Editor artifact is available</h1>
-      <p>The static frontend artifact was built, but this foundation package is not connected to PlayCanvas-hosted or Universo-backed project persistence yet.</p>
-      <p>Smoke mode: <code>artifact-only</code>.</p>
+      <p>The editor files are ready. Project saving, assets, and collaboration are not connected in this integration step yet.</p>
     </section>
-    <section lang="ru" aria-labelledby="playcanvas-editor-artifact-title-ru">
+    <section lang="ru" data-locale-panel="ru" hidden aria-labelledby="playcanvas-editor-artifact-title-ru">
       <h1 id="playcanvas-editor-artifact-title-ru">Артефакт PlayCanvas Editor доступен</h1>
-      <p>Static frontend artifact собран, но этот foundation-пакет ещё не подключён к PlayCanvas-hosted или Universo-backed сохранению проектов.</p>
-      <p>Режим smoke-проверки: <code>artifact-only</code>.</p>
+      <p>Файлы редактора готовы. Сохранение проектов, ассеты и совместная работа пока не подключены на этом шаге интеграции.</p>
     </section>
   </main>
+  <script>
+const canvas = document.querySelector('canvas');
+const params = new URLSearchParams(window.location.search);
+const locale = params.get('locale') === 'ru' ? 'ru' : 'en';
+document.documentElement.lang = locale;
+for (const panel of document.querySelectorAll('[data-locale-panel]')) {
+  panel.hidden = panel.getAttribute('data-locale-panel') !== locale;
+}
+if (canvas) {
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+  gradient.addColorStop(0, '#1d4ed8');
+  gradient.addColorStop(0.5, '#14b8a6');
+  gradient.addColorStop(1, '#f59e0b');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.92)';
+  ctx.font = '600 22px Arial, sans-serif';
+  ctx.fillText('PlayCanvas Editor', 28, 58);
+  ctx.font = '16px Arial, sans-serif';
+  ctx.fillText('Artifact-only integration surface', 28, 92);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.56)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(24, 24, canvas.width - 48, canvas.height - 48);
+}
+  </script>
 </body>
 </html>
 `

--- a/packages/universo-react-rest-docs/scripts/generate-openapi-source.js
+++ b/packages/universo-react-rest-docs/scripts/generate-openapi-source.js
@@ -219,7 +219,8 @@ const routeSources = [
         file: 'packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts',
         mountPrefix: '',
         tag: 'Packages',
-        security: bearerSecurity
+        security: bearerSecurity,
+        publicPathMatchers: [/^\/metahub\/:metahubId\/packages\/:packageSlug\/editor-artifact-token\//]
     },
     {
         file: 'packages/universo-react-metahubs-backend/src/domains/shared/routes/sharedEntityOverridesRoutes.ts',
@@ -323,6 +324,87 @@ const buildRequestBody = () => ({
     }
 })
 
+const jsonSchemaRef = (schemaName) => ({
+    content: {
+        'application/json': {
+            schema: { $ref: `#/components/schemas/${schemaName}` }
+        }
+    }
+})
+
+const successResponse = (schemaName, description = 'Successful response.') => ({
+    description,
+    ...jsonSchemaRef(schemaName)
+})
+
+const createdResponse = (schemaName) => successResponse(schemaName, 'Successful create or action response.')
+
+const packageOperationOverrides = {
+    'GET /metahub/{metahubId}/packages': {
+        responses: {
+            200: successResponse('MetahubPackageAttachmentListResponse')
+        }
+    },
+    'POST /metahub/{metahubId}/packages': {
+        requestBody: {
+            required: true,
+            ...jsonSchemaRef('PackageAttachRequest')
+        },
+        responses: {
+            201: createdResponse('MetahubPackageAttachment')
+        }
+    },
+    'GET /metahub/{metahubId}/packages/catalog': {
+        responses: {
+            200: successResponse('MetahubPackageCatalogResponse')
+        }
+    },
+    'GET /metahub/{metahubId}/packages/{packageSlug}/authoring-host': {
+        responses: {
+            200: successResponse('PackageAuthoringHostDescriptor')
+        }
+    },
+    'GET /metahub/{metahubId}/packages/{packageSlug}/editor-artifact-token/{artifactToken}/*': {
+        responses: {
+            200: { $ref: '#/components/responses/GenericSuccess' }
+        }
+    },
+    'PATCH /metahub/{metahubId}/package/{attachmentId}': {
+        requestBody: {
+            required: true,
+            ...jsonSchemaRef('PackageChangeVersionRequest')
+        },
+        responses: {
+            200: successResponse('MetahubPackageAttachment')
+        }
+    },
+    'PATCH /metahub/{metahubId}/package/{attachmentId}/config': {
+        requestBody: {
+            required: true,
+            ...jsonSchemaRef('PackageUpdateConfigRequest')
+        },
+        responses: {
+            200: successResponse('MetahubPackageAttachment')
+        }
+    }
+}
+
+const applyOperationOverride = (openApiOperation, method, openApiPath) => {
+    const override = packageOperationOverrides[`${method.toUpperCase()} ${openApiPath}`]
+    if (!override) {
+        return openApiOperation
+    }
+
+    return {
+        ...openApiOperation,
+        ...('requestBody' in override ? { requestBody: override.requestBody } : {}),
+        responses: {
+            ...openApiOperation.responses,
+            ...override.responses
+        }
+    }
+}
+
 const parseRoutePaths = (fileContent) => {
     const operations = []
     const routeRegex = /router\.(get|post|put|patch|delete)\(\s*(\[[\s\S]*?\]|'[^']+'|"[^"]+")/g
@@ -362,18 +444,22 @@ const buildSpec = () => {
                 operationsByPath.set(openApiPath, {})
             }
 
-            operationsByPath.get(openApiPath)[operation.method] = {
-                tags: [source.tag],
-                summary: `${operation.method.toUpperCase()} ${openApiPath}`,
-                description: `Auto-generated from ${source.file}. This operation is mounted on the live backend route surface and should be treated as current repository truth.`,
-                operationId: sanitizeOperationId(`${source.tag}_${operation.method}_${openApiPath}`),
-                parameters: buildParameters(concretePath),
-                responses: buildResponses(operation.method, isSecure),
-                ...(operation.method === 'post' || operation.method === 'put' || operation.method === 'patch'
-                    ? { requestBody: buildRequestBody() }
-                    : {}),
-                ...(isSecure ? { security } : {})
-            }
+            operationsByPath.get(openApiPath)[operation.method] = applyOperationOverride(
+                {
+                    tags: [source.tag],
+                    summary: `${operation.method.toUpperCase()} ${openApiPath}`,
+                    description: `Auto-generated from ${source.file}. This operation is mounted on the live backend route surface and should be treated as current repository truth.`,
+                    operationId: sanitizeOperationId(`${source.tag}_${operation.method}_${openApiPath}`),
+                    parameters: buildParameters(concretePath),
+                    responses: buildResponses(operation.method, isSecure),
+                    ...(operation.method === 'post' || operation.method === 'put' || operation.method === 'patch'
+                        ? { requestBody: buildRequestBody() }
+                        : {}),
+                    ...(isSecure ? { security } : {})
+                },
+                operation.method,
+                openApiPath
+            )
         }
     }
 
@@ -438,6 +524,235 @@ const buildSpec = () => {
                     additionalProperties: true,
                     description:
                         'Generic JSON object used where the route inventory is current but payload-specific schemas remain handler-defined.'
+                },
+                VersionedLocalizedContent: {
+                    type: 'object',
+                    additionalProperties: { type: 'string' },
+                    properties: {
+                        en: { type: 'string' },
+                        ru: { type: 'string' }
+                    },
+                    description: 'Localized package label or description map keyed by locale code.'
+                },
+                PackageDisplayMode: {
+                    type: 'string',
+                    enum: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'],
+                    description: 'Metahub authoring display mode for an attached package.'
+                },
+                PackageAttachmentEmptyConfig: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        schemaVersion: { type: 'string', enum: ['1'] },
+                        kind: { type: 'string', enum: ['none'] }
+                    },
+                    required: ['schemaVersion', 'kind'],
+                    description: 'Package configuration for packages without a user-visible authoring surface.'
+                },
+                PackageAttachmentDisplaySettings: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        mode: { $ref: '#/components/schemas/PackageDisplayMode' },
+                        developmentUrl: {
+                            type: ['string', 'null'],
+                            format: 'uri',
+                            description:
+                                'Optional trusted development URL used only when the package is configured for development hosting.'
+                        },
+                        showArtifactOnlyNotice: {
+                            type: 'boolean',
+                            description: 'Whether the host should show that only the isolated editor artifact is available.'
+                        }
+                    },
+                    required: ['mode', 'showArtifactOnlyNotice'],
+                    description: 'Display settings for a package authoring surface.'
+                },
+                PackageAttachmentDisplayConfig: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        schemaVersion: { type: 'string', enum: ['1'] },
+                        kind: { type: 'string', enum: ['display'] },
+                        display: { $ref: '#/components/schemas/PackageAttachmentDisplaySettings' }
+                    },
+                    required: ['schemaVersion', 'kind', 'display'],
+                    description: 'Package configuration for packages with a user-visible authoring surface.'
+                },
+                PackageAttachmentConfig: {
+                    oneOf: [
+                        { $ref: '#/components/schemas/PackageAttachmentEmptyConfig' },
+                        { $ref: '#/components/schemas/PackageAttachmentDisplayConfig' }
+                    ],
+                    description: 'Mutable metahub-scoped package configuration.'
+                },
+                PackageAuthoringSurfaceDescriptor: {
+                    type: 'object',
+                    additionalProperties: true,
+                    properties: {
+                        schemaVersion: { type: 'string', enum: ['1'] },
+                        kind: { type: 'string', enum: ['none', 'playcanvasEditor'] },
+                        packageSlug: { type: 'string' },
+                        supportedDisplayModes: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/PackageDisplayMode' }
+                        },
+                        defaultConfig: { $ref: '#/components/schemas/PackageAttachmentConfig' }
+                    },
+                    required: ['schemaVersion', 'kind', 'supportedDisplayModes', 'defaultConfig'],
+                    description: 'Authoring surface metadata exposed by a package catalog item.'
+                },
+                PackageSourceDescriptor: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        kind: { type: 'string', enum: ['workspace'] },
+                        packageName: { type: 'string' },
+                        importName: { type: 'string' },
+                        upstreamPackageName: { type: 'string' },
+                        upstreamVersion: { type: 'string' },
+                        runtimeTargets: {
+                            type: 'array',
+                            items: { type: 'string', enum: ['server', 'client'] }
+                        }
+                    },
+                    required: ['kind', 'packageName', 'importName', 'upstreamPackageName', 'upstreamVersion', 'runtimeTargets'],
+                    description: 'Package source metadata used by package registry and attachment responses.'
+                },
+                MetahubPackageAttachment: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: 'string' },
+                        metahubId: { type: 'string' },
+                        packageId: { type: 'string' },
+                        packageName: { type: 'string' },
+                        version: { type: 'string' },
+                        displayName: { $ref: '#/components/schemas/VersionedLocalizedContent' },
+                        description: { $ref: '#/components/schemas/VersionedLocalizedContent' },
+                        source: { $ref: '#/components/schemas/PackageSourceDescriptor' },
+                        authoringSurface: { $ref: '#/components/schemas/PackageAuthoringSurfaceDescriptor' },
+                        config: { $ref: '#/components/schemas/PackageAttachmentConfig' },
+                        attachedAt: { type: 'string', format: 'date-time' },
+                        isActive: { type: 'boolean' }
+                    },
+                    required: [
+                        'id',
+                        'metahubId',
+                        'packageId',
+                        'packageName',
+                        'version',
+                        'displayName',
+                        'source',
+                        'authoringSurface',
+                        'config',
+                        'attachedAt',
+                        'isActive'
+                    ],
+                    description: 'Package attached to a metahub with metahub-scoped authoring settings.'
+                },
+                MetahubPackageCatalogItem: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: 'string' },
+                        packageName: { type: 'string' },
+                        version: { type: 'string' },
+                        displayName: { $ref: '#/components/schemas/VersionedLocalizedContent' },
+                        description: { $ref: '#/components/schemas/VersionedLocalizedContent' },
+                        source: { $ref: '#/components/schemas/PackageSourceDescriptor' },
+                        authoringSurface: { $ref: '#/components/schemas/PackageAuthoringSurfaceDescriptor' },
+                        isActive: { type: 'boolean' },
+                        attached: { type: 'boolean' },
+                        attachedPackageId: { type: ['string', 'null'] },
+                        attachedVersion: { type: ['string', 'null'] },
+                        attachmentId: { type: ['string', 'null'] }
+                    },
+                    required: ['id', 'packageName', 'version', 'displayName', 'source', 'authoringSurface', 'isActive', 'attached'],
+                    description: 'Package available for attachment from the metahub package catalog.'
+                },
+                MetahubPackageAttachmentListResponse: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        items: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/MetahubPackageAttachment' }
+                        },
+                        total: { type: 'integer', minimum: 0 }
+                    },
+                    required: ['items', 'total']
+                },
+                MetahubPackageCatalogResponse: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        items: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/MetahubPackageCatalogItem' }
+                        },
+                        total: { type: 'integer', minimum: 0 }
+                    },
+                    required: ['items', 'total']
+                },
+                PackageAttachRequest: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        packageName: { type: 'string' },
+                        version: { type: 'string' }
+                    },
+                    required: ['packageName']
+                },
+                PackageChangeVersionRequest: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        version: { type: 'string' },
+                        resetConfig: { type: 'boolean' }
+                    },
+                    required: ['version']
+                },
+                PackageUpdateConfigRequest: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        config: { $ref: '#/components/schemas/PackageAttachmentConfig' }
+                    },
+                    required: ['config']
+                },
+                PackageAuthoringHostDescriptor: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                        packageSlug: { type: 'string' },
+                        packageName: { type: 'string' },
+                        version: { type: 'string' },
+                        displayName: { $ref: '#/components/schemas/VersionedLocalizedContent' },
+                        description: { $ref: '#/components/schemas/VersionedLocalizedContent' },
+                        attachmentConfig: { $ref: '#/components/schemas/PackageAttachmentConfig' },
+                        authoringSurface: { $ref: '#/components/schemas/PackageAuthoringSurfaceDescriptor' },
+                        allowedDisplayModes: {
+                            type: 'array',
+                            items: { $ref: '#/components/schemas/PackageDisplayMode' }
+                        },
+                        artifactStatus: {
+                            type: 'string',
+                            enum: ['available', 'missing', 'disabled', 'blocked', 'misconfigured']
+                        },
+                        artifactUrl: { type: ['string', 'null'] }
+                    },
+                    required: [
+                        'packageSlug',
+                        'packageName',
+                        'version',
+                        'displayName',
+                        'attachmentConfig',
+                        'authoringSurface',
+                        'allowedDisplayModes',
+                        'artifactStatus'
+                    ],
+                    description: 'Descriptor consumed by the metahub package authoring host route.'
                 },
                 ApiError: {
                     type: 'object',

--- a/packages/universo-react-rest-docs/src/openapi/index.yml
+++ b/packages/universo-react-rest-docs/src/openapi/index.yml
@@ -10420,7 +10420,11 @@ paths:
           description: attachmentId path parameter.
       responses:
         "200":
-          $ref: "#/components/responses/GenericSuccess"
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetahubPackageAttachment"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -10436,11 +10440,11 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GenericObject"
+              $ref: "#/components/schemas/PackageChangeVersionRequest"
       security: *a1
     delete:
       tags:
@@ -10484,6 +10488,57 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
       security: *a1
+  /metahub/{metahubId}/package/{attachmentId}/config:
+    patch:
+      tags:
+        - Packages
+      summary: PATCH /metahub/{metahubId}/package/{attachmentId}/config
+      description: Auto-generated from
+        packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts.
+        This operation is mounted on the live backend route surface and should
+        be treated as current repository truth.
+      operationId: Packages_patch_metahub_metahubId_package_attachmentId_config
+      parameters:
+        - name: metahubId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: metahubId path parameter.
+        - name: attachmentId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: attachmentId path parameter.
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetahubPackageAttachment"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PackageUpdateConfigRequest"
+      security: *a1
   /metahub/{metahubId}/packages:
     get:
       tags:
@@ -10503,7 +10558,11 @@ paths:
           description: metahubId path parameter.
       responses:
         "200":
-          $ref: "#/components/responses/GenericSuccess"
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetahubPackageAttachmentListResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -10539,7 +10598,11 @@ paths:
         "200":
           $ref: "#/components/responses/GenericSuccess"
         "201":
-          $ref: "#/components/responses/CreatedSuccess"
+          description: Successful create or action response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetahubPackageAttachment"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -10555,11 +10618,140 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GenericObject"
+              $ref: "#/components/schemas/PackageAttachRequest"
+      security: *a1
+  /metahub/{metahubId}/packages/{packageSlug}/authoring-host:
+    get:
+      tags:
+        - Packages
+      summary: GET /metahub/{metahubId}/packages/{packageSlug}/authoring-host
+      description: Auto-generated from
+        packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts.
+        This operation is mounted on the live backend route surface and should
+        be treated as current repository truth.
+      operationId: Packages_get_metahub_metahubId_packages_packageSlug_authoring_host
+      parameters:
+        - name: metahubId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: metahubId path parameter.
+        - name: packageSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: packageSlug path parameter.
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PackageAuthoringHostDescriptor"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+      security: *a1
+  /metahub/{metahubId}/packages/{packageSlug}/editor-artifact-token/{artifactToken}/*:
+    get:
+      tags:
+        - Packages
+      summary: GET
+        /metahub/{metahubId}/packages/{packageSlug}/editor-artifact-token/{artifactToken}/*
+      description: Auto-generated from
+        packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts.
+        This operation is mounted on the live backend route surface and should
+        be treated as current repository truth.
+      operationId: Packages_get_metahub_metahubId_packages_packageSlug_editor_artifact_token_artifactToken
+      parameters:
+        - name: metahubId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: metahubId path parameter.
+        - name: packageSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: packageSlug path parameter.
+        - name: artifactToken
+          in: path
+          required: true
+          schema:
+            type: string
+          description: artifactToken path parameter.
+      responses:
+        "200":
+          $ref: "#/components/responses/GenericSuccess"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /metahub/{metahubId}/packages/{packageSlug}/editor-artifact/*:
+    get:
+      tags:
+        - Packages
+      summary: GET /metahub/{metahubId}/packages/{packageSlug}/editor-artifact/*
+      description: Auto-generated from
+        packages/universo-react-metahubs-backend/src/domains/packages/routes/packagesRoutes.ts.
+        This operation is mounted on the live backend route surface and should
+        be treated as current repository truth.
+      operationId: Packages_get_metahub_metahubId_packages_packageSlug_editor_artifact
+      parameters:
+        - name: metahubId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: metahubId path parameter.
+        - name: packageSlug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: packageSlug path parameter.
+      responses:
+        "200":
+          $ref: "#/components/responses/GenericSuccess"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
       security: *a1
   /metahub/{metahubId}/packages/catalog:
     get:
@@ -10580,7 +10772,11 @@ paths:
           description: metahubId path parameter.
       responses:
         "200":
-          $ref: "#/components/responses/GenericSuccess"
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetahubPackageCatalogResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -12645,6 +12841,331 @@ components:
       additionalProperties: true
       description: Generic JSON object used where the route inventory is current but
         payload-specific schemas remain handler-defined.
+    VersionedLocalizedContent:
+      type: object
+      additionalProperties:
+        type: string
+      properties:
+        en:
+          type: string
+        ru:
+          type: string
+      description: Localized package label or description map keyed by locale code.
+    PackageDisplayMode:
+      type: string
+      enum:
+        - disabled
+        - embeddedIframe
+        - openSeparately
+        - developmentUrl
+      description: Metahub authoring display mode for an attached package.
+    PackageAttachmentEmptyConfig:
+      type: object
+      additionalProperties: false
+      properties:
+        schemaVersion:
+          type: string
+          enum:
+            - "1"
+        kind:
+          type: string
+          enum:
+            - none
+      required:
+        - schemaVersion
+        - kind
+      description: Package configuration for packages without a user-visible authoring
+        surface.
+    PackageAttachmentDisplaySettings:
+      type: object
+      additionalProperties: false
+      properties:
+        mode:
+          $ref: "#/components/schemas/PackageDisplayMode"
+        developmentUrl:
+          type:
+            - string
+            - "null"
+          format: uri
+          description: Optional trusted development URL used only when the package is
+            configured for development hosting.
+        showArtifactOnlyNotice:
+          type: boolean
+          description: Whether the host should show that only the isolated editor artifact
+            is available.
+      required:
+        - mode
+        - showArtifactOnlyNotice
+      description: Display settings for a package authoring surface.
+    PackageAttachmentDisplayConfig:
+      type: object
+      additionalProperties: false
+      properties:
+        schemaVersion:
+          type: string
+          enum:
+            - "1"
+        kind:
+          type: string
+          enum:
+            - display
+        display:
+          $ref: "#/components/schemas/PackageAttachmentDisplaySettings"
+      required:
+        - schemaVersion
+        - kind
+        - display
+      description: Package configuration for packages with a user-visible authoring surface.
+    PackageAttachmentConfig:
+      oneOf:
+        - $ref: "#/components/schemas/PackageAttachmentEmptyConfig"
+        - $ref: "#/components/schemas/PackageAttachmentDisplayConfig"
+      description: Mutable metahub-scoped package configuration.
+    PackageAuthoringSurfaceDescriptor:
+      type: object
+      additionalProperties: true
+      properties:
+        schemaVersion:
+          type: string
+          enum:
+            - "1"
+        kind:
+          type: string
+          enum:
+            - none
+            - playcanvasEditor
+        packageSlug:
+          type: string
+        supportedDisplayModes:
+          type: array
+          items:
+            $ref: "#/components/schemas/PackageDisplayMode"
+        defaultConfig:
+          $ref: "#/components/schemas/PackageAttachmentConfig"
+      required:
+        - schemaVersion
+        - kind
+        - supportedDisplayModes
+        - defaultConfig
+      description: Authoring surface metadata exposed by a package catalog item.
+    PackageSourceDescriptor:
+      type: object
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          enum:
+            - workspace
+        packageName:
+          type: string
+        importName:
+          type: string
+        upstreamPackageName:
+          type: string
+        upstreamVersion:
+          type: string
+        runtimeTargets:
+          type: array
+          items:
+            type: string
+            enum:
+              - server
+              - client
+      required:
+        - kind
+        - packageName
+        - importName
+        - upstreamPackageName
+        - upstreamVersion
+        - runtimeTargets
+      description: Package source metadata used by package registry and attachment
+        responses.
+    MetahubPackageAttachment:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        metahubId:
+          type: string
+        packageId:
+          type: string
+        packageName:
+          type: string
+        version:
+          type: string
+        displayName:
+          $ref: "#/components/schemas/VersionedLocalizedContent"
+        description:
+          $ref: "#/components/schemas/VersionedLocalizedContent"
+        source:
+          $ref: "#/components/schemas/PackageSourceDescriptor"
+        authoringSurface:
+          $ref: "#/components/schemas/PackageAuthoringSurfaceDescriptor"
+        config:
+          $ref: "#/components/schemas/PackageAttachmentConfig"
+        attachedAt:
+          type: string
+          format: date-time
+        isActive:
+          type: boolean
+      required:
+        - id
+        - metahubId
+        - packageId
+        - packageName
+        - version
+        - displayName
+        - source
+        - authoringSurface
+        - config
+        - attachedAt
+        - isActive
+      description: Package attached to a metahub with metahub-scoped authoring settings.
+    MetahubPackageCatalogItem:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        packageName:
+          type: string
+        version:
+          type: string
+        displayName:
+          $ref: "#/components/schemas/VersionedLocalizedContent"
+        description:
+          $ref: "#/components/schemas/VersionedLocalizedContent"
+        source:
+          $ref: "#/components/schemas/PackageSourceDescriptor"
+        authoringSurface:
+          $ref: "#/components/schemas/PackageAuthoringSurfaceDescriptor"
+        isActive:
+          type: boolean
+        attached:
+          type: boolean
+        attachedPackageId:
+          type:
+            - string
+            - "null"
+        attachedVersion:
+          type:
+            - string
+            - "null"
+        attachmentId:
+          type:
+            - string
+            - "null"
+      required:
+        - id
+        - packageName
+        - version
+        - displayName
+        - source
+        - authoringSurface
+        - isActive
+        - attached
+      description: Package available for attachment from the metahub package catalog.
+    MetahubPackageAttachmentListResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetahubPackageAttachment"
+        total:
+          type: integer
+          minimum: 0
+      required:
+        - items
+        - total
+    MetahubPackageCatalogResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetahubPackageCatalogItem"
+        total:
+          type: integer
+          minimum: 0
+      required:
+        - items
+        - total
+    PackageAttachRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        packageName:
+          type: string
+        version:
+          type: string
+      required:
+        - packageName
+    PackageChangeVersionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        version:
+          type: string
+        resetConfig:
+          type: boolean
+      required:
+        - version
+    PackageUpdateConfigRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        config:
+          $ref: "#/components/schemas/PackageAttachmentConfig"
+      required:
+        - config
+    PackageAuthoringHostDescriptor:
+      type: object
+      additionalProperties: false
+      properties:
+        packageSlug:
+          type: string
+        packageName:
+          type: string
+        version:
+          type: string
+        displayName:
+          $ref: "#/components/schemas/VersionedLocalizedContent"
+        description:
+          $ref: "#/components/schemas/VersionedLocalizedContent"
+        attachmentConfig:
+          $ref: "#/components/schemas/PackageAttachmentConfig"
+        authoringSurface:
+          $ref: "#/components/schemas/PackageAuthoringSurfaceDescriptor"
+        allowedDisplayModes:
+          type: array
+          items:
+            $ref: "#/components/schemas/PackageDisplayMode"
+        artifactStatus:
+          type: string
+          enum:
+            - available
+            - missing
+            - disabled
+            - blocked
+            - misconfigured
+        artifactUrl:
+          type:
+            - string
+            - "null"
+      required:
+        - packageSlug
+        - packageName
+        - version
+        - displayName
+        - attachmentConfig
+        - authoringSurface
+        - allowedDisplayModes
+        - artifactStatus
+      description: Descriptor consumed by the metahub package authoring host route.
     ApiError:
       type: object
       additionalProperties: true

--- a/packages/universo-react-types/src/common/packages.ts
+++ b/packages/universo-react-types/src/common/packages.ts
@@ -6,6 +6,67 @@ export type MetahubPackageSourceKind = (typeof METAHUB_PACKAGE_SOURCE_KINDS)[num
 export const METAHUB_PACKAGE_RUNTIME_TARGETS = ['server', 'client'] as const
 export type MetahubPackageRuntimeTarget = (typeof METAHUB_PACKAGE_RUNTIME_TARGETS)[number]
 
+export const PACKAGE_AUTHORING_SURFACE_KINDS = ['none', 'playcanvasEditor'] as const
+export type PackageAuthoringSurfaceKind = (typeof PACKAGE_AUTHORING_SURFACE_KINDS)[number]
+
+export const PACKAGE_DISPLAY_MODES = ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl'] as const
+export type PackageDisplayMode = (typeof PACKAGE_DISPLAY_MODES)[number]
+
+export interface PackageAttachmentEmptyConfig {
+    schemaVersion: '1'
+    kind: 'none'
+}
+
+export interface PackageAttachmentDisplayConfig {
+    schemaVersion: '1'
+    kind: 'display'
+    display: {
+        mode: PackageDisplayMode
+        developmentUrl?: string | null
+        showArtifactOnlyNotice: boolean
+    }
+}
+
+export type PackageAttachmentConfig = PackageAttachmentEmptyConfig | PackageAttachmentDisplayConfig
+
+export interface PackageAuthoringSurfaceNoneDescriptor {
+    schemaVersion: '1'
+    kind: 'none'
+    supportedDisplayModes: readonly []
+    defaultConfig: PackageAttachmentEmptyConfig
+}
+
+export interface PlayCanvasEditorAuthoringSurfaceDescriptor {
+    schemaVersion: '1'
+    kind: 'playcanvasEditor'
+    packageSlug: string
+    supportedDisplayModes: readonly PackageDisplayMode[]
+    defaultConfig: PackageAttachmentDisplayConfig
+    artifact?: {
+        packageName: '@universo-react/playcanvas-editor'
+        manifestFileName: 'universo-artifact-manifest.json'
+        outputRoot: 'dist/editor'
+        smokeMode: 'artifact-only'
+    }
+}
+
+export type PackageAuthoringSurfaceDescriptor = PackageAuthoringSurfaceNoneDescriptor | PlayCanvasEditorAuthoringSurfaceDescriptor
+
+export type PackageArtifactStatus = 'available' | 'missing' | 'disabled' | 'blocked' | 'misconfigured'
+
+export interface PackageAuthoringHostDescriptor {
+    packageSlug: string
+    packageName: string
+    version: string
+    displayName: VersionedLocalizedContent<string>
+    description?: VersionedLocalizedContent<string> | null
+    attachmentConfig: PackageAttachmentConfig
+    authoringSurface: PackageAuthoringSurfaceDescriptor
+    allowedDisplayModes: readonly PackageDisplayMode[]
+    artifactStatus: PackageArtifactStatus
+    artifactUrl?: string | null
+}
+
 export interface PackageSourceDescriptor {
     kind: MetahubPackageSourceKind
     packageName: string
@@ -22,6 +83,7 @@ export interface MetahubPackageRegistryItem {
     displayName: VersionedLocalizedContent<string>
     description?: VersionedLocalizedContent<string> | null
     source: PackageSourceDescriptor
+    authoringSurface: PackageAuthoringSurfaceDescriptor
     isActive: boolean
 }
 
@@ -34,6 +96,8 @@ export interface MetahubPackageAttachment {
     displayName: VersionedLocalizedContent<string>
     description?: VersionedLocalizedContent<string> | null
     source: PackageSourceDescriptor
+    authoringSurface: PackageAuthoringSurfaceDescriptor
+    config: PackageAttachmentConfig
     attachedAt: string
     isActive: boolean
 }
@@ -52,14 +116,20 @@ export interface AttachMetahubPackageRequest {
 
 export interface ChangeMetahubPackageVersionRequest {
     version: string
+    resetConfig?: boolean
+}
+
+export interface UpdateMetahubPackageConfigRequest {
+    config: PackageAttachmentConfig
 }
 
 export interface MetahubSnapshotPackage {
     packageName: string
     version: string
     source: PackageSourceDescriptor
+    config?: PackageAttachmentConfig
 }
 
-export interface ApplicationPackageDefinition extends MetahubSnapshotPackage {
+export interface ApplicationPackageDefinition extends Omit<MetahubSnapshotPackage, 'config'> {
     isActive: boolean
 }

--- a/packages/universo-react-utils/src/index.browser.ts
+++ b/packages/universo-react-utils/src/index.browser.ts
@@ -35,10 +35,12 @@ export { SAFE_MENU_HREF_RE, isSafeMenuHref, sanitizeMenuHref } from './validatio
 // Public routes utilities
 export {
     API_WHITELIST_URLS,
+    API_WHITELIST_PATH_PATTERNS,
     PUBLIC_UI_ROUTES,
     isPublicRoute,
     isWhitelistedApiPath,
     type ApiWhitelistUrl,
+    type ApiWhitelistPathPattern,
     type PublicUiRoute
 } from './routes'
 

--- a/packages/universo-react-utils/src/index.ts
+++ b/packages/universo-react-utils/src/index.ts
@@ -65,10 +65,12 @@ export { SAFE_MENU_HREF_RE, isSafeMenuHref, sanitizeMenuHref } from './validatio
 // Public routes utilities
 export {
     API_WHITELIST_URLS,
+    API_WHITELIST_PATH_PATTERNS,
     PUBLIC_UI_ROUTES,
     isPublicRoute,
     isWhitelistedApiPath,
     type ApiWhitelistUrl,
+    type ApiWhitelistPathPattern,
     type PublicUiRoute
 } from './routes'
 

--- a/packages/universo-react-utils/src/routes/__tests__/publicRoutes.test.ts
+++ b/packages/universo-react-utils/src/routes/__tests__/publicRoutes.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWhitelistedApiPath } from '..'
+
+describe('public API route matching', () => {
+    it('allows signed PlayCanvas Editor artifact asset URLs without whitelisting neighboring package routes', () => {
+        expect(
+            isWhitelistedApiPath(
+                '/api/v1/metahub/019e8381-8c57-7d73-9f15-a9c27237c703/packages/playcanvas-editor/editor-artifact-token/signed-token/assets/editor.js'
+            )
+        ).toBe(true)
+
+        expect(
+            isWhitelistedApiPath(
+                '/api/v1/metahub/019e8381-8c57-7d73-9f15-a9c27237c703/packages/playcanvas-editor/editor-artifact/index.html'
+            )
+        ).toBe(false)
+        expect(isWhitelistedApiPath('/api/v1/metahub/019e8381-8c57-7d73-9f15-a9c27237c703/packages')).toBe(false)
+    })
+})

--- a/packages/universo-react-utils/src/routes/index.ts
+++ b/packages/universo-react-utils/src/routes/index.ts
@@ -44,6 +44,13 @@ export const API_WHITELIST_URLS = [
 ] as const
 
 /**
+ * Backend API path patterns that don't require JWT authentication.
+ * Use only for public routes with dynamic path segments and route-local
+ * validation, such as short-lived signed asset URLs.
+ */
+export const API_WHITELIST_PATH_PATTERNS = [/^\/api\/v1\/metahub\/[^/]+\/packages\/[^/]+\/editor-artifact-token\/[^/]+\//] as const
+
+/**
  * Frontend UI routes where 401 response should NOT trigger redirect to /auth.
  * These are pages accessible to guests (non-authenticated users).
  *
@@ -95,9 +102,10 @@ export function isPublicRoute(pathname: string): boolean {
  * @returns true if the path is whitelisted
  */
 export function isWhitelistedApiPath(path: string): boolean {
-    return API_WHITELIST_URLS.some((url) => path.startsWith(url))
+    return API_WHITELIST_URLS.some((url) => path.startsWith(url)) || API_WHITELIST_PATH_PATTERNS.some((pattern) => pattern.test(path))
 }
 
 // Type exports for consumers
 export type ApiWhitelistUrl = (typeof API_WHITELIST_URLS)[number]
+export type ApiWhitelistPathPattern = (typeof API_WHITELIST_PATH_PATTERNS)[number]
 export type PublicUiRoute = (typeof PUBLIC_UI_ROUTES)[number]

--- a/packages/universo-react-utils/src/serialization/__tests__/publicationSnapshotHash.test.ts
+++ b/packages/universo-react-utils/src/serialization/__tests__/publicationSnapshotHash.test.ts
@@ -401,4 +401,64 @@ describe('normalizePublicationSnapshotForHash', () => {
         expect(normalized.layoutConfig).toEqual({})
         expect(normalized.entities).toEqual([])
     })
+
+    it('includes package attachment config in canonical hash normalization when present', () => {
+        const editorPackageName = `@universo-react/${'playcanvas-editor'}`
+        const basePackage = {
+            packageName: editorPackageName,
+            version: '0.1.0',
+            source: {
+                kind: 'workspace',
+                packageName: editorPackageName,
+                importName: editorPackageName,
+                upstreamPackageName: 'playcanvas-editor',
+                upstreamVersion: '2026.05.30',
+                runtimeTargets: []
+            }
+        }
+
+        const embedded = normalizePublicationSnapshotForHash({
+            packages: [
+                {
+                    ...basePackage,
+                    config: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'embeddedIframe',
+                            developmentUrl: null,
+                            showArtifactOnlyNotice: true
+                        }
+                    }
+                }
+            ]
+        })
+        const openSeparately = normalizePublicationSnapshotForHash({
+            packages: [
+                {
+                    ...basePackage,
+                    config: {
+                        schemaVersion: '1',
+                        kind: 'display',
+                        display: {
+                            mode: 'openSeparately',
+                            developmentUrl: null,
+                            showArtifactOnlyNotice: true
+                        }
+                    }
+                }
+            ]
+        })
+
+        expect(embedded.packages).toEqual([
+            expect.objectContaining({
+                packageName: editorPackageName,
+                config: expect.objectContaining({
+                    kind: 'display',
+                    display: expect.objectContaining({ mode: 'embeddedIframe' })
+                })
+            })
+        ])
+        expect(JSON.stringify(embedded.packages)).not.toEqual(JSON.stringify(openSeparately.packages))
+    })
 })

--- a/packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts
+++ b/packages/universo-react-utils/src/serialization/publicationSnapshotHash.ts
@@ -140,7 +140,8 @@ const normalizePackage = (packageValue: unknown): Record<string, unknown> => {
             runtimeTargets: asArray<unknown>(source.runtimeTargets)
                 .map((target) => String(target ?? ''))
                 .sort(compareStrings)
-        }
+        },
+        config: item.config === undefined ? undefined : item.config
     }
 }
 

--- a/tools/check-playcanvas-editor-isolation.mjs
+++ b/tools/check-playcanvas-editor-isolation.mjs
@@ -27,6 +27,12 @@ const EDITOR_PACKAGE_BLOCKED_PUBLIC_REEXPORTS = [
     '../vendor/'
 ]
 const EDITOR_PACKAGE_BLOCKED_EXPORT_PATHS = ['vendor/', 'playcanvas-editor/']
+const ALLOWED_EDITOR_PACKAGE_METADATA_FILES = new Set([
+    'packages/universo-react-metahubs-backend/src/domains/packages/data/seed-packages.json',
+    'packages/universo-react-metahubs-backend/src/domains/packages/services/packageConfigValidation.ts',
+    'packages/universo-react-metahubs-backend/src/tests/services/PackageSeeder.test.ts',
+    'packages/universo-react-types/src/common/packages.ts'
+])
 
 const toRelative = (absolutePath) => path.relative(ROOT, absolutePath).split(path.sep).join('/')
 
@@ -57,6 +63,9 @@ const isAllowedEditorPackageFile = (relativeFile) => {
     if (relativeFile.endsWith('/package.json')) return true
     return false
 }
+
+const isAllowedEditorPackageMetadataReference = (relativeFile, blocked) =>
+    blocked === '@universo-react/playcanvas-editor' && ALLOWED_EDITOR_PACKAGE_METADATA_FILES.has(relativeFile)
 
 const violations = []
 
@@ -101,7 +110,7 @@ for await (const file of walk(PACKAGES_DIR)) {
     for (const blocked of BLOCKED_REFERENCES) {
         let index = content.indexOf(blocked)
         while (index !== -1) {
-            if (!isAllowedEditorPackageFile(relativeFile)) {
+            if (!isAllowedEditorPackageFile(relativeFile) && !isAllowedEditorPackageMetadataReference(relativeFile, blocked)) {
                 violations.push(`${relativeFile}:${lineNumberFor(content, index)}: blocked PlayCanvas Editor boundary reference ${blocked}`)
             }
             index = content.indexOf(blocked, index + blocked.length)

--- a/tools/fixtures/metahubs-quiz-app-snapshot.json
+++ b/tools/fixtures/metahubs-quiz-app-snapshot.json
@@ -3545,5 +3545,5 @@
         ],
         "layoutWidgetOverrides": []
     },
-    "snapshotHash": "659eebf44aba8304530f00513aea992bc1404bb96a66a7c587b2088096ce80ff"
+    "snapshotHash": "5a7fdf445c9bc5fd1779f076e039b05dc234f080075d74a066012973266239e1"
 }

--- a/tools/fixtures/metahubs-self-hosted-app-snapshot.json
+++ b/tools/fixtures/metahubs-self-hosted-app-snapshot.json
@@ -7671,5 +7671,5 @@
             }
         ]
     },
-    "snapshotHash": "86073615b946b8c83ffa47af3ef22f8c41c23d451592c7746346a180d53a2125"
+    "snapshotHash": "63967b45191870aa2f8bfdc31b626da1d25c71a293bad0528a85f52d96eeae01"
 }

--- a/tools/testing/e2e/specs/flows/metahub-packages-resources.spec.ts
+++ b/tools/testing/e2e/specs/flows/metahub-packages-resources.spec.ts
@@ -1,4 +1,6 @@
 import { createLocalizedContent } from '@universo-react/utils'
+import type { Page } from '@playwright/test'
+import { PNG } from 'pngjs'
 
 import { expect, test } from '../../fixtures/test'
 import {
@@ -17,7 +19,8 @@ import {
     expectNoPageHorizontalOverflow,
     expectNoTechnicalLeakage,
     expectNoVisibleTextPatterns,
-    expectRuntimeUxViewportMatrix
+    expectRuntimeUxViewportMatrix,
+    waitForLayoutFrame
 } from '../../support/browser/runtimeUx'
 
 const resolveUserRoleIds = (roles: Array<{ id?: string; codename?: string }>): string[] => {
@@ -26,6 +29,109 @@ const resolveUserRoleIds = (roles: Array<{ id?: string; codename?: string }>): s
 }
 
 const rawPackageTextPatterns = [/@universo-react\//, /@colyseus\//, /\bcolyseus\.js\b/i]
+
+const openPlayCanvasEditorSettingsDialog = async (page: Page) => {
+    const editorRow = page.getByTestId('metahub-packages-tab').getByRole('row', { name: /PlayCanvas Editor/ })
+    await editorRow.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+    await page.getByRole('menuitem', { name: 'Settings' }).click()
+    await expect(page.getByRole('menu')).toHaveCount(0)
+    const dialog = page.getByRole('dialog', { name: 'Package display settings' })
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByTestId('dialog-resize-handle')).toHaveCount(0)
+    await waitForLayoutFrame(page)
+    return dialog
+}
+
+const scrollPackagesTableActionsIntoViewByGesture = async (page: Page) => {
+    const table = page.getByRole('table', { name: /Packages|Пакеты/ })
+    const container = table.locator('xpath=./ancestor::*[contains(@class, "MuiTableContainer-root")][1]')
+    await expect(container).toBeVisible()
+    await container.hover()
+    await page.mouse.wheel(1200, 0)
+
+    await expect.poll(() => container.evaluate((element) => (element as HTMLElement).scrollLeft)).toBeGreaterThan(0)
+}
+
+const expectPlayCanvasEditorIframeLoaded = async (page: Page, locale: 'en' | 'ru' = 'en') => {
+    const editorIframe = page.locator('iframe[title="PlayCanvas Editor"]')
+    await expect(editorIframe).toBeVisible()
+    await expect(editorIframe).toHaveAttribute('sandbox', 'allow-scripts')
+    await expect(editorIframe).toHaveAttribute('referrerpolicy', 'no-referrer')
+    await expect(editorIframe).toHaveAttribute('allow', '')
+    await expect(editorIframe).toHaveAttribute('src', new RegExp(`[?&]locale=${locale}(?:&|$)`))
+
+    const editorFrame = page.frameLocator('iframe[title="PlayCanvas Editor"]')
+    if (locale === 'ru') {
+        await expect(editorFrame.getByRole('heading', { name: 'Артефакт PlayCanvas Editor доступен' })).toBeVisible()
+        await expect(editorFrame.getByRole('heading', { name: 'PlayCanvas Editor artifact is available' })).toBeHidden()
+    } else {
+        await expect(editorFrame.getByRole('heading', { name: 'PlayCanvas Editor artifact is available' })).toBeVisible()
+        await expect(editorFrame.getByRole('heading', { name: 'Артефакт PlayCanvas Editor доступен' })).toBeHidden()
+    }
+    const previewCanvas = editorFrame.getByLabel('PlayCanvas Editor artifact preview')
+    await expect(previewCanvas).toBeVisible()
+    const canvasBox = await previewCanvas.boundingBox()
+    expect(canvasBox?.width ?? 0).toBeGreaterThan(200)
+    expect(canvasBox?.height ?? 0).toBeGreaterThan(100)
+    const canvasScreenshot = await previewCanvas.screenshot()
+    const screenshotPng = PNG.sync.read(canvasScreenshot)
+    const canvasPaint = (() => {
+        const buckets = new Set<string>()
+        let sampledOpaquePixels = 0
+        const { data } = screenshotPng
+        for (let index = 0; index < data.length; index += 4 * 97) {
+            const alpha = data[index + 3] ?? 0
+            if (alpha === 0) continue
+            sampledOpaquePixels += 1
+            const red = Math.floor((data[index] ?? 0) / 32)
+            const green = Math.floor((data[index + 1] ?? 0) / 32)
+            const blue = Math.floor((data[index + 2] ?? 0) / 32)
+            buckets.add(`${red}:${green}:${blue}`)
+        }
+        return {
+            colorBuckets: buckets.size,
+            sampledOpaquePixels
+        }
+    })()
+    expect(canvasPaint.sampledOpaquePixels).toBeGreaterThan(20)
+    expect(canvasPaint.colorBuckets).toBeGreaterThan(1)
+    expect(new Set(canvasScreenshot).size).toBeGreaterThan(16)
+}
+
+const expectPlayCanvasEditorHostKeyboardLoop = async (page: Page, locale: 'en' | 'ru' = 'en') => {
+    const backLinkName = locale === 'ru' ? 'Назад к пакетам' : 'Back to packages'
+    const backLink = page.getByRole('link', { name: backLinkName })
+    const editorIframe = page.locator('iframe[title="PlayCanvas Editor"]')
+    const editorFrame = page.frameLocator('iframe[title="PlayCanvas Editor"]')
+    const previewCanvas = editorFrame.getByLabel('PlayCanvas Editor artifact preview')
+
+    await expect(backLink).toBeVisible()
+    await backLink.focus()
+    await expect(backLink).toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(editorIframe).toBeFocused()
+    await previewCanvas.click()
+    await expect(editorIframe).toBeFocused()
+    await page.keyboard.press('Shift+Tab')
+    await expect(backLink).toBeFocused()
+}
+
+const expectPlayCanvasEditorHostWarning = async (page: Page, message: string, label: string) => {
+    await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Back to packages' })).toBeVisible()
+    await expect(page.getByText(message)).toBeVisible()
+    await expect(page.locator('iframe[title="PlayCanvas Editor"]')).toHaveCount(0)
+    await expectNoTechnicalLeakage(page.locator('body'), {
+        label,
+        checkUuidSubstrings: true
+    })
+    await expectNoVisibleTextPatterns(
+        page.locator('body'),
+        [/editor-artifact\/index\.html/i, /artifactStatus/i, /\bblocked\b/i, /\bmisconfigured\b/i, /\bERR_[A-Z_]+\b/i],
+        { label }
+    )
+    await expectNoPageHorizontalOverflow(page, label)
+}
 
 test('@flow @packages metahub resources packages tab is usable and localized', async ({ browser, page, runManifest }, testInfo) => {
     test.setTimeout(240_000)
@@ -77,7 +183,11 @@ test('@flow @packages metahub resources packages tab is usable and localized', a
         await page.goto('/metahubs')
         const metahubEntry = page.getByText(metahubName, { exact: true }).first()
         await expect(metahubEntry).toBeVisible({ timeout: 30_000 })
-        await page.locator(`a[href="/metahub/${metahub.id}"]`).first().click()
+        const metahubLink = metahubEntry
+            .locator('xpath=ancestor::*[.//a[starts-with(@href, "/metahub/")]][1]//a[starts-with(@href, "/metahub/")]')
+            .first()
+        await expect(metahubLink).toBeVisible()
+        await metahubLink.click()
         await page.getByRole('link', { name: 'Resources' }).click()
         await page.waitForURL('**/resources')
         await expect(page.getByRole('heading', { name: 'Resources' })).toBeVisible()
@@ -87,6 +197,7 @@ test('@flow @packages metahub resources packages tab is usable and localized', a
         await expect(packagesTab).toBeVisible()
         await expect(page.getByRole('table', { name: 'Packages' })).toBeVisible()
         await expect(packagesTab.getByRole('heading', { name: 'PlayCanvas Engine' })).toBeVisible()
+        await expect(packagesTab.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
         await expect(packagesTab.getByRole('heading', { name: 'Colyseus Server' })).toBeVisible()
         await expect(packagesTab.getByRole('heading', { name: 'Colyseus Client' })).toBeVisible()
         await expectNoTechnicalLeakage(packagesTab, {
@@ -104,6 +215,296 @@ test('@flow @packages metahub resources packages tab is usable and localized', a
         await expect(keyboardAttachDialog.getByTestId('dialog-resize-handle')).toHaveCount(0)
         await keyboardAttachDialog.getByRole('button', { name: 'Cancel' }).click()
         await expect(keyboardAttachDialog).toHaveCount(0)
+
+        await page.getByRole('button', { name: 'Connect PlayCanvas Editor' }).click()
+        const editorAttachDialog = page.getByRole('dialog', { name: 'Connect package' })
+        await expect(editorAttachDialog).toBeVisible()
+        await expect(editorAttachDialog.getByTestId('dialog-resize-handle')).toHaveCount(0)
+        await editorAttachDialog.getByRole('button', { name: 'Connect package' }).click()
+        await expect(editorAttachDialog).toHaveCount(0)
+        const editorRow = packagesTab.getByRole('row', { name: /PlayCanvas Editor/ })
+        await expect(editorRow.getByText('Connected')).toBeVisible()
+        const authoringHostEndpointPattern = /\/api\/v1\/metahub\/[^/]+\/packages\/playcanvas-editor\/authoring-host$/
+
+        await editorRow.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).focus()
+        await page.keyboard.press('Enter')
+        await page.getByRole('menuitem', { name: 'Settings' }).click()
+        await expect(page.getByRole('menu')).toHaveCount(0)
+        const editorSettingsDialog = page.getByRole('dialog', { name: 'Package display settings' })
+        await expect(editorSettingsDialog).toBeVisible()
+        await expect(editorSettingsDialog.getByTestId('dialog-resize-handle')).toHaveCount(0)
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor settings dialog desktop')
+        await waitForLayoutFrame(page)
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-settings-en.png'), fullPage: true })
+        await expect(editorSettingsDialog.getByLabel('Display mode')).toContainText('Embedded')
+        await editorSettingsDialog.getByLabel('Display mode').press('Tab')
+        await expect(editorSettingsDialog.getByRole('switch', { name: 'Show artifact status notice' })).toBeFocused()
+        await expect(editorSettingsDialog.getByText('Development URL mode is disabled on this server.')).toBeVisible()
+        await editorSettingsDialog.getByLabel('Display mode').click()
+        await expect(page.getByRole('option', { name: 'Development URL' })).toHaveCount(0)
+        await page.keyboard.press('Escape')
+        await editorSettingsDialog.getByRole('button', { name: 'Reset to defaults' }).click()
+        await expect(editorSettingsDialog.getByLabel('Display mode')).toContainText('Embedded')
+        await expect(editorSettingsDialog.getByRole('button', { name: 'Save settings' })).toBeEnabled()
+        await editorSettingsDialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(editorSettingsDialog).toHaveCount(0)
+
+        await page.route(authoringHostEndpointPattern, async (route) => {
+            const response = await route.fetch()
+            const descriptor = await response.json()
+            await route.fulfill({
+                status: response.status(),
+                headers: response.headers(),
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    ...descriptor,
+                    allowedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl']
+                })
+            })
+        })
+        const configEndpointPattern = /\/api\/v1\/metahub\/[^/]+\/package\/[^/]+\/config$/
+        await page.route(configEndpointPattern, async (route) => {
+            if (route.request().method() === 'PATCH') {
+                await route.fulfill({
+                    status: 400,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ error: 'Development URL is not allowed' })
+                })
+                return
+            }
+            await route.continue()
+        })
+        const devUrlDialog = await openPlayCanvasEditorSettingsDialog(page)
+        await devUrlDialog.getByLabel('Display mode').click()
+        await page.getByRole('option', { name: 'Development URL' }).click()
+        await devUrlDialog.getByLabel('Development URL').fill('not-a-url')
+        await expect(devUrlDialog.getByText('Enter a valid http or https URL.')).toBeVisible()
+        await expect(devUrlDialog.getByRole('button', { name: 'Save settings' })).toBeDisabled()
+        await devUrlDialog.getByLabel('Development URL').fill('http://127.0.0.1:5999/editor')
+        await expect(devUrlDialog.getByRole('button', { name: 'Save settings' })).toBeEnabled()
+        const rejectedDevUrlSave = page.waitForResponse(
+            (response) =>
+                response.request().method() === 'PATCH' &&
+                configEndpointPattern.test(new URL(response.url()).pathname) &&
+                response.status() === 400
+        )
+        await devUrlDialog.getByRole('button', { name: 'Save settings' }).click()
+        await rejectedDevUrlSave
+        await expect(page.getByText('Package operation failed. Please refresh and try again.')).toBeVisible()
+        await devUrlDialog.getByRole('button', { name: 'Cancel' }).click()
+        await expect(devUrlDialog).toHaveCount(0)
+        await page.unroute(configEndpointPattern)
+        await page.unroute(authoringHostEndpointPattern)
+
+        await expectRuntimeUxViewportMatrix(page, 'PlayCanvas Editor settings dialog', {
+            beforeEachViewport: async (viewport) => {
+                await page.goto(`/metahub/${metahub.id}/resources`)
+                await expect(page.getByTestId('metahub-packages-tab')).toBeVisible()
+                const dialog = await openPlayCanvasEditorSettingsDialog(page)
+                await expect(dialog.getByLabel('Display mode')).toBeVisible()
+                await expect(dialog.getByRole('button', { name: 'Reset to defaults' })).toBeVisible()
+                await expect(dialog.getByRole('button', { name: 'Save settings' })).toBeVisible()
+                await page.screenshot({ path: testInfo.outputPath(`playcanvas-editor-settings-${viewport.name}.png`), fullPage: true })
+            }
+        })
+        await page.goto(`/metahub/${metahub.id}/resources`)
+        const editorRowAfterSettingsMatrix = page.getByTestId('metahub-packages-tab').getByRole('row', { name: /PlayCanvas Editor/ })
+        await editorRowAfterSettingsMatrix.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Settings' }).click()
+        await expect(page.getByRole('menu')).toHaveCount(0)
+        const editorSettingsDialogAfterMatrix = page.getByRole('dialog', { name: 'Package display settings' })
+        await expect(editorSettingsDialogAfterMatrix).toBeVisible()
+        await editorSettingsDialogAfterMatrix.getByLabel('Display mode').click()
+        await page.getByRole('option', { name: 'Open separately' }).click()
+        await editorSettingsDialogAfterMatrix.getByRole('button', { name: 'Save settings' }).click()
+        await expect(editorSettingsDialogAfterMatrix).toHaveCount(0)
+
+        const editorRowForSeparateMode = page.getByTestId('metahub-packages-tab').getByRole('row', { name: /PlayCanvas Editor/ })
+        await editorRowForSeparateMode.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Open editor' }).click()
+        await page.waitForURL(`**/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expect(page.getByRole('link', { name: 'Back to packages' })).toBeVisible()
+        await expect(page.getByText('This editor is configured to open separately.')).toBeVisible()
+        const separateEditorLink = page.getByRole('link', { name: 'Open editor' })
+        await expect(separateEditorLink).toHaveAttribute('target', '_blank')
+        await expect(separateEditorLink).toHaveAttribute('rel', /noopener/)
+        await expect(separateEditorLink).toHaveAttribute('rel', /noreferrer/)
+        await expect(separateEditorLink).toHaveAttribute(
+            'href',
+            /\/metahub\/[^/]+\/resources\/packages\/playcanvas-editor\/editor\?view=sandboxed-frame$/
+        )
+        await expect(separateEditorLink).not.toHaveAttribute('href', /editor-artifact\/index\.html/)
+        const popupPromise = page.waitForEvent('popup')
+        await separateEditorLink.click()
+        const separateEditorPage = await popupPromise
+        await separateEditorPage.waitForLoadState('domcontentloaded')
+        await applyBrowserPreferences(separateEditorPage, { language: 'en' })
+        await expect(separateEditorPage).toHaveURL(/\/resources\/packages\/playcanvas-editor\/editor\?view=sandboxed-frame$/)
+        await expect(separateEditorPage.getByText('Editor artifact is ready.')).toBeVisible()
+        await expectPlayCanvasEditorIframeLoaded(separateEditorPage)
+        await expectNoPageHorizontalOverflow(separateEditorPage, 'PlayCanvas Editor separate sandboxed host page')
+        await separateEditorPage.close()
+
+        await page.goto(`/metahub/${metahub.id}/resources`)
+        const editorRowForEmbeddedMode = page.getByTestId('metahub-packages-tab').getByRole('row', { name: /PlayCanvas Editor/ })
+        await editorRowForEmbeddedMode.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Settings' }).click()
+        const embeddedSettingsDialog = page.getByRole('dialog', { name: 'Package display settings' })
+        await expect(page.getByRole('menu')).toHaveCount(0)
+        await embeddedSettingsDialog.getByLabel('Display mode').click()
+        await page.getByRole('option', { name: 'Embedded' }).click()
+        await embeddedSettingsDialog.getByRole('button', { name: 'Save settings' }).click()
+        await expect(embeddedSettingsDialog).toHaveCount(0)
+
+        const editorArtifactIndexPattern =
+            /\/api\/v1\/metahub\/[^/]+\/packages\/playcanvas-editor\/editor-artifact-token\/[^/]+\/index\.html(?:\?.*)?$/
+        let delayedArtifactIndex = false
+        await page.route(editorArtifactIndexPattern, async (route) => {
+            if (!delayedArtifactIndex) {
+                delayedArtifactIndex = true
+                await new Promise((resolve) => setTimeout(resolve, 1500))
+            }
+            const response = await route.fetch()
+            await route.fulfill({
+                status: response.status(),
+                headers: response.headers(),
+                body: await response.body()
+            })
+        })
+        await editorRowForEmbeddedMode.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Open editor' }).click()
+        await page.waitForURL(`**/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expect(page.getByText('Loading editor frame...')).toBeVisible()
+        const hostResponse = await page.request.get(page.url())
+        expect(hostResponse.ok()).toBeTruthy()
+        expect(hostResponse.headers()['content-security-policy']).toContain("frame-src 'self'")
+        expect(hostResponse.headers()['content-security-policy']).toContain("child-src 'self'")
+        await expectPlayCanvasEditorIframeLoaded(page)
+        const editorFrameSrc = await page.locator('iframe[title="PlayCanvas Editor"]').getAttribute('src')
+        expect(editorFrameSrc).toBeTruthy()
+        const anonymousArtifactContext = await browser.newContext()
+        try {
+            const anonymousArtifactResponse = await anonymousArtifactContext.request.get(
+                new URL(editorFrameSrc ?? '', page.url()).toString()
+            )
+            expect(anonymousArtifactResponse.ok()).toBeTruthy()
+        } finally {
+            await anonymousArtifactContext.close()
+        }
+        await expect(page.getByText('Editor artifact is ready.')).toBeVisible()
+        await page.unroute(editorArtifactIndexPattern)
+        await expectPlayCanvasEditorHostKeyboardLoop(page)
+        await expectNoTechnicalLeakage(page.locator('body'), {
+            label: 'PlayCanvas Editor host page',
+            checkUuidSubstrings: true
+        })
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor host page desktop')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-host.png'), fullPage: true })
+
+        await page.route(authoringHostEndpointPattern, async (route) => {
+            const response = await route.fetch()
+            const descriptor = await response.json()
+            await route.fulfill({
+                status: response.status(),
+                headers: response.headers(),
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    ...descriptor,
+                    artifactStatus: 'missing',
+                    artifactUrl: null
+                })
+            })
+        })
+        await page.goto(`/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expect(page.getByRole('link', { name: 'Back to packages' })).toBeVisible()
+        await expect(page.getByText('The editor artifact is not available yet.')).toBeVisible()
+        await expect(page.locator('iframe[title="PlayCanvas Editor"]')).toHaveCount(0)
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor missing artifact host page')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-host-missing-artifact.png'), fullPage: true })
+        await page.unroute(authoringHostEndpointPattern)
+
+        for (const artifactStatus of ['blocked', 'misconfigured'] as const) {
+            await page.route(authoringHostEndpointPattern, async (route) => {
+                const response = await route.fetch()
+                const descriptor = await response.json()
+                await route.fulfill({
+                    status: response.status(),
+                    headers: response.headers(),
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        ...descriptor,
+                        artifactStatus,
+                        artifactUrl: null
+                    })
+                })
+            })
+            await page.goto(`/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+            await expectPlayCanvasEditorHostWarning(
+                page,
+                'Editor display settings are incomplete.',
+                `PlayCanvas Editor ${artifactStatus} host state`
+            )
+            await page.unroute(authoringHostEndpointPattern)
+        }
+
+        await page.route(editorArtifactIndexPattern, async (route) => {
+            await route.fulfill({
+                status: 503,
+                contentType: 'text/html; charset=utf-8',
+                body: '<!doctype html><title>Service unavailable</title>'
+            })
+        })
+        await page.goto(`/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expect(page.getByRole('link', { name: 'Back to packages' })).toBeVisible()
+        await expect(page.getByText('The editor frame could not be loaded.')).toBeVisible()
+        await expect(page.getByText('Editor artifact is ready.')).toHaveCount(0)
+        await expect(page.locator('iframe[title="PlayCanvas Editor"]')).toHaveCount(0)
+        await expectNoTechnicalLeakage(page.locator('body'), {
+            label: 'PlayCanvas Editor iframe failure state',
+            checkUuidSubstrings: true
+        })
+        await expectNoVisibleTextPatterns(
+            page.locator('body'),
+            [/editor-artifact-token\/[^/]+\/index\.html/i, /Service unavailable/i, /\b503\b/, /\bERR_[A-Z_]+\b/i],
+            { label: 'PlayCanvas Editor iframe failure state' }
+        )
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor iframe failure state')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-host-iframe-failure.png'), fullPage: true })
+        await page.unroute(editorArtifactIndexPattern)
+
+        await expectRuntimeUxViewportMatrix(page, 'PlayCanvas Editor host page', {
+            beforeEachViewport: async (viewport) => {
+                await page.goto(`/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+                await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+                await expectPlayCanvasEditorIframeLoaded(page)
+                await expect(page.getByText('Editor artifact is ready.')).toBeVisible()
+                await page.screenshot({ path: testInfo.outputPath(`playcanvas-editor-host-${viewport.name}.png`), fullPage: true })
+            }
+        })
+
+        memberContext = await createLoggedInBrowserContext(browser, { email: memberUser.email ?? memberEmail, password: memberPassword })
+        await applyBrowserPreferences(memberContext.page, { language: 'en' })
+        await memberContext.page.goto(`/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(memberContext.page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expect(memberContext.page.getByRole('link', { name: 'Back to packages' })).toBeVisible()
+        await expect(memberContext.page.getByText('You do not have permission to open this editor.')).toBeVisible()
+        await expect(memberContext.page.getByText('Failed to load editor settings.')).toHaveCount(0)
+        await expect(memberContext.page.locator('iframe[title="PlayCanvas Editor"]')).toHaveCount(0)
+
+        await page.goto(`/metahub/${metahub.id}/resources`)
+        await expect(page.getByTestId('metahub-packages-tab')).toBeVisible()
+        const editorRowAfterHost = page.getByTestId('metahub-packages-tab').getByRole('row', { name: /PlayCanvas Editor/ })
+        await editorRowAfterHost.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Disconnect package' }).click()
+        const editorDetachDialog = page.getByRole('dialog', { name: 'Disconnect package' })
+        await expect(editorDetachDialog).toBeVisible()
+        await editorDetachDialog.getByRole('button', { name: 'Disconnect package' }).click()
+        await expect(editorDetachDialog).toHaveCount(0)
+        await expect(editorRowAfterHost.getByText('Available')).toBeVisible()
 
         await page.getByRole('button', { name: 'Connect PlayCanvas Engine' }).click()
         const attachDialog = page.getByRole('dialog', { name: 'Connect package' })
@@ -132,7 +533,12 @@ test('@flow @packages metahub resources packages tab is usable and localized', a
         await expect(colyseusAttachDialog).toHaveCount(0)
         await expect(colyseusClientRow.getByText('Connected')).toBeVisible()
 
-        memberContext = await createLoggedInBrowserContext(browser, { email: memberUser.email ?? memberEmail, password: memberPassword })
+        if (!memberContext) {
+            memberContext = await createLoggedInBrowserContext(browser, {
+                email: memberUser.email ?? memberEmail,
+                password: memberPassword
+            })
+        }
         await applyBrowserPreferences(memberContext.page, { language: 'en' })
         await memberContext.page.goto(`/metahub/${metahub.id}/resources`)
         await expect(memberContext.page.getByRole('heading', { name: 'Resources' })).toBeVisible()
@@ -141,6 +547,8 @@ test('@flow @packages metahub resources packages tab is usable and localized', a
         const readOnlyPackagesTab = memberContext.page.getByTestId('metahub-packages-tab')
         const readOnlyColyseusClientRow = readOnlyPackagesTab.getByRole('row', { name: /Colyseus Client/ })
         await expect(readOnlyColyseusClientRow.getByRole('button', { name: 'Disconnect Colyseus Client' })).toBeDisabled()
+        const readOnlyEditorRow = readOnlyPackagesTab.getByRole('row', { name: /PlayCanvas Editor/ })
+        await expect(readOnlyEditorRow.getByRole('button', { name: 'Connect PlayCanvas Editor' })).toBeDisabled()
         await expect(readOnlyColyseusClientRow.locator('[aria-label="Package version for Colyseus Client"]')).toHaveClass(/Mui-disabled/)
         await expectNoTechnicalLeakage(readOnlyPackagesTab, {
             label: 'Read-only metahub packages tab',
@@ -192,17 +600,100 @@ test('@flow @packages metahub resources packages tab is usable and localized', a
         await failedAttachDialog.getByRole('button', { name: 'Отмена' }).click()
         await page.unroute(packagesEndpointPattern)
 
+        await applyBrowserPreferences(page, { language: 'en' })
+        await page.setViewportSize({ width: 390, height: 844 })
+        await page.goto(`/metahub/${metahub.id}/resources`)
+        const mobilePackagesTab = page.getByTestId('metahub-packages-tab')
+        await expect(mobilePackagesTab).toBeVisible()
+        await expect(page.getByRole('table', { name: 'Packages' })).toBeVisible()
+        await scrollPackagesTableActionsIntoViewByGesture(page)
+        const mobileEditorRow = mobilePackagesTab.getByRole('row', { name: /PlayCanvas Editor/ })
+        await expect(mobileEditorRow.getByRole('button', { name: 'Connect PlayCanvas Editor' })).toBeVisible()
+        await mobileEditorRow.getByRole('button', { name: 'Connect PlayCanvas Editor' }).click()
+        const mobileEditorAttachDialog = page.getByRole('dialog', { name: 'Connect package' })
+        await expect(mobileEditorAttachDialog).toBeVisible()
+        await mobileEditorAttachDialog.getByRole('button', { name: 'Connect package' }).click()
+        await expect(mobileEditorAttachDialog).toHaveCount(0)
+        await scrollPackagesTableActionsIntoViewByGesture(page)
+        await expect(mobileEditorRow.getByRole('button', { name: 'Actions for PlayCanvas Editor' })).toBeVisible()
+        await mobileEditorRow.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await expect(page.getByRole('menuitem', { name: 'Settings' })).toBeVisible()
+        await expect(page.getByRole('menuitem', { name: 'Open editor' })).toBeVisible()
+        await page.getByRole('menuitem', { name: 'Settings' }).click()
+        const mobileSettingsDialog = page.getByRole('dialog', { name: 'Package display settings' })
+        await expect(mobileSettingsDialog).toBeVisible()
+        await expect(mobileSettingsDialog.getByLabel('Display mode')).toBeVisible()
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor mobile settings action path')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-settings-mobile-action-path.png'), fullPage: true })
+        await mobileSettingsDialog.getByRole('button', { name: 'Save settings' }).click()
+        await expect(mobileSettingsDialog).toHaveCount(0)
+        await scrollPackagesTableActionsIntoViewByGesture(page)
+        await mobileEditorRow.getByRole('button', { name: 'Actions for PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Open editor' }).click()
+        await page.waitForURL(`**/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expectPlayCanvasEditorIframeLoaded(page)
+        await expect(page.getByText('Editor artifact is ready.')).toBeVisible()
+        await expectPlayCanvasEditorHostKeyboardLoop(page)
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor mobile host action path')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-host-mobile-action-path.png'), fullPage: true })
+
+        await applyBrowserPreferences(page, { language: 'ru' })
+        await page.setViewportSize({ width: 1280, height: 900 })
+        await page.goto(`/metahub/${metahub.id}/resources`)
+        await page.route(authoringHostEndpointPattern, async (route) => {
+            const response = await route.fetch()
+            const descriptor = await response.json()
+            await route.fulfill({
+                status: response.status(),
+                headers: response.headers(),
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    ...descriptor,
+                    allowedDisplayModes: ['disabled', 'embeddedIframe', 'openSeparately', 'developmentUrl']
+                })
+            })
+        })
+        const ruEditorRow = page.getByTestId('metahub-packages-tab').getByRole('row', { name: /PlayCanvas Editor/ })
+        await ruEditorRow.getByRole('button', { name: 'Действия для PlayCanvas Editor' }).click()
+        await page.getByRole('menuitem', { name: 'Настройки' }).click()
+        const ruSettingsDialog = page.getByRole('dialog', { name: 'Настройки отображения пакета' })
+        await expect(ruSettingsDialog).toBeVisible()
+        await expect(ruSettingsDialog.getByLabel('Режим отображения')).toBeVisible()
+        await expect(ruSettingsDialog.getByRole('button', { name: 'Сохранить настройки' })).toBeVisible()
+        await ruSettingsDialog.getByLabel('Режим отображения').click()
+        await page.getByRole('option', { name: 'Адрес разработки' }).click()
+        await ruSettingsDialog.getByLabel('Адрес разработки').fill('не-url')
+        await expect(ruSettingsDialog.getByText('Введите корректный адрес с http или https.')).toBeVisible()
+        await expect(ruSettingsDialog.getByRole('button', { name: 'Сохранить настройки' })).toBeDisabled()
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor settings dialog ru')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-settings-ru.png'), fullPage: true })
+        await page.keyboard.press('Escape')
+        await page.unroute(authoringHostEndpointPattern)
+        await page.goto(`/metahub/${metahub.id}/resources/packages/playcanvas-editor/editor`)
+        await expect(page.getByRole('heading', { name: 'PlayCanvas Editor' })).toBeVisible()
+        await expectPlayCanvasEditorIframeLoaded(page, 'ru')
+        await expect(page.getByText('Артефакт редактора готов.')).toBeVisible()
+        await expectPlayCanvasEditorHostKeyboardLoop(page, 'ru')
+        await expectNoPageHorizontalOverflow(page, 'PlayCanvas Editor host page ru')
+        await page.screenshot({ path: testInfo.outputPath('playcanvas-editor-host-ru.png'), fullPage: true })
+
         await expectRuntimeUxViewportMatrix(page, 'Metahub packages resources page', {
             beforeEachViewport: async () => {
                 await page.goto(`/metahub/${metahub.id}/resources`)
                 await expect(page.getByTestId('metahub-packages-tab')).toBeVisible()
+                await expect(page.getByRole('table', { name: /Packages|Пакеты/ })).toBeVisible()
             }
         })
         await page.setViewportSize({ width: 768, height: 900 })
         await page.goto(`/metahub/${metahub.id}/resources`)
+        await expect(page.getByTestId('metahub-packages-tab')).toBeVisible()
+        await expect(page.getByRole('table', { name: /Packages|Пакеты/ })).toBeVisible()
         await page.screenshot({ path: testInfo.outputPath('metahub-packages-tablet.png'), fullPage: true })
         await page.setViewportSize({ width: 390, height: 844 })
         await page.goto(`/metahub/${metahub.id}/resources`)
+        await expect(page.getByTestId('metahub-packages-tab')).toBeVisible()
+        await expect(page.getByRole('table', { name: /Packages|Пакеты/ })).toBeVisible()
         await page.screenshot({ path: testInfo.outputPath('metahub-packages-mobile.png'), fullPage: true })
     } finally {
         if (memberContext) {

--- a/tools/testing/e2e/support/browser/preferences.ts
+++ b/tools/testing/e2e/support/browser/preferences.ts
@@ -8,18 +8,26 @@ export type BrowserPreferenceOptions = {
 export async function applyBrowserPreferences(page: Page, options: BrowserPreferenceOptions = {}) {
     const language = options.language ?? 'en'
     const isDarkMode = options.isDarkMode === true
+    const preferences = {
+        nextLanguage: language,
+        nextIsDarkMode: isDarkMode
+    }
 
-    await page.addInitScript(
-        ({ nextLanguage, nextIsDarkMode }) => {
+    await page.addInitScript(({ nextLanguage, nextIsDarkMode }) => {
+        window.localStorage.setItem('i18nextLng', nextLanguage)
+        window.localStorage.setItem('isDarkMode', String(nextIsDarkMode))
+        window.localStorage.setItem('mui-mode', nextIsDarkMode ? 'dark' : 'light')
+    }, preferences)
+
+    await page.evaluate(({ nextLanguage, nextIsDarkMode }) => {
+        try {
             window.localStorage.setItem('i18nextLng', nextLanguage)
             window.localStorage.setItem('isDarkMode', String(nextIsDarkMode))
             window.localStorage.setItem('mui-mode', nextIsDarkMode ? 'dark' : 'light')
-        },
-        {
-            nextLanguage: language,
-            nextIsDarkMode: isDarkMode
+        } catch {
+            // about:blank has no origin-local storage; the init script covers the next navigation.
         }
-    )
+    }, preferences)
 }
 
 export function parseRgbColor(input: string): [number, number, number] | null {

--- a/tools/testing/e2e/support/browser/runtimeUx.ts
+++ b/tools/testing/e2e/support/browser/runtimeUx.ts
@@ -306,7 +306,7 @@ export async function expectDataGridHorizontalScrollConstrained(page: Page, labe
     }
 }
 
-const waitForLayoutFrame = async (page: Page) =>
+export const waitForLayoutFrame = async (page: Page) =>
     page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))))
 
 export async function expectRuntimeUxViewportMatrix(


### PR DESCRIPTION
Fixes #834

# Description

This PR adds the first PlayCanvas Editor metahub authoring integration slice. Metahub owners can connect `@universo-react/playcanvas-editor`, configure how its isolated artifact is displayed, and open it through a safe localized authoring host without promoting the Editor package into runtime module dependencies.

## Changes Made

- Added shared package contracts for authoring surfaces, deterministic package slugs, per-metahub package display config, authoring host descriptors, and artifact status metadata.
- Extended the metahubs package schema with `obj_packages.authoring_surface` and `rel_metahub_packages.config`, plus an authoring-settings migration and schema parity coverage.
- Seeded `@universo-react/playcanvas-editor` as an authoring-only package with empty runtime targets, default embedded display settings, artifact metadata, and isolated package boundary checks.
- Added backend package config validation, package attach/version/config lifecycle handling, copy/snapshot export/import preservation, and runtime publication exclusion for authoring-only packages.
- Added manager-only PlayCanvas Editor authoring host APIs and authenticated static artifact serving with token revalidation, manifest/file availability checks, path containment, CSP, iframe sandboxing, and development URL allowlist validation.
- Added Metahub Resources Packages UI settings and launch flows for disabled, embedded iframe, open separately, and development URL modes with localized EN/RU text.
- Added the PlayCanvas Editor host page with user-facing loading, missing, blocked, misconfigured, permission, iframe failure, and artifact-ready states.

## Additional Work

- Updated OpenAPI generation and generated REST docs for the new package settings and authoring-host contracts.
- Updated GitBook documentation in English and Russian for metahub packages and PlayCanvas Editor behavior.
- Added Memory Bank research, plan, task, and progress records for the implementation and QA closures.
- Strengthened PlayCanvas Editor artifact smoke behavior and repository isolation guard coverage.
- Updated package snapshot hash coverage and affected snapshot fixtures so package display config is integrity-checked for metahub snapshots.
- Added focused backend, frontend, utility, migration, and Playwright E2E coverage for package settings, host behavior, tokenized artifacts, responsive UI, i18n, and failure states.

## Testing

- [x] `pnpm --filter @universo-react/metahubs-backend test -- --runInBand src/tests/routes/packagesRoutes.test.ts src/tests/persistence/packagesStore.test.ts src/tests/platform/packageAuthoringSettingsMigration.test.ts src/tests/services/PackageSeeder.test.ts`
- [x] `pnpm --filter @universo-react/applications-backend test -- --runInBand src/tests/routes/sync/syncPackagePersistence.test.ts src/tests/services/applicationReleaseBundle.test.ts`
- [x] `pnpm --dir packages/universo-react-metahubs-frontend exec vitest run --config vitest.config.ts src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx --coverage.enabled=false`
- [x] `pnpm --filter @universo-react/applications-backend build`
- [x] `pnpm --filter @universo-react/metahubs-backend build`
- [x] `pnpm --filter @universo-react/metahubs-frontend build`
- [x] `pnpm run check:playcanvas-editor-isolation`
- [x] `git diff --check`
- [x] `.agents/skills/autoreview/scripts/autoreview --mode local`
- [x] Local minimal Supabase Playwright `@packages` chromium flow was completed during the implementation QA cycle.

<details>
<summary>In Russian</summary>

Исправляет #834

# Описание

Этот PR добавляет первый срез authoring-интеграции PlayCanvas Editor для метахабов. Владельцы метахабов могут подключить `@universo-react/playcanvas-editor`, настроить способ отображения его изолированного артефакта и открыть его через безопасный локализованный authoring host, не продвигая пакет Editor в runtime module dependencies.

## Внесенные изменения

- Добавлены shared package contracts для authoring surfaces, deterministic package slugs, per-metahub package display config, authoring host descriptors и artifact status metadata.
- Расширена package schema метахабов полями `obj_packages.authoring_surface` и `rel_metahub_packages.config`, а также добавлены authoring-settings migration и schema parity coverage.
- `@universo-react/playcanvas-editor` зарегистрирован как authoring-only пакет с пустыми runtime targets, default embedded display settings, artifact metadata и isolated package boundary checks.
- Добавлены backend package config validation, package attach/version/config lifecycle handling, сохранение при copy/snapshot export/import и runtime publication exclusion для authoring-only packages.
- Добавлены manager-only PlayCanvas Editor authoring host APIs и authenticated static artifact serving с token revalidation, manifest/file availability checks, path containment, CSP, iframe sandboxing и development URL allowlist validation.
- Добавлены settings и launch flows в Metahub Resources Packages UI для режимов disabled, embedded iframe, open separately и development URL с локализованными EN/RU текстами.
- Добавлена страница PlayCanvas Editor host с user-facing состояниями loading, missing, blocked, misconfigured, permission, iframe failure и artifact-ready.

## Дополнительная работа

- Обновлены OpenAPI generation и generated REST docs для новых package settings и authoring-host contracts.
- Обновлена GitBook documentation на английском и русском языках для metahub packages и поведения PlayCanvas Editor.
- Добавлены Memory Bank research, plan, task и progress records для implementation и QA closures.
- Усилены PlayCanvas Editor artifact smoke behavior и repository isolation guard coverage.
- Обновлены package snapshot hash coverage и затронутые snapshot fixtures, чтобы package display config проверялся на целостность в metahub snapshots.
- Добавлены focused backend, frontend, utility, migration и Playwright E2E coverage для package settings, host behavior, tokenized artifacts, responsive UI, i18n и failure states.

## Тестирование

- [x] `pnpm --filter @universo-react/metahubs-backend test -- --runInBand src/tests/routes/packagesRoutes.test.ts src/tests/persistence/packagesStore.test.ts src/tests/platform/packageAuthoringSettingsMigration.test.ts src/tests/services/PackageSeeder.test.ts`
- [x] `pnpm --filter @universo-react/applications-backend test -- --runInBand src/tests/routes/sync/syncPackagePersistence.test.ts src/tests/services/applicationReleaseBundle.test.ts`
- [x] `pnpm --dir packages/universo-react-metahubs-frontend exec vitest run --config vitest.config.ts src/domains/packages/ui/__tests__/MetahubPackagesTab.test.tsx --coverage.enabled=false`
- [x] `pnpm --filter @universo-react/applications-backend build`
- [x] `pnpm --filter @universo-react/metahubs-backend build`
- [x] `pnpm --filter @universo-react/metahubs-frontend build`
- [x] `pnpm run check:playcanvas-editor-isolation`
- [x] `git diff --check`
- [x] `.agents/skills/autoreview/scripts/autoreview --mode local`
- [x] Local minimal Supabase Playwright `@packages` chromium flow был выполнен во время implementation QA cycle.
</details>
