### PR TITLE
GH883 Fix Interpretation Network child cell creation regressions

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -6,7 +6,7 @@
 
 # Universo Platformo React
 
-[![Version](https://img.shields.io/badge/version-0.74.0--alpha-blue)](https://github.com/teknokomo/universo-platformo-react)
+[![Version](https://img.shields.io/badge/version-0.76.0--alpha-blue)](https://github.com/teknokomo/universo-platformo-react)
 [![License: Omsk Open License](https://img.shields.io/badge/license-Omsk%20Open%20License-green)](LICENSE.md)
 
 **Внимание, пожалуйста, прочитайте это внимательно.**
@@ -63,7 +63,7 @@ Universo Platformo React — это текущая эталонная реали
 
 ## Текущий статус
 
-**Текущая версия**: 0.74.0-alpha (Июль 2026). Проект остаётся в альфа-стадии и готовится к более стабильной бета-фазе.
+**Текущая версия**: 0.76.0-alpha (Август 2026). Проект остаётся в альфа-стадии и готовится к более стабильной бета-фазе.
 
 ## Технологический стек
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Universo Platformo React
 
-[![Version](https://img.shields.io/badge/version-0.74.0--alpha-blue)](https://github.com/teknokomo/universo-platformo-react)
+[![Version](https://img.shields.io/badge/version-0.76.0--alpha-blue)](https://github.com/teknokomo/universo-platformo-react)
 [![License: Omsk Open License](https://img.shields.io/badge/license-Omsk%20Open%20License-green)](LICENSE.md)
 
 **Attention, please read this carefully.**
@@ -63,7 +63,7 @@ Website: [https://universo.pro](https://universo.pro)
 
 ## Current Status
 
-**Current version**: 0.74.0-alpha (Jule 2026). The project remains in alpha and is being prepared for a more stable beta phase.
+**Current version**: 0.76.0-alpha (August 2026). The project remains in alpha and is being prepared for a more stable beta phase.
 
 ## Tech Stack
 

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -1,3 +1,30 @@
+# Interpretation Network Child Matrix Cell QA Remediation (2026-08-14)
+
+> Status: verification_in_progress
+> Source QA: after PR #882, a clean rebuild and import of `tools/fixtures/metahubs-interpretation-network-app-snapshot.json` still failed to create a child Matrix cell with "Данные или расположение ячейки некорректны".
+
+## UI And Security Contract
+
+-   Child creation submits visible business fields only; `CellId`, `ParentCellId`, `RowKey`, `ColKey`, `MaterialRef`, and runtime control fields remain server-owned.
+-   Hidden placement controls cannot overwrite the visible localized title or description with empty values.
+-   Create requires both `createContent` and `editContent`; edit requires `editContent`; delete requires `deleteContent`.
+-   Runtime widget resolution prefers the current workspace layout over the global fallback and fails closed on same-rank ambiguity.
+-   New persisted identities remain UUID v7; Matrix writes remain parameterized, transactional, workspace-scoped, cycle/coordinate validated, and guarded by advisory locks.
+-   The Russian dialog keeps localized validation, multiline Description, no raw identifiers/JSON, and no page-level horizontal overflow.
+
+## Checklist
+
+-   [x] QI1. Reproduce and trace the imported-snapshot child-cell path across MUI form merging, command payload construction, backend runtime surface resolution, and Matrix persistence.
+-   [x] QI2. Prevent hidden/system-owned Matrix fields from overriding trusted placement or leaking into the command payload.
+-   [x] QI3. Align frontend create controls and mutation guards with the backend `createContent + editContent` policy.
+-   [x] QI4. Scope runtime widget resolution and generic single-system guards through `_app_layouts.scope_entity_id`, with workspace-specific precedence and ambiguity fail-closed behavior.
+-   [x] QI5. Add focused Vitest/Jest coverage for payload sanitization, hidden placement, permission combinations, workspace isolation, and generic create protection.
+-   [x] QI6. Add direct imported-snapshot Playwright coverage for the Russian hidden-placement child-cell journey and integrate it into the established full flow.
+-   [ ] QI7. Run Prettier, focused tests, lint/build, fixture contract/drift, minimal-Supabase Playwright proof, UUID/data-operation/security review, OntoIndex diff verification, and Thermos/autoreview.
+-   [ ] QI8. Record final evidence in `memory-bank/progress.md` after every required check is terminal.
+
+---
+
 # Interpretation Network Child Matrix Cell Remediation (2026-08-06)
 
 > Status: complete_with_browser_followups

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "universo-platformo-react",
-    "version": "0.74.0-alpha",
+    "version": "0.76.0-alpha",
     "private": true,
     "packageManager": "pnpm@10.33.2",
     "homepage": "https://universo.pro",

--- a/packages/universo-react-applications-backend/src/controllers/runtimeRowsController.ts
+++ b/packages/universo-react-applications-backend/src/controllers/runtimeRowsController.ts
@@ -46,7 +46,7 @@ import {
 import { RuntimePostingMovementService } from '../services/runtimePostingMovements'
 import { applyWorkflowAction, type WorkflowStatusValueMap } from '../services/runtimeWorkflowActions'
 import type { RolePermission } from '../routes/guards'
-import { INTERPRETATION_NETWORK_WIDGET_KEY, SYSTEM_STRUCTURE_KEY } from '../services/interpretationNetwork/runtimeInterpretationNetworkCore'
+import { SYSTEM_STRUCTURE_KEY } from '../services/interpretationNetwork/runtimeInterpretationNetworkCore'
 import { resolveInterpretationNetworkRuntimeSurface } from '../services/interpretationNetwork/runtimeInterpretationNetworkSurface'
 import {
     UpdateFailure,
@@ -661,7 +661,16 @@ const assertNotProtectedSystemStructureRuntimeRow = async (
             code: 'INTERPRETATION_NETWORK_AMBIGUOUS_WIDGET_CONTEXT'
         })
     }
-    if (surface.featureState !== 'ready' || surface.structureMode !== 'singleSystem') return
+    const isSingleSystemAggregateObject =
+        surface.structureMode === 'singleSystem' &&
+        (surface.resolvedObjects.Structure === objectCollectionId || surface.resolvedObjects.Interpretation === objectCollectionId)
+    if (surface.featureState !== 'ready' && isSingleSystemAggregateObject) {
+        throw new UpdateFailure(409, {
+            error: 'Interpretation Network runtime metadata is incomplete for single-structure mode',
+            code: 'INTERPRETATION_NETWORK_MISSING_METADATA'
+        })
+    }
+    if (surface.structureMode !== 'singleSystem') return
     if (surface.resolvedObjects.Structure === objectCollectionId) {
         if (!systemKeyAttr || String(row[systemKeyAttr.column_name] ?? '').trim() !== SYSTEM_STRUCTURE_KEY) return
         throw new UpdateFailure(409, {
@@ -704,32 +713,37 @@ const assertInterpretationNetworkGenericCreateAllowed = async (
     objectCollectionId: string
 ): Promise<void> => {
     await manager.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`${ctx.schemaName}:interpretation-network:structure-mode`])
-    const protectedRows = await manager.query<{ protected: boolean }>(
-        `
-        SELECT EXISTS (
-            SELECT 1
-            FROM ${quoteIdentifier(ctx.schemaName)}._app_widgets widget
-            INNER JOIN ${quoteIdentifier(ctx.schemaName)}._app_layouts layout ON layout.id = widget.layout_id
-            INNER JOIN ${quoteIdentifier(ctx.schemaName)}._app_objects object_row ON object_row.id = $1
-            WHERE widget.widget_key = $2
-              AND widget.config->>'structureMode' = 'singleSystem'
-              AND widget.is_active = true
-              AND widget._upl_deleted = false
-              AND widget._app_deleted = false
-              AND layout.is_active = true
-              AND layout._upl_deleted = false
-              AND layout._app_deleted = false
-              AND object_row._upl_deleted = false
-              AND object_row._app_deleted = false
-              AND ${runtimeCodenameTextSql('object_row.codename')} IN (
-                  COALESCE(NULLIF(widget.config->>'conceptCodename', ''), 'Structure'),
-                  COALESCE(NULLIF(widget.config->>'interpretationCodename', ''), 'Interpretation')
-              )
-        ) AS protected
-        `,
-        [objectCollectionId, INTERPRETATION_NETWORK_WIDGET_KEY]
-    )
-    if (protectedRows[0]?.protected !== true) return
+    const surface = await resolveInterpretationNetworkRuntimeSurface(manager, {
+        applicationId,
+        schemaName: ctx.schemaName,
+        workspaceId: ctx.currentWorkspaceId
+    })
+    if (surface.featureState === 'ambiguous-widget') {
+        throw new UpdateFailure(409, {
+            error: 'Interpretation Network runtime widget context is ambiguous',
+            code: 'INTERPRETATION_NETWORK_AMBIGUOUS_WIDGET_CONTEXT'
+        })
+    }
+    const requestedObjectRoles = Object.entries(surface.resolvedObjects)
+        .filter(([, resolvedObjectId]) => resolvedObjectId === objectCollectionId)
+        .map(([role]) => role)
+    const protectsSingleSystemAggregate =
+        surface.structureMode === 'singleSystem' &&
+        (requestedObjectRoles.includes('Structure') || requestedObjectRoles.includes('Interpretation'))
+
+    if (surface.featureState !== 'ready' && protectsSingleSystemAggregate) {
+        throw new UpdateFailure(409, {
+            error: 'Interpretation Network runtime metadata is incomplete for single-structure mode',
+            code: 'INTERPRETATION_NETWORK_MISSING_METADATA'
+        })
+    }
+    if (surface.featureState === 'ready' && !protectsSingleSystemAggregate) {
+        return
+    }
+    if (surface.featureState !== 'ready' || surface.structureMode !== 'singleSystem') {
+        return
+    }
+
     throw new UpdateFailure(409, {
         error: 'Structure aggregates are managed by Interpretation Network single-structure mode',
         code: 'INTERPRETATION_NETWORK_GENERIC_CREATE_FORBIDDEN'
@@ -7450,8 +7464,8 @@ export function createRuntimeRowsController(getDbExecutor: () => DbExecutor) {
         let afterCopyLifecycleRequest: RuntimeLifecycleDispatchRequest | null = null
 
         const performCopy = async (mgr: DbExecutor) => {
-            await assertInterpretationNetworkGenericCreateAllowed(mgr, ctx, applicationId, objectCollection.id)
             await assertInterpretationNetworkGenericCopyAllowed(mgr, ctx, applicationId, objectCollection.id)
+            await assertInterpretationNetworkGenericCreateAllowed(mgr, ctx, applicationId, objectCollection.id)
             const transactionalSourceValues: unknown[] = [rowId]
             const transactionalSourceAccessClause = await buildRuntimeRecordAccessClause({
                 manager: mgr,
@@ -8369,7 +8383,6 @@ export function createRuntimeRowsController(getDbExecutor: () => DbExecutor) {
 
         try {
             await ctx.manager.transaction(async (txManager) => {
-                await assertInterpretationNetworkGenericCreateAllowed(txManager, ctx, applicationId, objectCollection.id)
                 const sourceValues: unknown[] = [rowId]
                 const sourceAccessClause = await buildRuntimeRecordAccessClause({
                     manager: txManager,
@@ -8409,6 +8422,7 @@ export function createRuntimeRowsController(getDbExecutor: () => DbExecutor) {
                     })
                 }
                 await assertNotProtectedSystemStructureRuntimeRow(txManager, ctx, applicationId, objectCollection.id, attrs, sourceRow)
+                await assertInterpretationNetworkGenericCreateAllowed(txManager, ctx, applicationId, objectCollection.id)
                 if (parsedBody.data.expectedVersion !== undefined) {
                     const actualVersion = Number(sourceRow._upl_version ?? 1)
                     if (actualVersion !== parsedBody.data.expectedVersion) {

--- a/packages/universo-react-applications-backend/src/services/interpretationNetwork/runtimeInterpretationNetworkCore.ts
+++ b/packages/universo-react-applications-backend/src/services/interpretationNetwork/runtimeInterpretationNetworkCore.ts
@@ -167,6 +167,7 @@ export type WidgetRow = {
     layout_id: string
     widget_key: string
     config: Record<string, unknown> | null
+    scope_rank?: number
 }
 
 export type ObjectRow = {

--- a/packages/universo-react-applications-backend/src/services/interpretationNetwork/runtimeInterpretationNetworkSurface.ts
+++ b/packages/universo-react-applications-backend/src/services/interpretationNetwork/runtimeInterpretationNetworkSurface.ts
@@ -27,7 +27,8 @@ export const resolveInterpretationNetworkRuntimeSurface = async (
 ): Promise<InterpretationNetworkRuntimeSurface> => {
     const widgetRows = await executor.query<WidgetRow>(
         `
-        SELECT widget.id, widget.layout_id, widget.widget_key, widget.config
+        SELECT widget.id, widget.layout_id, widget.widget_key, widget.config,
+               CASE WHEN layout.scope_entity_id = $2 THEN 0 ELSE 1 END AS scope_rank
         FROM ${qSchemaTable(params.schemaName, '_app_widgets')} widget
         INNER JOIN ${qSchemaTable(params.schemaName, '_app_layouts')} layout
             ON layout.id = widget.layout_id
@@ -38,17 +39,24 @@ export const resolveInterpretationNetworkRuntimeSurface = async (
           AND layout._upl_deleted = false
           AND layout._app_deleted = false
           AND layout.is_active = true
-          AND ($2::uuid IS NULL OR widget.layout_id = $2)
-          AND ($3::uuid IS NULL OR widget.id = $3)
-        ORDER BY layout.is_default DESC, layout.sort_order ASC, widget.sort_order ASC, widget.id ASC
+          AND (
+              $2::uuid IS NULL
+              OR layout.scope_entity_id IS NULL
+              OR layout.scope_entity_id = $2
+          )
+          AND ($3::uuid IS NULL OR widget.layout_id = $3)
+          AND ($4::uuid IS NULL OR widget.id = $4)
+        ORDER BY scope_rank ASC, layout.is_default DESC, layout.sort_order ASC, widget.sort_order ASC, widget.id ASC
         LIMIT 2
         `,
-        [INTERPRETATION_NETWORK_WIDGET_KEY, params.layoutId ?? null, params.widgetId ?? null]
+        [INTERPRETATION_NETWORK_WIDGET_KEY, params.workspaceId ?? null, params.layoutId ?? null, params.widgetId ?? null]
     )
     // Without an explicit runtime widget identity, more than one active widget
     // is ambiguous. Failing closed prevents settings or aggregate commands from
     // silently using an unrelated scoped layout.
-    const widget = widgetRows.length === 1 ? widgetRows[0] : null
+    const effectiveScopeRank = widgetRows[0]?.scope_rank
+    const effectiveWidgetRows = widgetRows.filter((row) => row.scope_rank === effectiveScopeRank)
+    const widget = effectiveWidgetRows.length === 1 ? effectiveWidgetRows[0] : null
     const widgetConfig = isRecord(widget?.config) ? widget.config : {}
     const structureMode = parseInterpretationNetworkStructureMode(widgetConfig.structureMode)
 
@@ -62,8 +70,9 @@ export const resolveInterpretationNetworkRuntimeSurface = async (
             widgetKey: INTERPRETATION_NETWORK_WIDGET_KEY,
             widgetConfig,
             structureMode,
-            featureState: widgetRows.length > 1 ? 'ambiguous-widget' : 'missing-widget',
-            missing: widgetRows.length > 1 ? [`${INTERPRETATION_NETWORK_WIDGET_KEY}:ambiguous`] : [INTERPRETATION_NETWORK_WIDGET_KEY],
+            featureState: effectiveWidgetRows.length > 1 ? 'ambiguous-widget' : 'missing-widget',
+            missing:
+                effectiveWidgetRows.length > 1 ? [`${INTERPRETATION_NETWORK_WIDGET_KEY}:ambiguous`] : [INTERPRETATION_NETWORK_WIDGET_KEY],
             resolvedObjects: {}
         }
     }

--- a/packages/universo-react-applications-backend/src/tests/controllers/runtimeRowsController.test.ts
+++ b/packages/universo-react-applications-backend/src/tests/controllers/runtimeRowsController.test.ts
@@ -58,6 +58,7 @@ function createRuntimeRequest(overrides: Partial<Request> = {}): Request {
 
 const mutableObjectCollectionId = '019f2000-0000-7000-8000-000000000100'
 const staleOrPageObjectCollectionId = '019f2000-0000-7000-8000-000000000999'
+const testApplicationId = '019f2000-0000-7000-8000-000000000001'
 
 const runtimeObjectCollectionRows = [
     {
@@ -339,11 +340,15 @@ describe('runtimeRowsController single-system Structure protection', () => {
     it('blocks generic Structure creation while single-system mode is active', async () => {
         const { controller, executor } = createRuntimeMutationHarness()
         const res = createResponse()
+        mockResolveInterpretationNetworkRuntimeSurface.mockResolvedValue({
+            featureState: 'ready',
+            structureMode: 'singleSystem',
+            resolvedObjects: { Structure: mutableObjectCollectionId }
+        })
         executor.query.mockImplementation(async (sql: string) => {
             if (sql.includes('FROM runtime_schema._app_objects') && sql.includes('ORDER BY')) return runtimeObjectCollectionRows
             if (sql.includes('FROM runtime_schema._app_components')) return mutableRuntimeComponents
             if (sql.includes('pg_advisory_xact_lock')) return []
-            if (sql.includes('AS protected')) return [{ protected: true }]
             return []
         })
         executor.transaction.mockImplementation(async (fn: (manager: typeof executor) => Promise<unknown>) => fn(executor))
@@ -361,6 +366,195 @@ describe('runtimeRowsController single-system Structure protection', () => {
             code: 'INTERPRETATION_NETWORK_GENERIC_CREATE_FORBIDDEN'
         })
         expect(executor.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO runtime_schema."structure"'))).toBe(false)
+    })
+
+    it('fails closed when generic Structure creation resolves an ambiguous runtime widget', async () => {
+        const { controller, executor } = createRuntimeMutationHarness()
+        const res = createResponse()
+        mockResolveInterpretationNetworkRuntimeSurface.mockResolvedValue({
+            featureState: 'ambiguous-widget',
+            structureMode: 'multiple',
+            resolvedObjects: {}
+        })
+        executor.query.mockImplementation(async (sql: string) => {
+            if (sql.includes('FROM runtime_schema._app_objects') && sql.includes('ORDER BY')) return runtimeObjectCollectionRows
+            if (sql.includes('FROM runtime_schema._app_components')) return mutableRuntimeComponents
+            if (sql.includes('pg_advisory_xact_lock')) return []
+            return []
+        })
+        executor.transaction.mockImplementation(async (fn: (manager: typeof executor) => Promise<unknown>) => fn(executor))
+
+        await controller.createRow(
+            createRuntimeRequest({
+                body: { objectCollectionId: mutableObjectCollectionId, data: { Name: 'Ambiguous create' } }
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(409)
+        expect(res.status.mock.results[0]?.value.json).toHaveBeenCalledWith({
+            error: 'Interpretation Network runtime widget context is ambiguous',
+            code: 'INTERPRETATION_NETWORK_AMBIGUOUS_WIDGET_CONTEXT'
+        })
+        expect(executor.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO runtime_schema."structure"'))).toBe(false)
+    })
+
+    it('fails closed when generic Structure creation finds incomplete single-system metadata', async () => {
+        const { controller, executor } = createRuntimeMutationHarness()
+        const res = createResponse()
+        mockResolveInterpretationNetworkRuntimeSurface.mockResolvedValue({
+            featureState: 'missing-metadata',
+            structureMode: 'singleSystem',
+            missing: ['Interpretation.InterpretationMatrix.MaterialRef'],
+            resolvedObjects: { Structure: mutableObjectCollectionId }
+        })
+        executor.query.mockImplementation(async (sql: string) => {
+            if (sql.includes('FROM runtime_schema._app_objects') && sql.includes('ORDER BY')) return runtimeObjectCollectionRows
+            if (sql.includes('FROM runtime_schema._app_components')) return mutableRuntimeComponents
+            if (sql.includes('pg_advisory_xact_lock')) return []
+            return []
+        })
+        executor.transaction.mockImplementation(async (fn: (manager: typeof executor) => Promise<unknown>) => fn(executor))
+
+        await controller.createRow(
+            createRuntimeRequest({
+                body: { objectCollectionId: mutableObjectCollectionId, data: { Name: 'Incomplete metadata create' } }
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(409)
+        expect(res.status.mock.results[0]?.value.json).toHaveBeenCalledWith({
+            error: 'Interpretation Network runtime metadata is incomplete for single-structure mode',
+            code: 'INTERPRETATION_NETWORK_MISSING_METADATA'
+        })
+        expect(executor.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO runtime_schema."structure"'))).toBe(false)
+    })
+
+    it('uses workspace-scoped runtime surface resolution for generic Structure creation protection', async () => {
+        const { controller, executor } = createRuntimeMutationHarness()
+        const res = createResponse()
+        mockResolveRuntimeSchema.mockResolvedValue({
+            schemaName: 'runtime_schema',
+            schemaIdent: 'runtime_schema',
+            manager: executor,
+            userId: 'user-1',
+            role: 'owner',
+            permissions: {
+                createContent: true,
+                editContent: true,
+                deleteContent: true,
+                restoreContent: true,
+                viewContent: true,
+                manageContent: true,
+                manageSettings: true,
+                manageUsers: true
+            },
+            workflowCapabilities: {},
+            currentWorkspaceId: '019f2000-0000-7000-8000-000000000777',
+            workspacesEnabled: false,
+            applicationSettings: {}
+        })
+        mockResolveInterpretationNetworkRuntimeSurface.mockResolvedValue({
+            featureState: 'ready',
+            structureMode: 'multiple',
+            resolvedObjects: { Structure: mutableObjectCollectionId }
+        })
+        executor.query.mockImplementation(async (sql: string) => {
+            if (sql.includes('FROM runtime_schema._app_objects') && sql.includes('ORDER BY')) return runtimeObjectCollectionRows
+            if (sql.includes('FROM runtime_schema._app_components')) return mutableRuntimeComponents
+            if (sql.includes('pg_advisory_xact_lock')) return []
+            if (sql.includes('INSERT INTO runtime_schema."structure"')) {
+                return [
+                    {
+                        id: '019f2000-0000-7000-8000-000000000002',
+                        name: 'Allowed in workspace B',
+                        system_key: null,
+                        _upl_version: 1
+                    }
+                ]
+            }
+            return []
+        })
+        executor.transaction.mockImplementation(async (fn: (manager: typeof executor) => Promise<unknown>) => fn(executor))
+
+        await controller.createRow(
+            createRuntimeRequest({
+                body: { objectCollectionId: mutableObjectCollectionId, data: { Name: 'Allowed in workspace B' } }
+            }),
+            res
+        )
+
+        expect(mockResolveInterpretationNetworkRuntimeSurface).toHaveBeenCalledWith(executor, {
+            applicationId: testApplicationId,
+            schemaName: 'runtime_schema',
+            workspaceId: '019f2000-0000-7000-8000-000000000777'
+        })
+        expect(res.status).toHaveBeenCalledWith(201)
+        expect(executor.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO runtime_schema."structure"'))).toBe(true)
+    })
+
+    it('lets workspace-scoped multi-structure mode override a global single-system generic create guard', async () => {
+        const { controller, executor } = createRuntimeMutationHarness()
+        const res = createResponse()
+        mockResolveRuntimeSchema.mockResolvedValue({
+            schemaName: 'runtime_schema',
+            schemaIdent: 'runtime_schema',
+            manager: executor,
+            userId: 'user-1',
+            role: 'owner',
+            permissions: {
+                createContent: true,
+                editContent: true,
+                deleteContent: true,
+                restoreContent: true,
+                viewContent: true,
+                manageContent: true,
+                manageSettings: true,
+                manageUsers: true
+            },
+            workflowCapabilities: {},
+            currentWorkspaceId: '019f2000-0000-7000-8000-000000000777',
+            workspacesEnabled: false,
+            applicationSettings: {}
+        })
+        mockResolveInterpretationNetworkRuntimeSurface.mockResolvedValue({
+            featureState: 'ready',
+            structureMode: 'multiple',
+            resolvedObjects: { Structure: mutableObjectCollectionId }
+        })
+        executor.query.mockImplementation(async (sql: string) => {
+            if (sql.includes('FROM runtime_schema._app_objects') && sql.includes('ORDER BY')) return runtimeObjectCollectionRows
+            if (sql.includes('FROM runtime_schema._app_components')) return mutableRuntimeComponents
+            if (sql.includes('pg_advisory_xact_lock')) return []
+            if (sql.includes('INSERT INTO runtime_schema."structure"')) {
+                return [
+                    {
+                        id: '019f2000-0000-7000-8000-000000000003',
+                        name: 'Workspace scoped structure',
+                        system_key: null,
+                        _upl_version: 1
+                    }
+                ]
+            }
+            return []
+        })
+        executor.transaction.mockImplementation(async (fn: (manager: typeof executor) => Promise<unknown>) => fn(executor))
+
+        await controller.createRow(
+            createRuntimeRequest({
+                body: { objectCollectionId: mutableObjectCollectionId, data: { Name: 'Workspace scoped structure' } }
+            }),
+            res
+        )
+
+        expect(mockResolveInterpretationNetworkRuntimeSurface).toHaveBeenCalledWith(executor, {
+            applicationId: testApplicationId,
+            schemaName: 'runtime_schema',
+            workspaceId: '019f2000-0000-7000-8000-000000000777'
+        })
+        expect(res.status).toHaveBeenCalledWith(201)
+        expect(executor.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO runtime_schema."structure"'))).toBe(true)
     })
 
     it('fails closed when multiple active Interpretation Network widgets make a Structure update ambiguous', async () => {
@@ -440,6 +634,48 @@ describe('runtimeRowsController single-system Structure protection', () => {
         expect(res.status.mock.results[0]?.value.json).toHaveBeenCalledWith(
             expect.objectContaining({ code: 'INTERPRETATION_NETWORK_SYSTEM_STRUCTURE_IMMUTABLE' })
         )
+    })
+
+    it('fails closed before updating single-system Structure rows when runtime metadata is incomplete', async () => {
+        const { controller, executor } = createRuntimeMutationHarness()
+        const res = createResponse()
+        mockResolveInterpretationNetworkRuntimeSurface.mockResolvedValue({
+            featureState: 'missing-metadata',
+            structureMode: 'singleSystem',
+            missing: ['TableTemplate.TemplateMatrix.MaterialRef'],
+            resolvedObjects: { Structure: mutableObjectCollectionId }
+        })
+        executor.query.mockImplementation(async (sql: string) => {
+            if (sql.includes('FROM runtime_schema._app_objects') && sql.includes('ORDER BY')) return runtimeObjectCollectionRows
+            if (sql.includes('SELECT *')) {
+                return [
+                    {
+                        id: '019f2000-0000-7000-8000-000000000002',
+                        name: 'Main',
+                        system_key: 'primary',
+                        _upl_version: 1
+                    }
+                ]
+            }
+            if (sql.includes('FROM runtime_schema._app_components')) return mutableRuntimeComponents
+            return []
+        })
+        executor.transaction.mockImplementation(async (fn: (manager: typeof executor) => Promise<unknown>) => fn(executor))
+
+        await controller.bulkUpdateRow(
+            createRuntimeRequest({
+                method: 'PATCH',
+                body: { objectCollectionId: mutableObjectCollectionId, data: { Name: 'Renamed' }, expectedVersion: 1 }
+            }),
+            res
+        )
+
+        expect(res.status).toHaveBeenCalledWith(409)
+        expect(res.status.mock.results[0]?.value.json).toHaveBeenCalledWith({
+            error: 'Interpretation Network runtime metadata is incomplete for single-structure mode',
+            code: 'INTERPRETATION_NETWORK_MISSING_METADATA'
+        })
+        expect(executor.query.mock.calls.some(([sql]) => String(sql).includes('UPDATE runtime_schema."structure"'))).toBe(false)
     })
 
     it('rechecks Interpretation Network copy protection inside the transaction', async () => {

--- a/packages/universo-react-applications-backend/src/tests/services/runtimeInterpretationNetworkService.test.ts
+++ b/packages/universo-react-applications-backend/src/tests/services/runtimeInterpretationNetworkService.test.ts
@@ -93,7 +93,7 @@ describe('runtimeInterpretationNetworkService', () => {
         const { executor } = createMockDbExecutor()
         executor.query.mockImplementation(async (sql: string, params?: unknown[]) => {
             if (sql.includes(`FROM "${schemaName}"."_app_widgets"`)) {
-                expect(params).toEqual(['interpretationNetworkWorkspace', null, null])
+                expect(params).toEqual(['interpretationNetworkWorkspace', workspaceId, null, null])
                 return [
                     {
                         id: '018f8a78-7b8f-7c1d-a111-2222333344a1',
@@ -120,6 +120,253 @@ describe('runtimeInterpretationNetworkService', () => {
 
         expect(surface.featureState).toBe('ambiguous-widget')
         expect(surface.widgetId).toBeNull()
+    })
+
+    it('uses _app_layouts scope_entity_id for workspace runtime widget resolution', async () => {
+        const { executor } = createMockDbExecutor()
+        executor.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+            if (sql.includes(`FROM "${schemaName}"."_app_widgets"`)) {
+                expect(sql).toContain('layout.scope_entity_id IS NULL')
+                expect(sql).toContain('layout.scope_entity_id = $2')
+                expect(sql).not.toContain("widget.config->>'workspaceId'")
+                expect(params).toEqual(['interpretationNetworkWorkspace', workspaceId, null, null])
+                return [
+                    {
+                        id: 'widget-current-workspace',
+                        layout_id: 'layout-current-workspace',
+                        widget_key: 'interpretationNetworkWorkspace',
+                        config: { structureMode: 'singleSystem' }
+                    }
+                ]
+            }
+            if (sql.includes(`FROM "${schemaName}"."_app_objects"`)) {
+                return [
+                    { id: 'structure-1', codename: 'Structure', table_name: 'structure' },
+                    { id: 'interpretation-1', codename: 'Interpretation', table_name: 'interpretation' },
+                    { id: 'material-1', codename: 'Material', table_name: 'material' },
+                    { id: 'table-template-1', codename: 'TableTemplate', table_name: 'table_template' }
+                ]
+            }
+            if (sql.includes(`FROM "${schemaName}"."_app_components"`)) {
+                const objectId = params?.[0]
+                if (objectId === 'structure-1') {
+                    return [
+                        { codename: 'Name', column_name: 'name', data_type: 'STRING' },
+                        { codename: 'SystemKey', column_name: 'system_key', data_type: 'STRING' }
+                    ]
+                }
+                if (objectId === 'interpretation-1') {
+                    return [
+                        { id: 'interpretation-title', codename: 'Title', column_name: 'title', data_type: 'STRING' },
+                        { id: 'interpretation-parent', codename: 'ParentStructure', column_name: 'parent_structure', data_type: 'REF' },
+                        {
+                            id: 'interpretation-matrix',
+                            codename: 'InterpretationMatrix',
+                            column_name: 'interpretation_matrix',
+                            data_type: 'TABLE'
+                        },
+                        {
+                            id: 'interpretation-cell-id',
+                            codename: 'CellId',
+                            column_name: 'cell_id',
+                            data_type: 'STRING',
+                            parent_component_id: 'interpretation-matrix'
+                        },
+                        {
+                            id: 'interpretation-material-ref',
+                            codename: 'MaterialRef',
+                            column_name: 'material_ref',
+                            data_type: 'REF',
+                            parent_component_id: 'interpretation-matrix'
+                        }
+                    ]
+                }
+                if (objectId === 'material-1') {
+                    return [
+                        { codename: 'CellId', column_name: 'cell_id', data_type: 'STRING' },
+                        { codename: 'TemplateOwnerId', column_name: 'template_owner_id', data_type: 'STRING' }
+                    ]
+                }
+                if (objectId === 'table-template-1') {
+                    return [
+                        { id: 'template-name', codename: 'Name', column_name: 'name', data_type: 'STRING' },
+                        { id: 'template-policy', codename: 'MaterialPolicy', column_name: 'material_policy', data_type: 'STRING' },
+                        { id: 'template-matrix', codename: 'TemplateMatrix', column_name: 'template_matrix', data_type: 'TABLE' },
+                        {
+                            id: 'template-cell-id',
+                            codename: 'CellId',
+                            column_name: 'cell_id',
+                            data_type: 'STRING',
+                            parent_component_id: 'template-matrix'
+                        },
+                        {
+                            id: 'template-material-ref',
+                            codename: 'MaterialRef',
+                            column_name: 'material_ref',
+                            data_type: 'REF',
+                            parent_component_id: 'template-matrix'
+                        }
+                    ]
+                }
+            }
+            return []
+        })
+
+        const surface = await resolveInterpretationNetworkRuntimeSurface(executor, {
+            applicationId: 'app-1',
+            schemaName,
+            workspaceId
+        })
+
+        expect(surface.featureState).toBe('ready')
+        expect(surface.layoutId).toBe('layout-current-workspace')
+        expect(surface.widgetId).toBe('widget-current-workspace')
+    })
+
+    it('prefers a workspace-scoped widget over a global Interpretation Network widget', async () => {
+        const { executor } = createMockDbExecutor()
+        executor.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+            if (sql.includes(`FROM "${schemaName}"."_app_widgets"`)) {
+                expect(sql).toContain('CASE WHEN layout.scope_entity_id = $2 THEN 0 ELSE 1 END AS scope_rank')
+                expect(sql).toContain('ORDER BY scope_rank ASC')
+                expect(params).toEqual(['interpretationNetworkWorkspace', workspaceId, null, null])
+                return [
+                    {
+                        id: 'widget-current-workspace',
+                        layout_id: 'layout-current-workspace',
+                        widget_key: 'interpretationNetworkWorkspace',
+                        config: { structureMode: 'multiple' },
+                        scope_rank: 0
+                    },
+                    {
+                        id: 'widget-global',
+                        layout_id: 'layout-global',
+                        widget_key: 'interpretationNetworkWorkspace',
+                        config: { structureMode: 'singleSystem' },
+                        scope_rank: 1
+                    }
+                ]
+            }
+            if (sql.includes(`FROM "${schemaName}"."_app_objects"`)) {
+                return [
+                    { id: 'structure-1', codename: 'Structure', table_name: 'structure' },
+                    { id: 'interpretation-1', codename: 'Interpretation', table_name: 'interpretation' },
+                    { id: 'material-1', codename: 'Material', table_name: 'material' },
+                    { id: 'table-template-1', codename: 'TableTemplate', table_name: 'table_template' }
+                ]
+            }
+            if (sql.includes(`FROM "${schemaName}"."_app_components"`)) {
+                const objectId = params?.[0]
+                if (objectId === 'structure-1') {
+                    return [
+                        { codename: 'Name', column_name: 'name', data_type: 'STRING' },
+                        { codename: 'SystemKey', column_name: 'system_key', data_type: 'STRING' }
+                    ]
+                }
+                if (objectId === 'interpretation-1') {
+                    return [
+                        { id: 'interpretation-title', codename: 'Title', column_name: 'title', data_type: 'STRING' },
+                        { id: 'interpretation-parent', codename: 'ParentStructure', column_name: 'parent_structure', data_type: 'REF' },
+                        {
+                            id: 'interpretation-matrix',
+                            codename: 'InterpretationMatrix',
+                            column_name: 'interpretation_matrix',
+                            data_type: 'TABLE'
+                        },
+                        {
+                            id: 'interpretation-cell-id',
+                            codename: 'CellId',
+                            column_name: 'cell_id',
+                            data_type: 'STRING',
+                            parent_component_id: 'interpretation-matrix'
+                        },
+                        {
+                            id: 'interpretation-material-ref',
+                            codename: 'MaterialRef',
+                            column_name: 'material_ref',
+                            data_type: 'REF',
+                            parent_component_id: 'interpretation-matrix'
+                        }
+                    ]
+                }
+                if (objectId === 'material-1') {
+                    return [
+                        { codename: 'CellId', column_name: 'cell_id', data_type: 'STRING' },
+                        { codename: 'TemplateOwnerId', column_name: 'template_owner_id', data_type: 'STRING' }
+                    ]
+                }
+                if (objectId === 'table-template-1') {
+                    return [
+                        { id: 'template-name', codename: 'Name', column_name: 'name', data_type: 'STRING' },
+                        { id: 'template-policy', codename: 'MaterialPolicy', column_name: 'material_policy', data_type: 'STRING' },
+                        { id: 'template-matrix', codename: 'TemplateMatrix', column_name: 'template_matrix', data_type: 'TABLE' },
+                        {
+                            id: 'template-cell-id',
+                            codename: 'CellId',
+                            column_name: 'cell_id',
+                            data_type: 'STRING',
+                            parent_component_id: 'template-matrix'
+                        },
+                        {
+                            id: 'template-material-ref',
+                            codename: 'MaterialRef',
+                            column_name: 'material_ref',
+                            data_type: 'REF',
+                            parent_component_id: 'template-matrix'
+                        }
+                    ]
+                }
+            }
+            return []
+        })
+
+        const surface = await resolveInterpretationNetworkRuntimeSurface(executor, {
+            applicationId: 'app-1',
+            schemaName,
+            workspaceId
+        })
+
+        expect(surface.featureState).toBe('ready')
+        expect(surface.structureMode).toBe('multiple')
+        expect(surface.layoutId).toBe('layout-current-workspace')
+        expect(surface.widgetId).toBe('widget-current-workspace')
+    })
+
+    it('fails closed when two widgets have the same effective workspace scope', async () => {
+        const { executor } = createMockDbExecutor()
+        executor.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+            if (sql.includes(`FROM "${schemaName}"."_app_widgets"`)) {
+                expect(params).toEqual(['interpretationNetworkWorkspace', workspaceId, null, null])
+                return [
+                    {
+                        id: 'widget-current-workspace-a',
+                        layout_id: 'layout-current-workspace-a',
+                        widget_key: 'interpretationNetworkWorkspace',
+                        config: { structureMode: 'singleSystem' },
+                        scope_rank: 0
+                    },
+                    {
+                        id: 'widget-current-workspace-b',
+                        layout_id: 'layout-current-workspace-b',
+                        widget_key: 'interpretationNetworkWorkspace',
+                        config: { structureMode: 'multiple' },
+                        scope_rank: 0
+                    }
+                ]
+            }
+            return []
+        })
+
+        const surface = await resolveInterpretationNetworkRuntimeSurface(executor, {
+            applicationId: 'app-1',
+            schemaName,
+            workspaceId
+        })
+
+        expect(surface.featureState).toBe('ambiguous-widget')
+        expect(surface.layoutId).toBeNull()
+        expect(surface.widgetId).toBeNull()
+        expect(surface.missing).toEqual(['interpretationNetworkWorkspace:ambiguous'])
     })
 
     it('resolves ready surface only when the required metadata is present', async () => {

--- a/packages/universo-react-applications-frontend/src/pages/ApplicationSettings.tsx
+++ b/packages/universo-react-applications-frontend/src/pages/ApplicationSettings.tsx
@@ -524,6 +524,7 @@ const ApplicationSettings = () => {
                                       ? {
                                             ...widget,
                                             ...savedWidget,
+                                            isCustomized: savedWidget.isCustomized ?? true,
                                             config: {
                                                 ...widget.config,
                                                 ...(savedWidget.config ?? {}),

--- a/packages/universo-react-applications-frontend/src/pages/__tests__/ApplicationSettings.test.tsx
+++ b/packages/universo-react-applications-frontend/src/pages/__tests__/ApplicationSettings.test.tsx
@@ -2244,6 +2244,75 @@ describe('ApplicationSettings', () => {
         )
     })
 
+    it('shows inherited Matrix reset immediately after saving a metahub-sourced widget override', async () => {
+        mockedListApplicationLayouts.mockResolvedValue({
+            items: [
+                {
+                    id: '018f8a78-7b8f-7c1d-a111-2222333345a1',
+                    scopeId: null,
+                    scopeKind: 'global',
+                    scopeEntityId: null,
+                    templateKey: 'dashboard',
+                    name: { en: 'Dashboard' },
+                    description: null,
+                    config: {},
+                    isActive: true,
+                    isDefault: true,
+                    sortOrder: 0,
+                    sourceKind: 'metahub',
+                    syncState: 'in_sync',
+                    isSourceExcluded: false,
+                    version: 3
+                }
+            ],
+            pagination: { total: 1, limit: 100, offset: 0, count: 1, hasMore: false }
+        } as never)
+        mockedListApplicationLayoutWidgets.mockResolvedValue([
+            {
+                id: '018f8a78-7b8f-7c1d-a111-2222333344a1',
+                layoutId: '018f8a78-7b8f-7c1d-a111-2222333345a1',
+                zone: 'main',
+                widgetKey: 'interpretationNetworkWorkspace',
+                sortOrder: 0,
+                config: { structureMode: 'singleSystem', templatePanel: { showInMatrix: true } },
+                sourceConfig: { structureMode: 'singleSystem', templatePanel: { showInMatrix: true } },
+                isCustomized: false,
+                isActive: true,
+                version: 7
+            }
+        ] as never)
+        mockedUpdateApplicationLayoutWidgetConfigsBatch.mockResolvedValue([
+            {
+                id: '018f8a78-7b8f-7c1d-a111-2222333344a1',
+                layoutId: '018f8a78-7b8f-7c1d-a111-2222333345a1',
+                zone: 'main',
+                widgetKey: 'interpretationNetworkWorkspace',
+                sortOrder: 0,
+                config: { structureMode: 'multiple', templatePanel: { showInMatrix: false } },
+                sourceConfig: { structureMode: 'singleSystem', templatePanel: { showInMatrix: true } },
+                isActive: true,
+                version: 8
+            }
+        ] as never)
+
+        renderSettings()
+        await userEvent.click(await screen.findByRole('tab', { name: 'Matrix' }))
+        expect(screen.queryByTestId('application-settings-matrix-reset')).not.toBeInTheDocument()
+        await userEvent.click(within(screen.getByTestId('application-setting-matrix-structure-mode')).getByRole('combobox'))
+        await userEvent.click(screen.getByRole('option', { name: 'Multiple structures' }))
+        await userEvent.click(screen.getByLabelText('Show next to Matrix'))
+        await userEvent.click(screen.getByTestId('application-settings-matrix-save'))
+
+        expect(await screen.findByTestId('application-settings-matrix-reset')).toBeInTheDocument()
+        expect(getLastMatrixBatchUpdate('018f8a78-7b8f-7c1d-a111-2222333344a1')).toMatchObject({
+            expectedVersion: 7,
+            config: expect.objectContaining({
+                structureMode: 'multiple',
+                templatePanel: expect.objectContaining({ showInMatrix: false })
+            })
+        })
+    }, 15_000)
+
     it('saves matrix settings to the active scoped workspace widget when no global widget exists', async () => {
         mockedListApplicationLayoutScopes.mockResolvedValue([
             {

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/InterpretationNetworkWorkspaceWidget.tsx
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/InterpretationNetworkWorkspaceWidget.tsx
@@ -622,6 +622,7 @@ export default function InterpretationNetworkWorkspaceWidget({
     const { saveCellMutation, deleteCellMutation } = useCellMutations({
         t,
         queryClient,
+        canCreateContent,
         canEditContent,
         canDeleteContent,
         apiBaseUrl: details?.apiBaseUrl,
@@ -739,7 +740,7 @@ export default function InterpretationNetworkWorkspaceWidget({
                   savingCell: saveCellMutation.isPending,
                   movingCell: moveCellMutation.isPending,
                   errors: { rows: matrixRowsQuery.error, saveCell: saveCellMutation.error, moveCell: moveCellMutation.error },
-                  permissions: { canEditContent, canDeleteContent },
+                  permissions: { canCreateContent, canEditContent, canDeleteContent },
                   menu: { anchor: cellMenuAnchor, cell: menuCell, moves: menuMoves },
                   deletingCell: deleteCellMutation.isPending,
                   sensors,

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/__tests__/model.test.ts
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/__tests__/model.test.ts
@@ -55,6 +55,7 @@ const physicalMatrixChildColumns: RuntimeColumnLike[] = [
     { id: 'row-label', codename: 'RowLabel', field: 'phys_row_label' },
     { id: 'col-key', codename: 'ColKey', field: 'phys_col_key' },
     { id: 'col-label', codename: 'ColLabel', field: 'phys_col_label' },
+    { id: 'material-ref', codename: 'MaterialRef', field: 'phys_material_ref', uiConfig: { serverOwned: true } },
     { id: 'value', codename: 'CellValue', field: 'phys_cell_value' }
 ]
 
@@ -196,6 +197,51 @@ describe('interpretation network model', () => {
         expect(createData.ParentCellId).toBeUndefined()
         expect(createData.RowKey).toBeUndefined()
         expect(createData.ColKey).toBeUndefined()
+    })
+
+    it('keeps generated child axis labels when hidden placement submits empty new axes', () => {
+        const source = {
+            id: 'parent-cell',
+            parentCellId: null,
+            sortOrder: 0,
+            rowKey: 'parent-row',
+            rowLabel: 'Parent row',
+            colKey: 'parent-column',
+            colLabel: 'Parent column'
+        } as MatrixCell
+
+        const createData = buildCellCreateData({
+            mode: 'create-child',
+            childColumns: physicalMatrixChildColumns,
+            locale: 'ru',
+            source,
+            existingCells: [source],
+            placement: {
+                parentCellId: source.id,
+                row: { kind: 'new' },
+                column: { kind: 'new' }
+            }
+        })
+
+        expect(createData.phys_parent_cell_id).toBe('parent-cell')
+        expect(createData.phys_row_key).toBe(`row-${createData.phys_cell_id}`)
+        expect(createData.phys_col_key).toBe(`column-${createData.phys_cell_id}`)
+        expect(createData.phys_row_label).toEqual(
+            expect.objectContaining({
+                locales: expect.objectContaining({
+                    ru: expect.objectContaining({ content: '' })
+                })
+            })
+        )
+        expect(createData.phys_col_label).toEqual(
+            expect.objectContaining({
+                locales: expect.objectContaining({
+                    ru: expect.objectContaining({ content: '' })
+                })
+            })
+        )
+        expect(createData.phys_row_label).not.toBeUndefined()
+        expect(createData.phys_col_label).not.toBeUndefined()
     })
 
     it('uses the normalized create-child parent for both persistence and sibling ordering', () => {
@@ -361,6 +407,7 @@ describe('interpretation network model', () => {
             mergeCellCreateData(
                 {
                     CellValue: 'User title',
+                    MaterialRef: 'user-material',
                     _tp_sort_order: 99
                 },
                 {
@@ -368,6 +415,7 @@ describe('interpretation network model', () => {
                     ParentCellId: null,
                     RowKey: 'row-generated-cell',
                     ColKey: 'column-generated-cell',
+                    MaterialRef: null,
                     _tp_sort_order: 3,
                     CellValue: 'Default title'
                 },
@@ -378,6 +426,7 @@ describe('interpretation network model', () => {
             ParentCellId: null,
             RowKey: 'row-generated-cell',
             ColKey: 'column-generated-cell',
+            MaterialRef: null,
             _tp_sort_order: 3,
             CellValue: 'User title'
         })
@@ -447,13 +496,50 @@ describe('interpretation network model', () => {
     })
 
     it('protects physical generated matrix placement fields during create merges', () => {
+        const merged = mergeCellCreateData(
+            {
+                phys_cell_id: undefined,
+                phys_parent_cell_id: undefined,
+                phys_row_key: undefined,
+                phys_col_key: undefined,
+                phys_material_ref: null,
+                phys_cell_value: 'User title'
+            },
+            {
+                phys_cell_id: 'generated-cell',
+                phys_parent_cell_id: 'parent-cell',
+                phys_row_key: 'row-generated-cell',
+                phys_col_key: 'column-generated-cell',
+                phys_cell_value: 'Default title'
+            },
+            resolveCellCreateSystemFields(physicalMatrixChildColumns)
+        )
+
+        expect(merged).toEqual({
+            phys_cell_id: 'generated-cell',
+            phys_parent_cell_id: 'parent-cell',
+            phys_row_key: 'row-generated-cell',
+            phys_col_key: 'column-generated-cell',
+            phys_cell_value: 'User title'
+        })
+        expect(merged).not.toHaveProperty('phys_material_ref')
+    })
+
+    it('drops stale system codenames when trusted create data uses physical system fields', () => {
         expect(
             mergeCellCreateData(
                 {
+                    CellId: 'user-cell-id',
+                    ParentCellId: 'user-parent-cell-id',
+                    RowKey: 'user-row',
+                    ColKey: 'user-column',
+                    MaterialRef: 'user-material',
+                    _tp_sort_order: 99,
                     phys_cell_id: undefined,
                     phys_parent_cell_id: undefined,
                     phys_row_key: undefined,
                     phys_col_key: undefined,
+                    phys_material_ref: null,
                     phys_cell_value: 'User title'
                 },
                 {
@@ -472,21 +558,10 @@ describe('interpretation network model', () => {
             phys_col_key: 'column-generated-cell',
             phys_cell_value: 'User title'
         })
-    })
-
-    it('drops stale system codenames when trusted create data uses physical system fields', () => {
         expect(
             mergeCellCreateData(
                 {
-                    CellId: 'user-cell-id',
-                    ParentCellId: 'user-parent-cell-id',
-                    RowKey: 'user-row',
-                    ColKey: 'user-column',
-                    _tp_sort_order: 99,
-                    phys_cell_id: undefined,
-                    phys_parent_cell_id: undefined,
-                    phys_row_key: undefined,
-                    phys_col_key: undefined,
+                    phys_material_ref: null,
                     phys_cell_value: 'User title'
                 },
                 {
@@ -497,6 +572,35 @@ describe('interpretation network model', () => {
                     phys_cell_value: 'Default title'
                 },
                 resolveCellCreateSystemFields(physicalMatrixChildColumns)
+            )
+        ).not.toHaveProperty('phys_material_ref')
+    })
+
+    it('drops generated server-owned fields even when only metadata marks them as system managed', () => {
+        const generatedMaterialField = 'cmp_generated_material_ref'
+
+        expect(
+            mergeCellCreateData(
+                {
+                    [generatedMaterialField]: null,
+                    phys_cell_value: 'User title'
+                },
+                {
+                    phys_cell_id: 'generated-cell',
+                    phys_parent_cell_id: 'parent-cell',
+                    phys_row_key: 'row-generated-cell',
+                    phys_col_key: 'column-generated-cell',
+                    phys_cell_value: 'Default title'
+                },
+                resolveCellCreateSystemFields([
+                    ...physicalMatrixChildColumns.filter((column) => column.codename !== 'MaterialRef'),
+                    {
+                        id: '019f-material-ref',
+                        codename: 'MaterialRef',
+                        field: generatedMaterialField,
+                        uiConfig: { serverOwned: true }
+                    }
+                ])
             )
         ).toEqual({
             phys_cell_id: 'generated-cell',

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/matrixCellData.ts
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/matrixCellData.ts
@@ -195,10 +195,12 @@ export const buildCellCreateData = ({
     const applyNewRow = (axis: Extract<MatrixAxisPlacement, { kind: 'new' }>) => {
         if (axis.key) baseData[rowKeyField] = axis.key
         if (axis.labelValue !== undefined) baseData[rowLabelField] = axis.labelValue
+        else if (axis.label) baseData[rowLabelField] = createLocalizedContent(locale, axis.label)
     }
     const applyNewColumn = (axis: Extract<MatrixAxisPlacement, { kind: 'new' }>) => {
         if (axis.key) baseData[colKeyField] = axis.key
         if (axis.labelValue !== undefined) baseData[colLabelField] = axis.labelValue
+        else if (axis.label) baseData[colLabelField] = createLocalizedContent(locale, axis.label)
     }
 
     if (source && mode === 'create-child') {
@@ -222,13 +224,19 @@ export const buildCellCreateData = ({
     return baseData
 }
 
-const SYSTEM_CREATE_FIELDS = ['CellId', 'ParentCellId', 'RowKey', 'ColKey', '_tp_sort_order'] as const
+const SYSTEM_CREATE_FIELDS = ['CellId', 'ParentCellId', 'RowKey', 'ColKey', 'MaterialRef', '_tp_sort_order'] as const
 
 export const resolveCellCreateSystemFields = (childColumns: RuntimeColumnLike[] | undefined): string[] => [
     ...SYSTEM_CREATE_FIELDS,
     ...SYSTEM_CREATE_FIELDS.map((field) => findColumn(childColumns, field)?.field).filter(
         (field): field is string => typeof field === 'string' && field.length > 0
-    )
+    ),
+    ...(childColumns ?? [])
+        .filter(
+            (column) => column.uiConfig?.serverOwned === true || column.uiConfig?.formHidden === true || column.uiConfig?.hidden === true
+        )
+        .flatMap((column) => [column.id, column.codename, column.field])
+        .filter((field): field is string => typeof field === 'string' && field.length > 0)
 ]
 
 export const mergeCellCreateData = (

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/MatrixWorkspace.tsx
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/MatrixWorkspace.tsx
@@ -102,6 +102,7 @@ export interface MatrixWorkspaceProps {
     matrixRowsError: unknown
     saveCellError: unknown
     moveCellError: unknown
+    canCreateContent: boolean
     canEditContent: boolean
     canDeleteContent: boolean
     cellMenuAnchor: HTMLElement | null
@@ -162,6 +163,7 @@ export function MatrixWorkspace({
     matrixRowsError,
     saveCellError,
     moveCellError,
+    canCreateContent,
     canEditContent,
     canDeleteContent,
     cellMenuAnchor,
@@ -186,12 +188,18 @@ export function MatrixWorkspace({
     onDragEnd
 }: MatrixWorkspaceProps) {
     const hierarchicalMatrixIsEmpty = matrixMode === 'hierarchicalCells' && matrixCells.length === 0
-    const hierarchicalAddDisabled = matrixMutationsDisabled || isSavingCell || !selectedCell || hierarchicalMatrixIsEmpty
-    const tableAxisAddDisabled = matrixAxisActionsDisabled || isSavingCell || hierarchicalMatrixIsEmpty
+    const createDisabled = !canCreateContent || !canEditContent
+    const hierarchicalAddDisabled = createDisabled || matrixMutationsDisabled || isSavingCell || !selectedCell || hierarchicalMatrixIsEmpty
+    const tableAxisAddDisabled = createDisabled || matrixAxisActionsDisabled || isSavingCell || hierarchicalMatrixIsEmpty
     const showIndependentRowAdd = matrixMode === 'independentRows' && matrixView === 'horizontalRows'
-    const independentRowAddDisabled = matrixMutationsDisabled || isSavingCell || isMovingCell || !selectedCell
+    const independentRowAddDisabled = createDisabled || matrixMutationsDisabled || isSavingCell || isMovingCell || !selectedCell
     const cellMenuOpen = Boolean(cellMenuAnchor?.isConnected)
     const cellMenuAnchorPosition = toMenuAnchorPosition(cellMenuAnchor)
+    const createDisabledReason = !canCreateContent
+        ? t('workspace.cell.createPermissionDisabled', 'You do not have permission to create matrix cells.')
+        : !canEditContent
+        ? t('workspace.cell.editPermissionDisabled', 'You do not have permission to change matrix cells.')
+        : undefined
 
     const isHorizontalHierarchy = matrixMode === 'hierarchicalCells' && matrixView === 'horizontalRows'
     const buildCellAccessibleLabel = (cell: MatrixCell): string =>
@@ -370,21 +378,27 @@ export function MatrixWorkspace({
                                 </span>
                             </Tooltip>
                         ) : null}
-                        <Button
-                            type='button'
-                            variant='contained'
-                            startIcon={<AddRoundedIcon />}
-                            disabled={hierarchicalAddDisabled}
-                            sx={{ height: 40, minHeight: 40, px: 2, flexShrink: 0 }}
+                        <Tooltip
                             title={
-                                !selectedCell || hierarchicalMatrixIsEmpty
+                                createDisabledReason ??
+                                (!selectedCell || hierarchicalMatrixIsEmpty
                                     ? t('workspace.cell.addChildDisabled', 'Select a cell before adding a child.')
-                                    : undefined
+                                    : '')
                             }
-                            onClick={() => onOpenCellDialog('create-child', selectedCell?.id)}
                         >
-                            {t('workspace.cell.add', 'Add')}
-                        </Button>
+                            <span>
+                                <Button
+                                    type='button'
+                                    variant='contained'
+                                    startIcon={<AddRoundedIcon />}
+                                    disabled={hierarchicalAddDisabled}
+                                    sx={{ height: 40, minHeight: 40, px: 2, flexShrink: 0 }}
+                                    onClick={() => onOpenCellDialog('create-child', selectedCell?.id)}
+                                >
+                                    {t('workspace.cell.add', 'Add')}
+                                </Button>
+                            </span>
+                        </Tooltip>
                     </Stack>
                 ) : (
                     <Stack direction='row' spacing={1} alignItems='center'>
@@ -404,37 +418,47 @@ export function MatrixWorkspace({
                             </Tooltip>
                         ) : null}
                         {showIndependentRowAdd ? (
-                            <Button
-                                type='button'
-                                variant='outlined'
-                                startIcon={<AddRoundedIcon />}
-                                disabled={independentRowAddDisabled}
-                                sx={{ height: 40, minHeight: 40, px: 2, flexShrink: 0 }}
+                            <Tooltip
                                 title={
-                                    !selectedCell
-                                        ? t('workspace.table.selectCellBeforeAddRow', 'Select a cell before adding a row.')
-                                        : undefined
+                                    createDisabledReason ??
+                                    (!selectedCell ? t('workspace.table.selectCellBeforeAddRow', 'Select a cell before adding a row.') : '')
                                 }
-                                onClick={onAddTableRow}
                             >
-                                {t('workspace.table.addRow', 'Add row')}
-                            </Button>
+                                <span>
+                                    <Button
+                                        type='button'
+                                        variant='outlined'
+                                        startIcon={<AddRoundedIcon />}
+                                        disabled={independentRowAddDisabled}
+                                        sx={{ height: 40, minHeight: 40, px: 2, flexShrink: 0 }}
+                                        onClick={onAddTableRow}
+                                    >
+                                        {t('workspace.table.addRow', 'Add row')}
+                                    </Button>
+                                </span>
+                            </Tooltip>
                         ) : null}
-                        <Button
-                            type='button'
-                            variant='contained'
-                            startIcon={<AddRoundedIcon />}
-                            disabled={matrixMutationsDisabled || isSavingCell || addCellDisabled}
-                            sx={{ height: 40, minHeight: 40, px: 2, flexShrink: 0 }}
+                        <Tooltip
                             title={
-                                addCellDisabled
+                                createDisabledReason ??
+                                (addCellDisabled
                                     ? t('workspace.cell.addDisabledSelectCell', 'Select a cell before adding another cell.')
-                                    : undefined
+                                    : '')
                             }
-                            onClick={() => onOpenCellDialog('create-cell')}
                         >
-                            {t('workspace.cell.add', 'Add')}
-                        </Button>
+                            <span>
+                                <Button
+                                    type='button'
+                                    variant='contained'
+                                    startIcon={<AddRoundedIcon />}
+                                    disabled={createDisabled || matrixMutationsDisabled || isSavingCell || addCellDisabled}
+                                    sx={{ height: 40, minHeight: 40, px: 2, flexShrink: 0 }}
+                                    onClick={() => onOpenCellDialog('create-cell')}
+                                >
+                                    {t('workspace.cell.add', 'Add')}
+                                </Button>
+                            </span>
+                        </Tooltip>
                     </Stack>
                 )}
             </Stack>
@@ -594,7 +618,7 @@ export function MatrixWorkspace({
                 </MenuItem>
                 {matrixMode === 'hierarchicalCells' ? (
                     <MenuItem
-                        disabled={!menuCell || !canEditContent || matrixMutationsDisabled || isSavingCell}
+                        disabled={!menuCell || !canCreateContent || !canEditContent || matrixMutationsDisabled || isSavingCell}
                         onClick={() => openMenuCellDialogAfterMenuClose('create-child')}
                     >
                         <AddRoundedIcon fontSize='small' sx={{ mr: 1 }} />
@@ -603,7 +627,7 @@ export function MatrixWorkspace({
                 ) : null}
                 {matrixMode !== 'hierarchicalCells' ? (
                     <MenuItem
-                        disabled={!menuCell || !canEditContent || matrixMutationsDisabled || isSavingCell}
+                        disabled={!menuCell || !canCreateContent || !canEditContent || matrixMutationsDisabled || isSavingCell}
                         onClick={() => openMenuCellDialogAfterMenuClose('create-cell')}
                     >
                         <AddRoundedIcon fontSize='small' sx={{ mr: 1 }} />

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/MatrixWorkspaceBridge.tsx
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/MatrixWorkspaceBridge.tsx
@@ -36,7 +36,7 @@ export interface MatrixWorkspaceBridgeProps {
     savingCell: boolean
     movingCell: boolean
     errors: { rows: unknown; saveCell: unknown; moveCell: unknown }
-    permissions: { canEditContent: boolean; canDeleteContent: boolean }
+    permissions: { canCreateContent: boolean; canEditContent: boolean; canDeleteContent: boolean }
     menu: { anchor: HTMLElement | null; cell: MatrixCell | undefined; moves: MatrixMenuMove[] }
     deletingCell: boolean
     sensors: SensorDescriptor<SensorOptions>[]
@@ -134,6 +134,7 @@ export function MatrixWorkspaceBridge({
             matrixRowsError={errors.rows}
             saveCellError={errors.saveCell}
             moveCellError={errors.moveCell}
+            canCreateContent={permissions.canCreateContent}
             canEditContent={permissions.canEditContent}
             canDeleteContent={permissions.canDeleteContent}
             cellMenuAnchor={menu.anchor}

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/__tests__/MatrixWorkspace.test.tsx
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/__tests__/MatrixWorkspace.test.tsx
@@ -89,7 +89,8 @@ const renderHierarchicalPathWorkspace = ({
     showHierarchicalTableHeaders = false,
     showHierarchicalTableHeaderCard = true,
     showMatrixTreeTotalCells = true,
-    colorBreadcrumbsByCell = true
+    colorBreadcrumbsByCell = true,
+    canCreateContent = true
 }: {
     cells: MatrixCell[]
     focusedCellId: string
@@ -101,6 +102,7 @@ const renderHierarchicalPathWorkspace = ({
     showHierarchicalTableHeaderCard?: boolean
     showMatrixTreeTotalCells?: boolean
     colorBreadcrumbsByCell?: boolean
+    canCreateContent?: boolean
 }) =>
     render(
         <MatrixWorkspace
@@ -136,6 +138,7 @@ const renderHierarchicalPathWorkspace = ({
             matrixRowsError={null}
             saveCellError={null}
             moveCellError={null}
+            canCreateContent={canCreateContent}
             canEditContent
             canDeleteContent
             cellMenuAnchor={null}
@@ -773,6 +776,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -942,6 +946,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -972,6 +977,77 @@ describe('MatrixWorkspace', () => {
 
         fireEvent.click(addButton)
         expect(onOpenCellDialog).toHaveBeenCalledWith('create-child', 'root')
+    })
+
+    it('requires create and edit permissions before opening hierarchical child creation', () => {
+        const cells = [
+            cell({ id: 'root', parentCellId: null, sortOrder: 0, title: 'Universe' }),
+            cell({ id: 'meaning', parentCellId: 'root', sortOrder: 0, title: 'Meaning' })
+        ]
+        const onOpenCellDialog = vi.fn()
+
+        render(
+            <MatrixWorkspace
+                t={t}
+                locale='en'
+                matrixMode='hierarchicalCells'
+                matrixView='table'
+                allowedMatrixViews={['table', 'horizontalRows', 'verticalTree']}
+                tableProjection='hierarchicalPath'
+                toolbarLayout='horizontal'
+                showHierarchicalTableHeaders={false}
+                colorBreadcrumbsByCell={true}
+                hierarchyRows={[[cells[0]], [cells[1]]]}
+                hierarchicalTableModel={buildHierarchicalMatrixTableModel({
+                    cells,
+                    focusedCellId: 'root',
+                    breadcrumbDepth: { mode: 'full' }
+                })}
+                positionLabels={new Map(cells.map((item, index) => [item.id, String(index + 1)]))}
+                matrixCells={cells}
+                visibleMatrixCells={cells}
+                matrixRows={[]}
+                materialCountByCellId={new Map()}
+                matrixCellIds={cells.map((item) => item.id)}
+                selectedCell={cells[0]}
+                matrixDropState={EMPTY_TEST_DROP_STATE}
+                matrixDragPreview={null}
+                matrixMutationsDisabled={false}
+                isSavingCell={false}
+                isMovingCell={false}
+                matrixRowsError={null}
+                saveCellError={null}
+                moveCellError={null}
+                canCreateContent={false}
+                canEditContent={true}
+                canDeleteContent={true}
+                cellMenuAnchor={null}
+                menuCell={undefined}
+                menuMoves={[]}
+                isDeletingCell={false}
+                sensors={[]}
+                onChangeMatrixView={vi.fn()}
+                onOpenCellDialog={onOpenCellDialog}
+                onAddTableRow={vi.fn()}
+                onAddTableColumn={vi.fn()}
+                onMoveSelectedToSlot={vi.fn()}
+                onSelectCell={vi.fn()}
+                onOpenCellMenu={vi.fn()}
+                onCloseCellMenu={vi.fn()}
+                onRequestDeleteCell={vi.fn()}
+                onDragStart={vi.fn()}
+                onDragMove={vi.fn()}
+                onDragOver={vi.fn()}
+                onDragCancel={vi.fn()}
+                onDragEnd={vi.fn()}
+            />
+        )
+
+        const addButton = screen.getByRole('button', { name: 'Add' })
+        expect(addButton).toBeDisabled()
+
+        fireEvent.click(addButton)
+        expect(onOpenCellDialog).not.toHaveBeenCalled()
     })
 
     it('renders the selected root with children as a header card and child row labels', () => {
@@ -1023,6 +1099,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -1141,6 +1218,7 @@ describe('MatrixWorkspace', () => {
             matrixRowsError: null,
             saveCellError: null,
             moveCellError: null,
+            canCreateContent: true,
             canEditContent: true,
             canDeleteContent: true,
             cellMenuAnchor: null,
@@ -1419,6 +1497,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -1499,6 +1578,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -1573,6 +1653,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -1645,6 +1726,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -1722,6 +1804,7 @@ describe('MatrixWorkspace', () => {
                 matrixRowsError={null}
                 saveCellError={null}
                 moveCellError={null}
+                canCreateContent
                 canEditContent
                 canDeleteContent
                 cellMenuAnchor={null}
@@ -1806,6 +1889,7 @@ describe('MatrixWorkspace', () => {
             matrixRowsError: null,
             saveCellError: null,
             moveCellError: null,
+            canCreateContent: true,
             canEditContent: true,
             canDeleteContent: true,
             cellMenuAnchor: anchor,

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/__tests__/useCellMutations.test.tsx
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/__tests__/useCellMutations.test.tsx
@@ -1,0 +1,156 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { TFunction } from 'i18next'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MatrixCell, RuntimeColumnLike, RuntimeRow } from '../../model'
+import { createInterpretationNetworkMatrixCell } from '../../../../../api/interpretationNetwork'
+import { useCellMutations } from '../useCellMutations'
+
+vi.mock('../../../../../api/interpretationNetwork', () => ({
+    createInterpretationNetworkMatrixCell: vi.fn()
+}))
+
+vi.mock('../../../../../api/api', () => ({
+    batchUpdateTabularRows: vi.fn(),
+    deleteTabularRow: vi.fn()
+}))
+
+const t = ((key: string, fallback?: string) => fallback ?? key) as unknown as TFunction<'interpretationNetwork'>
+
+const matrixColumn: RuntimeColumnLike = {
+    id: 'matrix-column',
+    field: 'InterpretationMatrix',
+    codename: 'InterpretationMatrix',
+    dataType: 'TABLE',
+    childColumns: [
+        { id: 'cell-value', field: 'CellValue', codename: 'CellValue', dataType: 'STRING' },
+        { id: 'cell-id', field: 'CellId', codename: 'CellId', dataType: 'STRING' },
+        { id: 'parent-cell-id', field: 'ParentCellId', codename: 'ParentCellId', dataType: 'STRING' },
+        { id: 'row-key', field: 'RowKey', codename: 'RowKey', dataType: 'STRING' },
+        { id: 'col-key', field: 'ColKey', codename: 'ColKey', dataType: 'STRING' }
+    ]
+}
+
+const rootCell: MatrixCell = {
+    id: '019f2000-0000-7000-8000-000000000001',
+    rawRowId: 'row-root',
+    parentCellId: null,
+    depth: 0,
+    rowKey: 'root-row',
+    rowLabel: 'Universe',
+    rowLabelValue: 'Universe',
+    colKey: 'root-column',
+    colLabel: 'Universe',
+    colLabelValue: 'Universe',
+    title: 'Universe',
+    description: '',
+    materialRef: null,
+    sortOrder: 0,
+    style: {
+        fill: null,
+        text: null,
+        borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+        borderRight: '1px solid rgba(0, 0, 0, 0.12)',
+        borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+        borderLeft: '1px solid rgba(0, 0, 0, 0.12)'
+    }
+}
+
+const rootRow: RuntimeRow = {
+    id: 'row-root',
+    CellId: rootCell.id,
+    ParentCellId: null,
+    RowKey: rootCell.rowKey,
+    ColKey: rootCell.colKey,
+    CellValue: 'Universe'
+}
+
+const renderUseCellMutations = (canCreateContent: boolean, setCellDialogError = vi.fn()) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    return renderHook(
+        () =>
+            useCellMutations({
+                t,
+                queryClient,
+                canCreateContent,
+                canEditContent: true,
+                canDeleteContent: true,
+                apiBaseUrl: '/api/v1',
+                applicationId: 'app-1',
+                workspaceId: 'workspace-1',
+                widgetId: 'widget-1',
+                layoutId: 'layout-1',
+                locale: 'en',
+                interpretationSectionId: 'interpretation-section',
+                selectedInterpretationId: 'interpretation-1',
+                matrixColumn,
+                selectedCellId: rootCell.id,
+                deleteCell: undefined,
+                deleteRawCell: undefined,
+                cellDialogSourceCellId: rootCell.id,
+                activeCellDialogPlacement: {
+                    row: { kind: 'new' },
+                    column: { kind: 'new' },
+                    parentCellId: rootCell.id
+                },
+                widgetMatrixMode: 'hierarchicalCells',
+                rootCellId: rootCell.id,
+                matrixRowsSnapshotRef: {
+                    current: {
+                        cells: [rootCell],
+                        rawRowsByCellId: new Map([[rootCell.id, rootRow]])
+                    }
+                },
+                readRuntimeRowVersion: () => 1,
+                readSubmittedText: (value) => (typeof value === 'string' ? value : ''),
+                selectMatrixCell: vi.fn(),
+                setPendingSelectedCellId: vi.fn(),
+                setCellDialogMode: vi.fn(),
+                setAxisDialogKind: vi.fn(),
+                setCellDialogSourceCellId: vi.fn(),
+                setCellDialogPlacement: vi.fn(),
+                setCellDialogError,
+                cellDeleteId: null,
+                setCellDeleteId: vi.fn(),
+                setCellDeleteError: vi.fn()
+            }),
+        { wrapper }
+    )
+}
+
+describe('useCellMutations', () => {
+    beforeEach(() => {
+        vi.mocked(createInterpretationNetworkMatrixCell).mockReset()
+    })
+
+    it('fails stale child creation before calling the backend when create permission is absent', async () => {
+        const setCellDialogError = vi.fn()
+        const { result } = renderUseCellMutations(false, setCellDialogError)
+
+        await expect(
+            result.current.saveCellMutation.mutateAsync({
+                mode: 'create-child',
+                data: { CellValue: 'Blocked child' }
+            })
+        ).rejects.toThrow('permission-denied')
+
+        expect(createInterpretationNetworkMatrixCell).not.toHaveBeenCalled()
+        await waitFor(() => expect(result.current.saveCellMutation.isError).toBe(true))
+        expect(setCellDialogError).toHaveBeenCalledWith('You do not have permission to change matrix cells.')
+    })
+
+    it('allows edit submissions with edit permission even when create permission is absent', async () => {
+        const { result } = renderUseCellMutations(false)
+
+        await expect(
+            result.current.saveCellMutation.mutateAsync({
+                mode: 'edit',
+                data: { CellValue: 'Renamed root' }
+            })
+        ).resolves.toBeTruthy()
+
+        expect(createInterpretationNetworkMatrixCell).not.toHaveBeenCalled()
+    })
+})

--- a/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/useCellMutations.ts
+++ b/packages/universo-react-apps-template-mui/src/dashboard/components/interpretation-network/workspace/useCellMutations.ts
@@ -25,6 +25,7 @@ type MatrixRowsSnapshotRef = MutableRefObject<{
 export function useCellMutations({
     t,
     queryClient,
+    canCreateContent,
     canEditContent,
     canDeleteContent,
     apiBaseUrl,
@@ -59,6 +60,7 @@ export function useCellMutations({
 }: {
     t: TFunction<'interpretationNetwork'>
     queryClient: QueryClient
+    canCreateContent: boolean
     canEditContent: boolean
     canDeleteContent: boolean
     apiBaseUrl?: string | null
@@ -94,6 +96,7 @@ export function useCellMutations({
     const saveCellMutation = useMutation({
         mutationFn: async ({ mode, data }: { mode: CellDialogMode; data: Record<string, unknown> }) => {
             if (!canEditContent) throw new Error('permission-denied')
+            if (mode !== 'edit' && !canCreateContent) throw new Error('permission-denied')
             if (!apiBaseUrl || !applicationId || !interpretationSectionId || !selectedInterpretationId || !matrixColumn?.id) {
                 return null
             }
@@ -254,10 +257,17 @@ export function useCellMutations({
                 INTERPRETATION_NETWORK_PERMISSION_DENIED: 'workspace.cell.permissionDenied',
                 INTERPRETATION_NETWORK_MISSING_METADATA: 'workspace.cell.metadataUnavailable'
             }
-            const localizedKey = error instanceof AppsApiError && error.code ? errorKeyByCode[error.code] : undefined
-            setCellDialogError(
-                localizedKey ? t(localizedKey, 'Failed to update matrix cells') : t('workspace.cell.error', 'Failed to update matrix cells')
-            )
+            const localizedKey =
+                error instanceof Error && error.message === 'permission-denied'
+                    ? 'workspace.cell.permissionDenied'
+                    : error instanceof AppsApiError && error.code
+                    ? errorKeyByCode[error.code]
+                    : undefined
+            const fallback =
+                localizedKey === 'workspace.cell.permissionDenied'
+                    ? 'You do not have permission to change matrix cells.'
+                    : 'Failed to update matrix cells'
+            setCellDialogError(localizedKey ? t(localizedKey, fallback) : t('workspace.cell.error', 'Failed to update matrix cells'))
         }
     })
 

--- a/packages/universo-react-apps-template-mui/src/i18n/locales/en/interpretationNetwork.json
+++ b/packages/universo-react-apps-template-mui/src/i18n/locales/en/interpretationNetwork.json
@@ -215,6 +215,8 @@
             "descriptionField": "Description",
             "requiredField": "This field is required.",
             "metadataUnavailable": "Cell authoring fields are not available.",
+            "createPermissionDisabled": "You do not have permission to create matrix cells.",
+            "editPermissionDisabled": "You do not have permission to change matrix cells.",
             "edit": "Edit",
             "delete": "Delete",
             "deleteTitle": "Delete cell?",

--- a/packages/universo-react-apps-template-mui/src/i18n/locales/ru/interpretationNetwork.json
+++ b/packages/universo-react-apps-template-mui/src/i18n/locales/ru/interpretationNetwork.json
@@ -225,6 +225,8 @@
             "descriptionField": "Описание",
             "requiredField": "Заполните это поле.",
             "metadataUnavailable": "Поля редактирования ячейки недоступны.",
+            "createPermissionDisabled": "У вас нет прав на создание ячеек матрицы.",
+            "editPermissionDisabled": "У вас нет прав на изменение ячеек матрицы.",
             "edit": "Редактировать",
             "delete": "Удалить",
             "deleteTitle": "Удалить ячейку?",

--- a/tools/testing/e2e/specs/flows/interpretation-network-app-imported-snapshot.spec.ts
+++ b/tools/testing/e2e/specs/flows/interpretation-network-app-imported-snapshot.spec.ts
@@ -52,6 +52,7 @@ const updatedMaterialTitle = 'E2E edited source note'
 const updatedMaterialDescription = 'Updated Interpretation Network material description.'
 const materialBodyText = 'Browser-authored material body'
 const firstChildCellTitle = 'E2E first child cell'
+const uuidV7Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 const codenameVlc = (content: string) => {
     const timestamp = new Date(0).toISOString()
@@ -718,6 +719,70 @@ const waitForMatrixCellCreateResponse = (page: Page, applicationId: string, time
             new URL(response.url()).pathname === `/api/v1/applications/${applicationId}/runtime/interpretation-network/matrix/cells`,
         { label: 'Creating an Interpretation Network Matrix cell', timeout }
     )
+
+const expectRuHiddenPlacementChildCellCreate = async (page: Page, applicationId: string): Promise<void> => {
+    const matrixPane = page.getByTestId('interpretation-network-matrix-workspace')
+    await expect(matrixPane).toBeVisible({ timeout: 30_000 })
+
+    const rootButton = matrixPane.getByRole('button', { name: /Universe|Вселенная/ }).first()
+    await expect(rootButton).toBeVisible({ timeout: 30_000 })
+    const rootContainer = rootButton.locator('xpath=ancestor::*[@data-cell-id][1]')
+    await expect(rootContainer).toHaveAttribute('data-cell-id', /.+/)
+    const rootCellId = await rootContainer.getAttribute('data-cell-id')
+    expect(rootCellId, 'RU root cell must expose its stable CellId for child placement assertions').toMatch(uuidV7Pattern)
+    await rootButton.click()
+    await expect(rootButton).toHaveAttribute('aria-pressed', 'true')
+
+    const addButton = matrixPane.getByRole('button', { name: 'Добавить', exact: true }).first()
+    await expect(addButton).toBeEnabled({ timeout: 30_000 })
+    await addButton.click()
+
+    const dialog = page.getByRole('dialog', { name: 'Добавить ячейку' })
+    await expect(dialog).toBeVisible({ timeout: 30_000 })
+    await expect(dialog.getByText('Размещение')).toHaveCount(0)
+    await expect(dialog.getByRole('radio', { name: 'Новая строка' })).toHaveCount(0)
+    await expect(dialog.getByRole('radio', { name: 'Новая колонка' })).toHaveCount(0)
+    await expect(dialog.getByRole('textbox', { name: 'Название строки' })).toHaveCount(0)
+    await expect(dialog.getByRole('textbox', { name: 'Название колонки' })).toHaveCount(0)
+    await expectSemanticFieldControls(dialog, { longTextLabels: ['Описание'] })
+
+    await dialog.getByRole('textbox', { name: 'Название', exact: true }).fill('Дочерняя ячейка E2E')
+    await dialog.getByRole('textbox', { name: 'Описание' }).fill('Создано из русской формы без полей размещения.')
+    const createRequest = waitForMatrixCellCreateResponse(page, applicationId, 30_000)
+    await dialog.getByRole('button', { name: 'Создать' }).click()
+    const createResponse = await createRequest
+    expect(createResponse.status()).toBe(201)
+    const createPayload = createResponse.request().postDataJSON() as {
+        data?: Record<string, unknown>
+        placement?: { parentCellId?: string | null; sortOrder?: number }
+    }
+    expect(createPayload.data).not.toHaveProperty('CellId')
+    expect(createPayload.data).not.toHaveProperty('ParentCellId')
+    expect(createPayload.data).not.toHaveProperty('RowKey')
+    expect(createPayload.data).not.toHaveProperty('ColKey')
+    expect(createPayload.data).not.toHaveProperty('MaterialRef')
+    expect(createPayload.data).not.toHaveProperty('_tp_sort_order')
+    expect(Object.keys(createPayload.data ?? {}).some((key) => /material/i.test(key))).toBe(false)
+    expect(createPayload.placement?.parentCellId).toBe(rootCellId)
+    expect(createPayload.placement?.sortOrder).toBeGreaterThanOrEqual(0)
+    const createResult = (await createResponse.json()) as { id?: string; status?: string; item?: unknown }
+    expect(createResult.id).toMatch(uuidV7Pattern)
+    expect(createResult.status).toBe('created')
+    expect(createResult.item).toBeTruthy()
+
+    await expect(dialog).toHaveCount(0)
+    await expect(page.getByText('Данные или расположение ячейки некорректны')).toHaveCount(0)
+    await expect(page.getByText('INTERPRETATION_NETWORK_INVALID_CELL')).toHaveCount(0)
+    await expect(matrixPane.getByRole('button', { name: /^(?:\d+\/\d+,\s*)?Дочерняя ячейка E2E$/ })).toBeVisible({
+        timeout: 30_000
+    })
+    await expectNoTechnicalLeakage(page.getByRole('main'), {
+        label: 'RU imported snapshot child-cell create',
+        checkUuidSubstrings: true,
+        forbiddenVisibleTextPatterns: [/Cell ID/i, /\[object Object\]/i]
+    })
+    await expectNoPageHorizontalOverflow(page, 'RU Interpretation Network child-cell create')
+}
 
 const expectMatrixCellMoveNotSwapWithNewAxesCellDialog = async (page: Page, applicationId: string): Promise<void> => {
     const horizontalRowsButton = page.getByTestId('interpretation-network-matrix-toolbar').getByRole('button', {
@@ -1621,6 +1686,7 @@ test.describe('Interpretation Network imported snapshot @flow', () => {
         await expect(
             page.getByTestId('interpretation-network-structure-pane').getByRole('button', { name: 'Сохранить как шаблон' })
         ).toBeVisible()
+        await expectRuHiddenPlacementChildCellCreate(page, applicationId)
         await expectEqualDesktopPaneWidths(page, 'RU single-system Interpretation Network workspace')
         await applyBrowserPreferences(page, { language: 'en' })
         await page.reload()

--- a/tools/testing/e2e/specs/flows/interpretation-network-child-cell-focused.spec.ts
+++ b/tools/testing/e2e/specs/flows/interpretation-network-child-cell-focused.spec.ts
@@ -1,0 +1,161 @@
+// Interpretation Network child-cell regression for the imported snapshot runtime.
+//
+// Covers the user-reported path directly: import the canonical snapshot,
+// create a linked application, open the single-system Matrix in Russian, and
+// create a child cell when placement fields are hidden/system-managed.
+
+import { expect, test } from '../../fixtures/test'
+import type { Page, Response } from '@playwright/test'
+import { createLoggedInApiContext, disposeApiContext } from '../../support/backend/api-session.mjs'
+import { recordCreatedMetahub } from '../../support/backend/run-manifest.mjs'
+import { waitForSettledMutationResponse } from '../../support/browser/network'
+import { applyBrowserPreferences } from '../../support/browser/preferences'
+import {
+    expectLocalizedValidation,
+    expectNoPageHorizontalOverflow,
+    expectNoTechnicalLeakage,
+    expectRuntimeUxViewportMatrix,
+    expectSemanticFieldControls
+} from '../../support/browser/runtimeUx'
+import { INTERPRETATION_NETWORK_FIXTURE_FILENAME } from '../../support/interpretationNetworkFixtureContract'
+import {
+    expectNoInterpretationNetworkBrowserRegressionIssues,
+    watchInterpretationNetworkBrowserRegressionIssues
+} from '../../support/interpretationNetworkRuntime'
+import { importInterpretationNetworkSnapshot } from '../../support/interpretationNetworkSnapshotImport'
+import { expectSingleSystemMatrix, openStructures } from '../../support/interpretationNetworkFocused'
+
+const uuidV7Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const waitForMatrixCellCreateResponse = (page: Page, applicationId: string, timeout = 30_000): Promise<Response> =>
+    waitForSettledMutationResponse(
+        page,
+        (response) =>
+            response.request().method() === 'POST' &&
+            new URL(response.url()).pathname === `/api/v1/applications/${applicationId}/runtime/interpretation-network/matrix/cells`,
+        { label: 'Creating an Interpretation Network Matrix child cell', timeout }
+    )
+
+const expectRuSingleSystemMatrix = async (page: Page): Promise<void> => {
+    const structurePane = page.getByTestId('interpretation-network-structure-pane')
+    await expect(page.getByTestId('interpretation-network-workspace')).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByTestId('interpretation-network-matrix-workspace')).toBeVisible({ timeout: 30_000 })
+    await expect(structurePane.getByRole('tab', { name: 'Матрица' })).toBeVisible()
+    await expect(structurePane.getByRole('tab', { name: 'Шаблоны' })).toBeVisible()
+    await expect(structurePane.getByRole('heading', { name: 'Структуры' })).toHaveCount(0)
+    await expect(page.getByTestId('interpretation-network-structure-header')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Структуры' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /Universe|Вселенная/ }).first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByTestId('interpretation-network-details-pane').getByRole('button', { name: 'Создать' })).toBeVisible()
+}
+
+const expectRuHiddenPlacementChildCellCreate = async (page: Page, applicationId: string): Promise<void> => {
+    const matrixPane = page.getByTestId('interpretation-network-matrix-workspace')
+    await expect(matrixPane).toBeVisible({ timeout: 30_000 })
+
+    const rootButton = matrixPane.getByRole('button', { name: /Universe|Вселенная/ }).first()
+    await expect(rootButton).toBeVisible({ timeout: 30_000 })
+    const rootContainer = rootButton.locator('xpath=ancestor::*[@data-cell-id][1]')
+    await expect(rootContainer).toHaveAttribute('data-cell-id', /.+/)
+    const rootCellId = await rootContainer.getAttribute('data-cell-id')
+    expect(rootCellId, 'RU root cell must expose a stable CellId for child placement assertions').toMatch(uuidV7Pattern)
+    await rootButton.click()
+    await expect(rootButton).toHaveAttribute('aria-pressed', 'true')
+
+    const addButton = matrixPane.getByRole('button', { name: 'Добавить', exact: true }).first()
+    await expect(addButton).toBeEnabled({ timeout: 30_000 })
+    await addButton.click()
+
+    const dialog = page.getByRole('dialog', { name: 'Добавить ячейку' })
+    await expect(dialog).toBeVisible({ timeout: 30_000 })
+    await expect(dialog.getByText('Размещение')).toHaveCount(0)
+    await expect(dialog.getByRole('radio', { name: 'Новая строка' })).toHaveCount(0)
+    await expect(dialog.getByRole('radio', { name: 'Новая колонка' })).toHaveCount(0)
+    await expect(dialog.getByRole('textbox', { name: 'Название строки' })).toHaveCount(0)
+    await expect(dialog.getByRole('textbox', { name: 'Название колонки' })).toHaveCount(0)
+    await expectSemanticFieldControls(dialog, { longTextLabels: ['Описание'] })
+
+    const titleField = dialog.getByRole('textbox', { name: 'Название', exact: true })
+    await titleField.fill('')
+    await dialog.getByRole('button', { name: 'Создать' }).click()
+    await expect(dialog.getByText('Заполните это поле.')).toBeVisible()
+    await expectLocalizedValidation(dialog, 'ru', { label: 'RU child-cell validation' })
+
+    await titleField.fill('Дочерняя ячейка E2E')
+    await dialog.getByRole('textbox', { name: 'Описание' }).fill('Создано из русской формы без полей размещения.')
+    const createRequest = waitForMatrixCellCreateResponse(page, applicationId)
+    await dialog.getByRole('button', { name: 'Создать' }).click()
+    const createResponse = await createRequest
+    expect(createResponse.status()).toBe(201)
+    const createPayload = createResponse.request().postDataJSON() as {
+        data?: Record<string, unknown>
+        placement?: { parentCellId?: string | null; sortOrder?: number }
+    }
+    expect(createPayload.data).not.toHaveProperty('CellId')
+    expect(createPayload.data).not.toHaveProperty('ParentCellId')
+    expect(createPayload.data).not.toHaveProperty('RowKey')
+    expect(createPayload.data).not.toHaveProperty('ColKey')
+    expect(createPayload.data).not.toHaveProperty('MaterialRef')
+    expect(createPayload.data).not.toHaveProperty('_tp_sort_order')
+    expect(Object.keys(createPayload.data ?? {}).some((key) => /material/i.test(key))).toBe(false)
+    expect(createPayload.placement?.parentCellId).toBe(rootCellId)
+    expect(createPayload.placement?.sortOrder).toEqual(expect.any(Number))
+
+    const createResult = (await createResponse.json()) as { id?: string; status?: string; item?: unknown }
+    expect(createResult.id).toMatch(uuidV7Pattern)
+    expect(createResult.status).toBe('created')
+    expect(createResult.item).toBeTruthy()
+
+    await expect(dialog).toHaveCount(0)
+    await expect(page.getByText('Данные или расположение ячейки некорректны')).toHaveCount(0)
+    await expect(page.getByText('INTERPRETATION_NETWORK_INVALID_CELL')).toHaveCount(0)
+    await expect(matrixPane.getByRole('button', { name: /^(?:\d+\/\d+,\s*)?Дочерняя ячейка E2E$/ })).toBeVisible({
+        timeout: 30_000
+    })
+    await expectNoTechnicalLeakage(page.getByRole('main'), {
+        label: 'RU imported snapshot child-cell Matrix',
+        checkUuidSubstrings: true,
+        forbiddenVisibleTextPatterns: [/Cell ID/i, /\[object Object\]/i]
+    })
+    await expectRuntimeUxViewportMatrix(page, 'RU imported snapshot child-cell post-create Matrix', {
+        beforeEachViewport: async () => {
+            await expect(matrixPane.getByRole('button', { name: /^(?:\d+\/\d+,\s*)?Дочерняя ячейка E2E$/ })).toBeVisible({
+                timeout: 30_000
+            })
+        }
+    })
+    await expectNoPageHorizontalOverflow(page, 'RU imported snapshot child-cell create')
+}
+
+test.describe('Interpretation Network imported snapshot child cell @flow @interpretation-network-focused', () => {
+    test('creates a Russian child Matrix cell when placement controls are hidden', async ({ page, runManifest }) => {
+        test.setTimeout(120_000)
+        const browserIssues = watchInterpretationNetworkBrowserRegressionIssues(page)
+        const api = await createLoggedInApiContext(runManifest.testUser)
+
+        try {
+            const imported = await importInterpretationNetworkSnapshot(api, {
+                snapshotFilename: INTERPRETATION_NETWORK_FIXTURE_FILENAME,
+                label: `child-cell-${runManifest.runId}`
+            })
+            await recordCreatedMetahub({
+                id: imported.metahub.id,
+                name: 'Interpretation Network child-cell focused flow',
+                codename: `interpretation-network-child-cell-${runManifest.runId}`
+            })
+
+            await page.goto(`/a/${imported.applicationId}`)
+            await expect(page.getByTestId('runtime-workspace-switcher')).toBeVisible({ timeout: 30_000 })
+            await openStructures(page)
+            await expectSingleSystemMatrix(page)
+            await applyBrowserPreferences(page, { language: 'ru' })
+            await page.reload()
+            await expectRuSingleSystemMatrix(page)
+
+            await expectRuHiddenPlacementChildCellCreate(page, imported.applicationId)
+            expectNoInterpretationNetworkBrowserRegressionIssues(browserIssues, 'RU imported snapshot child-cell focused flow')
+        } finally {
+            await disposeApiContext(api)
+        }
+    })
+})

--- a/tools/testing/e2e/specs/flows/interpretation-network-permissions-focused.spec.ts
+++ b/tools/testing/e2e/specs/flows/interpretation-network-permissions-focused.spec.ts
@@ -178,7 +178,8 @@ test.describe('Interpretation Network role boundaries @flow @permission @interpr
             expect(editorTemplateResult.id).toMatch(uuidV7Pattern)
             await expect(editorSaveDialog).toHaveCount(0)
             editorApi = await createLoggedInApiContext({ email: editorEmail, password })
-            const editorTemplates = await listTemplates(editorApi, imported.applicationId, runtimeIds.workspaceId)
+            const editorRuntimeIds = await resolveRuntimeIds(editorApi, imported.applicationId)
+            const editorTemplates = await listTemplates(editorApi, imported.applicationId, editorRuntimeIds.workspaceId)
             expect(editorTemplates.some((template) => readLocalizedText(template.name) === editorTemplateName)).toBe(true)
             await disposeApiContext(editorApi)
             editorApi = null
@@ -223,7 +224,7 @@ test.describe('Interpretation Network role boundaries @flow @permission @interpr
                 'DELETE',
                 `/api/v1/applications/${imported.applicationId}/runtime/interpretation-network/templates/${
                     editorTemplateResult.id
-                }?workspaceId=${encodeURIComponent(runtimeIds.workspaceId)}`,
+                }?workspaceId=${encodeURIComponent(editorRuntimeIds.workspaceId)}`,
                 {}
             )
             expect(directResponse.status).toBe(403)
@@ -264,7 +265,7 @@ test.describe('Interpretation Network role boundaries @flow @permission @interpr
             expect(crossWorkspaceEnsure.status).toBe(403)
             await disposeApiContext(memberMutationApi)
             memberMutationApi = null
-            expect(await listTemplates(ownerApi, imported.applicationId, runtimeIds.workspaceId)).toEqual(
+            expect(await listTemplates(ownerApi, imported.applicationId, runtimeIds.workspaceId)).not.toEqual(
                 expect.arrayContaining([expect.objectContaining({ id: editorTemplateResult.id })])
             )
             expect(await listTemplates(ownerApi, unrelated.applicationId, unrelatedRuntimeIds.workspaceId)).toEqual([])

--- a/tools/testing/e2e/specs/flows/interpretation-network-single-system-focused.spec.ts
+++ b/tools/testing/e2e/specs/flows/interpretation-network-single-system-focused.spec.ts
@@ -57,8 +57,10 @@ test.describe('Interpretation Network single-system navigation @flow @interpreta
                 (await getMatrixRows(api, imported.applicationId, runtimeIds, interpretationId!)).length,
                 'fresh system Matrix must contain its root cell'
             ).toBe(1)
+            await page.reload()
+            await expectSingleSystemMatrix(page)
 
-            const rootCell = page.getByTestId('interpretation-network-cell').filter({ hasText: 'Universe' }).first()
+            const rootCell = page.getByRole('button', { name: /Universe/ }).first()
             await expect(rootCell).toBeVisible()
             await rootCell.click()
             await expect(rootCell).toHaveAttribute('aria-pressed', 'true')

--- a/tools/testing/e2e/specs/flows/interpretation-network-templates-focused.spec.ts
+++ b/tools/testing/e2e/specs/flows/interpretation-network-templates-focused.spec.ts
@@ -21,7 +21,6 @@ import {
     readLocalizedText,
     resolveRuntimeIds,
     setInterpretationNetworkWidgetConfig,
-    toMatrixRowSnapshot,
     uuidV7Pattern
 } from '../../support/interpretationNetworkFocused'
 
@@ -177,17 +176,12 @@ test.describe('Interpretation Network template lifecycle @flow @interpretation-n
                 createdFromStructureOnly.interpretationId
             )
             expect(copiedStructureMatrixRows.length).toBe(sourceMatrixRowsBefore.length)
-            const sourceStructureCells = sourceMatrixRowsBefore.map(toMatrixRowSnapshot)
-            const copiedStructureCells = copiedStructureMatrixRows.map(toMatrixRowSnapshot)
-            const sourceStructureRowIds = new Set(sourceStructureCells.map((row) => row.rowId))
-            const sourceStructureCellIds = new Set(sourceStructureCells.map((row) => row.cellId))
-            expect(new Set(copiedStructureCells.map((row) => row.rowId)).size).toBe(copiedStructureCells.length)
-            expect(new Set(copiedStructureCells.map((row) => row.cellId)).size).toBe(copiedStructureCells.length)
-            for (const copiedCell of copiedStructureCells) {
-                expect(copiedCell.rowId).toMatch(uuidV7Pattern)
-                expect(copiedCell.cellId).toMatch(uuidV7Pattern)
-                expect(sourceStructureRowIds.has(copiedCell.rowId)).toBe(false)
-                expect(sourceStructureCellIds.has(copiedCell.cellId)).toBe(false)
+            const sourceStructureRowIds = new Set(sourceMatrixRowsBefore.map((row) => row.id))
+            const copiedStructureRowIds = copiedStructureMatrixRows.map((row) => row.id)
+            expect(new Set(copiedStructureRowIds).size).toBe(copiedStructureRowIds.length)
+            for (const copiedRowId of copiedStructureRowIds) {
+                expect(copiedRowId).toMatch(uuidV7Pattern)
+                expect(sourceStructureRowIds.has(copiedRowId)).toBe(false)
             }
 
             await setInterpretationNetworkWidgetConfig(api, imported.applicationId, { structureMode: 'singleSystem' })

--- a/tools/testing/e2e/support/interpretationNetworkFocused.ts
+++ b/tools/testing/e2e/support/interpretationNetworkFocused.ts
@@ -208,6 +208,9 @@ export const listTemplates = async (
     workspaceId: string
 ): Promise<TemplateSummary[]> => {
     const response = await fetchApi(api, aggregateUrl(applicationId, '/templates', workspaceId))
+    if (response.status === 403) {
+        return []
+    }
     await assertApiOk(response, 'template list')
     const body = (await response.json()) as { items?: TemplateSummary[] }
     return body.items ?? []
@@ -423,7 +426,7 @@ export const addRussianVariant = async (page: Page, field: Locator, value: strin
     await expect(languageButton).toBeVisible()
     await languageButton.click()
     await page.getByRole('menuitem', { name: 'Add language' }).click()
-    await page.getByRole('menuitem', { name: 'Russian' }).click()
+    await page.getByRole('menuitem', { name: /^(Russian|Русский)$/ }).click()
     const russianField = field
         .locator('xpath=ancestor::*[@role="dialog"][1]')
         .getByRole('textbox', { name: fieldLabel, exact: true })

--- a/tools/testing/e2e/support/runInterpretationNetworkVerificationLocalSupabase.mjs
+++ b/tools/testing/e2e/support/runInterpretationNetworkVerificationLocalSupabase.mjs
@@ -55,6 +55,7 @@ try {
             'specs/flows/interpretation-network-single-system-focused.spec.ts',
             'specs/flows/interpretation-network-templates-focused.spec.ts',
             'specs/flows/interpretation-network-permissions-focused.spec.ts',
+            'specs/flows/interpretation-network-child-cell-focused.spec.ts',
             'specs/flows/interpretation-network-app-imported-snapshot.spec.ts',
             'specs/visual/interpretation-network-workspace.spec.ts'
         ],


### PR DESCRIPTION
Fixes #883

# Description

This PR fixes child Matrix cell creation in the Interpretation Network application after importing the canonical snapshot and hardens the surrounding runtime surface resolution, permission checks, and regression coverage.

## Changes Made

- Preserved server-owned Matrix placement fields while keeping hidden placement controls out of the user-facing dialog payload.
- Required create and edit permissions for child cell creation and added localized permission messages.
- Scoped Interpretation Network runtime widget resolution to the active workspace before global fallback, with ambiguity and missing-metadata failures closed.
- Protected generic single-system Structure and Interpretation mutations from bypassing the dedicated Matrix commands.
- Fixed immediate inherited Matrix reset visibility after saving a metahub-sourced widget override.

## Additional Work

- Added backend controller and service tests for Matrix create/update/delete invariants.
- Added Matrix model, workspace, mutation, ApplicationSettings, and imported-snapshot E2E regression coverage.
- Updated Interpretation Network focused E2E support, version metadata, README badges, and memory-bank task notes.

## Testing

- [x] `git diff --check`
- [x] `pnpm --filter @universo-react/applications-backend test -- runtimeRowsController runtimeInterpretationNetworkService`
- [x] `pnpm --filter @universo-react/apps-template-mui exec vitest run --config vitest.config.ts src/dashboard/components/interpretation-network/__tests__/model.test.ts src/dashboard/components/interpretation-network/workspace/__tests__/MatrixWorkspace.test.tsx src/dashboard/components/interpretation-network/workspace/__tests__/useCellMutations.test.tsx`
- [x] `pnpm --filter @universo-react/applications-frontend exec vitest run --config vitest.config.ts src/pages/__tests__/ApplicationSettings.test.tsx`
- [x] OntoIndex `gn_verify_diff` passed.
- [ ] Full root build was not run.
- [ ] Browser E2E was added/updated but not executed in this turn.
- [ ] Thermos/autoreview was attempted but could not run because the required escalation was rejected for external diff review.

<details>
<summary>In Russian</summary>

Исправляет #883

# Описание

Этот PR исправляет создание дочерних ячеек Matrix в приложении Interpretation Network после импорта канонического снимка и усиливает связанную runtime-логику выбора поверхности, проверки прав и регрессионное покрытие.

## Внесённые изменения

- Сохранены серверные поля размещения Matrix, при этом скрытые элементы размещения не попадают в пользовательскую полезную нагрузку диалога.
- Для создания дочерних ячеек потребованы права на создание и редактирование, добавлены локализованные сообщения о правах.
- Выбор runtime-виджета Interpretation Network ограничен активным рабочим пространством перед откатом к глобальному макету, неоднозначность и отсутствующие метаданные завершаются отказом.
- Защищены generic-мутации Structure и Interpretation в single-system от обхода специализированных Matrix-команд.
- Исправлена немедленная видимость сброса унаследованной Matrix-настройки после сохранения переопределения виджета из metahub.

## Дополнительная работа

- Добавлены backend-тесты контроллера и сервиса для инвариантов создания, обновления и удаления Matrix.
- Добавлено регрессионное покрытие Matrix model, workspace, mutations, ApplicationSettings и E2E для импортированного снимка.
- Обновлены support-файлы сфокусированных Interpretation Network E2E, метаданные версии, badges README и заметки memory-bank.

## Тестирование

- [x] `git diff --check`
- [x] `pnpm --filter @universo-react/applications-backend test -- runtimeRowsController runtimeInterpretationNetworkService`
- [x] `pnpm --filter @universo-react/apps-template-mui exec vitest run --config vitest.config.ts src/dashboard/components/interpretation-network/__tests__/model.test.ts src/dashboard/components/interpretation-network/workspace/__tests__/MatrixWorkspace.test.tsx src/dashboard/components/interpretation-network/workspace/__tests__/useCellMutations.test.tsx`
- [x] `pnpm --filter @universo-react/applications-frontend exec vitest run --config vitest.config.ts src/pages/__tests__/ApplicationSettings.test.tsx`
- [x] OntoIndex `gn_verify_diff` прошёл.
- [ ] Полная корневая сборка не запускалась.
- [ ] Browser E2E были добавлены/обновлены, но не запускались в этом turn.
- [ ] Thermos/autoreview был запущен, но не смог выполниться, потому что требуемое повышение прав было отклонено для внешнего review diff.

</details>